### PR TITLE
costmap_2d: fixed #22 by slightly decreasing inscribed radius.

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -675,7 +675,8 @@ namespace costmap_2d {
       unsigned char** cached_costs_;
       double** cached_distances_;
       double inscribed_radius_, circumscribed_radius_, inflation_radius_;
-      unsigned int cell_inscribed_radius_, cell_circumscribed_radius_, cell_inflation_radius_;
+      double cell_inscribed_radius_;
+      unsigned int cell_circumscribed_radius_, cell_inflation_radius_;
       double weight_;
       unsigned char circumscribed_cost_lb_, lethal_threshold_;
       bool track_unknown_space_;

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -61,7 +61,7 @@ namespace costmap_2d{
     memset(markers_, 0, size_x_ * size_y_ * sizeof(unsigned char));
 
     //convert our inflations from world to cell distance
-    cell_inscribed_radius_ = cellDistance(inscribed_radius);
+    cell_inscribed_radius_ = max( 0.0, inscribed_radius / resolution_ );
     cell_circumscribed_radius_ = cellDistance(circumscribed_radius);
     cell_inflation_radius_ = cellDistance(inflation_radius);
 


### PR DESCRIPTION
This would fix #22 by changing the cell_inscribed_radius_ member value from an unsigned int equal to ceil( inscribed_radius / resolution ) to a _double_ equal to inscribed_radius / resolution.

It turns out that the only place in the code where cell_inscribed_radius_ is even used is in a "<=" comparison with a double value which is the distance between two grid cells.  Therefore this change will only change a few of the pixels around the perimeter of the obstacle-inflation circle.

If this will change peoples' robot behaviors in a bad way, I can certainly make a parameter which lets you choose the old way or the new way.  There are so many parameters already though that I hesitate to add another, plus I really think this is likely to only improve behavior and not cause problems.
