### PR TITLE
fixed relative map image path in map_saver yaml output

### DIFF
--- a/map_server/src/map_saver.cpp
+++ b/map_server/src/map_saver.cpp
@@ -106,8 +106,14 @@ free_thresh: 0.196
       double yaw, pitch, roll;
       mat.getEulerYPR(yaw, pitch, roll);
 
+      // basename may modify content, so make copy
+      char* mapname_copy = strdup(mapname_.c_str());
+      char* base = basename(mapname_copy);
+      std::string relative_mapdatafile = std::string(base) + ".pgm";
+      free(mapname_copy);
+
       fprintf(yaml, "image: %s\nresolution: %f\norigin: [%f, %f, %f]\nnegate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n\n",
-              mapdatafile.c_str(), map->info.resolution, map->info.origin.position.x, map->info.origin.position.y, yaw);
+              relative_mapdatafile.c_str(), map->info.resolution, map->info.origin.position.x, map->info.origin.position.y, yaw);
 
       fclose(yaml);
 


### PR DESCRIPTION
When running `rosrun map_server map_saver -f <filename>` with a relative filename, the filename of the map image inside the yaml is stored with that same relative path - which is wrong. Instead, the yaml file should contain the name of the map image file relative to itself.

**Before patch:**

```
$ rosrun map_server map_saver -f sandbox/testing
[ INFO] [1366323538.069562295]: Waiting for the map
[ INFO] [1366323538.369252558, 1363811504.214671685]: Received a 1856 X 1376 map @ 0.050 m/pix
[ INFO] [1366323538.369344030, 1363811504.214671685]: Writing map occupancy data to sandbox/testing.pgm
[ INFO] [1366323538.462287213, 1363811504.305601653]: Writing map occupancy data to sandbox/testing.yaml
[ INFO] [1366323538.463380913, 1363811504.305601653]: Done

$ cat sandbox/testing.yaml 
image: sandbox/testing.pgm
resolution: 0.050000
origin: [-42.200000, -51.800000, 0.000000]
negate: 0
occupied_thresh: 0.65
free_thresh: 0.196
```

**After patch:**

```
$ rosrun map_server map_saver -f sandbox/testing
[ INFO] [1366323150.978162425]: Waiting for the map
[ INFO] [1366323151.236549579]: Received a 1120 X 1376 map @ 0.050 m/pix
[ INFO] [1366323151.236616502]: Writing map occupancy data to sandbox/testing.pgm
[ INFO] [1366323151.292219974, 1363811117.136858758]: Writing map occupancy data to sandbox/testing.yaml
[ INFO] [1366323151.293449450, 1363811117.136858758]: Done

$ cat sandbox/testing.yaml
image: testing.pgm
resolution: 0.050000
origin: [-42.200000, -51.800000, 0.000000]
negate: 0
occupied_thresh: 0.65
free_thresh: 0.196
```
