### PR TITLE
Get map action

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(catkin REQUIRED
             tf
             nav_msgs
             rostest
+            actionlib
+            actionlib_msgs
         )
 
 catkin_package(
@@ -17,6 +19,7 @@ catkin_package(
         roscpp
         tf
         nav_msgs
+        actionlib_msgs
 )
 include_directories( include )
 add_library(image_loader src/image_loader.cpp)

--- a/map_server/package.xml
+++ b/map_server/package.xml
@@ -17,11 +17,15 @@
     <build_depend>roscpp</build_depend>
     <build_depend>nav_msgs</build_depend>
     <build_depend>tf</build_depend>
+    <build_depend>actionlib</build_depend>
+    <build_depend>actionlib_msgs</build_depend>
 
     <run_depend>roslib</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>nav_msgs</run_depend>
     <run_depend>tf</run_depend>
+    <run_depend>actionlib</run_depend>
+    <run_depend>actionlib_msgs</run_depend>
 
     <export>
         <cpp cflags="-I${prefix}/include `rosboost-cfg --cflags`" lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib `rosboost-cfg --lflags thread`"/>

--- a/map_server/scripts/get_map.py
+++ b/map_server/scripts/get_map.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import rospy
+from nav_msgs.msg import GetMapAction, GetMapGoal
+from actionlib import SimpleActionClient
+
+rospy.init_node('get_map', anonymous=True)
+
+rospy.loginfo('Connecting to server')
+ac = SimpleActionClient('get_static_map', GetMapAction)
+ac.wait_for_server()
+
+rospy.loginfo('Calling action to get map')
+ac.send_goal(GetMapGoal())
+
+rospy.loginfo('Waiting for result')
+ac.wait_for_result()
+
+result = ac.get_result()
+print result.map.info

--- a/move_base/CMakeLists.txt
+++ b/move_base/CMakeLists.txt
@@ -24,6 +24,7 @@ catkin_package(
     CATKIN_DEPENDS
         roscpp
         dynamic_reconfigure
+        actionlib_msgs
 )
 
 include_directories(


### PR DESCRIPTION
Adds an actionlib action server for getting the map from the map_server. Works the same way as the static_map service call, but with an action.

This pull requests requires a new action definition in common_msgs, and so can't be merged until this one is merged:
ros/common_msgs#8
