### PR TITLE
map_server depends on yaml-cpp and sdl-image

### DIFF
--- a/map_server/package.xml
+++ b/map_server/package.xml
@@ -17,11 +17,15 @@
     <build_depend>roscpp</build_depend>
     <build_depend>nav_msgs</build_depend>
     <build_depend>tf</build_depend>
+    <build_depend>yaml-cpp</build_depend>
+    <build_depend>sdl-image</build_depend>
 
     <run_depend>roslib</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>nav_msgs</run_depend>
     <run_depend>tf</run_depend>
+    <run_depend>yaml-cpp</run_depend>
+    <run_depend>sdl-image</run_depend>
 
     <export>
         <cpp cflags="-I${prefix}/include `rosboost-cfg --cflags`" lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib `rosboost-cfg --lflags thread`"/>


### PR DESCRIPTION
these get resolved by rosdep to their respective system dependencies
