### PR TITLE
making navfn code available to packages outside the navfn package for si...

### DIFF
--- a/navfn/CMakeLists.txt
+++ b/navfn/CMakeLists.txt
@@ -45,7 +45,12 @@ generate_messages(
 )
 
 catkin_package(
+    INCLUDE_DIRS
+        include
+    LIBRARIES
+        navfn
     CATKIN_DEPENDS
+        nav_core
         roscpp
         pluginlib
 )
@@ -63,6 +68,10 @@ target_link_libraries(navfn_node
 install(TARGETS navfn
        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
        )
+
+install(DIRECTORY include/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
 
 install(FILES bgp_plugin.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
...mple path planning problems. I am using the API internally here to determine if certain pathways are open without actually executing a plan.
