### PR TITLE
costmap_2d plugins obstacle_layer and voxel_layer use footprint_layer

### DIFF
--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -53,6 +53,7 @@
 #include <message_filters/subscriber.h>
 #include <dynamic_reconfigure/server.h>
 #include <costmap_2d/ObstaclePluginConfig.h>
+#include <costmap_2d/footprint_layer.h>
 
 namespace costmap_2d
 {
@@ -137,6 +138,9 @@ protected:
   virtual void raytraceFreespace(const costmap_2d::Observation& clearing_observation, double* min_x, double* min_y,
                                  double* max_x, double* max_y);
 
+  /** @brief Overridden from superclass Layer to pass new footprint into footprint_layer_. */
+  virtual void onFootprintChanged();
+
   std::string global_frame_; ///< @brief The global frame for the costmap
   double max_obstacle_height_; ///< @brief Max Obstacle Height
 
@@ -157,9 +161,10 @@ protected:
   bool has_been_reset_;
   double reset_min_x_, reset_max_x_, reset_min_y_, reset_max_y_;
 
+  FootprintLayer footprint_layer_; ///< @brief clears the footprint in this obstacle layer.
+
 private:
   void reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint32_t level);
-
 };
 }
 #endif

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -69,7 +69,6 @@ public:
   virtual void onInitialize();
   virtual void updateBounds(double origin_x, double origin_y, double origin_yaw, double* min_x, double* min_y, double* max_x,
                              double* max_y);
-  virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
   void updateOrigin(double new_origin_x, double new_origin_y);
   bool isDiscretized()

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -162,25 +162,8 @@ void VoxelLayer::updateBounds(double origin_x, double origin_y, double origin_ya
     grid_msg.header.stamp = ros::Time::now();
     voxel_pub_.publish(grid_msg);
   }
-}
 
-void VoxelLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
-{
-  if (!enabled_)
-    return;
-  const unsigned char* master_array = master_grid.getCharMap();
-  for (int j = min_j; j < max_j; j++)
-  {
-    for (int i = min_i; i < max_i; i++)
-    {
-      int index = getIndex(i, j);
-      if (costmap_[index] == NO_INFORMATION)
-        continue;
-      unsigned char old_cost = master_array[index];
-      if (old_cost == NO_INFORMATION || old_cost < costmap_[index])
-        master_grid.setCost(i, j, costmap_[index]);
-    }
-  }
+  footprint_layer_.updateBounds(origin_x, origin_y, origin_yaw, min_x, min_y, max_x, max_y);
 }
 
 void VoxelLayer::clearNonLethal(double wx, double wy, double w_size_x, double w_size_y, bool clear_no_info)


### PR DESCRIPTION
to clear the robot's footprint within their internal layer before merging onto the master costmap.

This was previously implemented specifically in voxel_with_footprint_layer.cpp but we have since realized that every voxel or obstacle layer will always need this, so I'm baking it into those classes directly.

A later commit will remove the voxel_with_footprint_layer class after references to it have been converted to regular voxel_layers.
