### PR TITLE
Changed costmap_2d_publisher from latched topic to one that republishes the latest full costmap to each new subscriber.

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
@@ -62,6 +62,7 @@ public:
    */
   ~Costmap2DPublisher();
 
+  /** @brief Include the given bounds in the changed-rectangle. */
   void updateBounds(unsigned int x0, unsigned int xn, unsigned int y0, unsigned int yn)
   {
     x0_ = std::min(x0, x0_);
@@ -85,6 +86,12 @@ public:
   }
 
 private:
+  /** @brief Prepare grid_ message for publication. */
+  void prepareGrid();
+
+  /** @brief Publish the latest full costmap to the new subscriber. */
+  void onNewSubscription( const ros::SingleSubscriberPublisher& pub );
+
   ros::NodeHandle* node;
   Costmap2D* costmap_;
   std::string global_frame_;


### PR DESCRIPTION
Previously this would only publish the full costmap once at the beginning, but that did not catch various configuration changes, so it would be stale.  This way whenever you disable the rviz display and re-enable it, you get a fresh copy of the latest full costmap.
