### PR TITLE
Use OccupancyGridUpdate message from map_msgs package now that it's been released.

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -33,7 +33,6 @@ add_definitions(${EIGEN_DEFINITIONS})
 add_message_files(
     DIRECTORY msg
     FILES
-    OccupancyGridUpdate.msg
     VoxelGrid.msg
 )
 

--- a/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
@@ -40,7 +40,7 @@
 #include <ros/ros.h>
 #include <costmap_2d/costmap_2d.h>
 #include <nav_msgs/OccupancyGrid.h>
-#include <costmap_2d/OccupancyGridUpdate.h>
+#include <map_msgs/OccupancyGridUpdate.h>
 #include <tf/transform_datatypes.h>
 
 namespace costmap_2d

--- a/costmap_2d/msg/OccupancyGridUpdate.msg
+++ b/costmap_2d/msg/OccupancyGridUpdate.msg
@@ -1,6 +1,0 @@
-Header header
-int32 x
-int32 y
-uint32 width
-uint32 height
-int8[] data

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -20,6 +20,7 @@
     <build_depend>roscpp</build_depend>
     <build_depend>roslib</build_depend>
     <build_depend>rostest</build_depend>
+    <build_depend>map_msgs</build_depend>
     <build_depend>std_msgs</build_depend>
     <build_depend>geometry_msgs</build_depend>
     <build_depend>sensor_msgs</build_depend>
@@ -37,6 +38,7 @@
     <run_depend>roscpp</run_depend>
     <run_depend>roslib</run_depend>
     <run_depend>rostest</run_depend>
+    <run_depend>map_msgs</run_depend>
     <run_depend>std_msgs</run_depend>
     <run_depend>geometry_msgs</run_depend>
     <run_depend>sensor_msgs</run_depend>

--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -48,7 +48,7 @@ Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle ros_node, Costmap2D* cost
     node(&ros_node), costmap_(costmap), global_frame_(global_frame), active_(false)
 {
   costmap_pub_ = ros_node.advertise<nav_msgs::OccupancyGrid>( topic_name, 1, boost::bind( &Costmap2DPublisher::onNewSubscription, this, _1 ));
-  costmap_update_pub_ = ros_node.advertise<costmap_2d::OccupancyGridUpdate>( topic_name + "_updates", 1 );
+  costmap_update_pub_ = ros_node.advertise<map_msgs::OccupancyGridUpdate>( topic_name + "_updates", 1 );
 
   if( cost_translation_table_ == NULL )
   {
@@ -121,7 +121,7 @@ void Costmap2DPublisher::publishCostmap()
   {
     boost::shared_lock < boost::shared_mutex > lock(*(costmap_->getLock()));
     // Publish Just an Update
-    costmap_2d::OccupancyGridUpdate update;
+    map_msgs::OccupancyGridUpdate update;
     update.header.stamp = ros::Time::now();
     update.header.frame_id = global_frame_;
     update.x = x0_;

--- a/enhanced_nav_display/CMakeLists.txt
+++ b/enhanced_nav_display/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(catkin REQUIRED
   roscpp
   rviz
   tf
-  costmap_2d
+  map_msgs
   message_filters
 )
 

--- a/enhanced_nav_display/package.xml
+++ b/enhanced_nav_display/package.xml
@@ -15,7 +15,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>costmap_2d</build_depend> <!-- map_msgs/OccupancyGridUpdate.msg copied to costmap_2d during catkinization. -->
+  <build_depend>map_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>pluginlib</build_depend>

--- a/enhanced_nav_display/src/costmap_display.cpp
+++ b/enhanced_nav_display/src/costmap_display.cpp
@@ -328,7 +328,7 @@ void Costmap::getColor(Ogre::ColourValue& color, char value){
     }
 }
 
-void Costmap::incomingUpdate(const costmap_2d::OccupancyGridUpdate::ConstPtr& msg){
+void Costmap::incomingUpdate(const map_msgs::OccupancyGridUpdate::ConstPtr& msg){
     if(!updateBaseColors()){
       uint32_t num_points = msg->data.size();
       for(uint32_t i=0;i<num_points;i++){

--- a/enhanced_nav_display/src/costmap_display.h
+++ b/enhanced_nav_display/src/costmap_display.h
@@ -33,7 +33,7 @@
 
 #include <rviz/display.h>
 #include <nav_msgs/OccupancyGrid.h>
-#include <costmap_2d/OccupancyGridUpdate.h>
+#include <map_msgs/OccupancyGridUpdate.h>
 #include <nav_msgs/MapMetaData.h>
 
 #ifndef Q_MOC_RUN
@@ -90,7 +90,7 @@ private:
   void unsubscribe();
   void clear();
   void incomingGrid( const nav_msgs::OccupancyGrid::ConstPtr& msg );
-  void incomingUpdate( const costmap_2d::OccupancyGridUpdate::ConstPtr& msg );
+  void incomingUpdate( const map_msgs::OccupancyGridUpdate::ConstPtr& msg );
   
   bool updateBaseColors();
   void colorAll();


### PR DESCRIPTION
Having OccupancyGridUpdate.msg defined in costmap_2d was intended to be temporary until map_msgs was catkinized and released, which has now been done.
