### PR TITLE
Edits necessary for a source compile on OSX with catkin

### DIFF
--- a/clear_costmap_recovery/CMakeLists.txt
+++ b/clear_costmap_recovery/CMakeLists.txt
@@ -30,6 +30,9 @@ catkin_package(
 )
 
 add_library(clear_costmap_recovery src/clear_costmap_recovery.cpp)
+target_link_libraries(clear_costmap_recovery
+    ${catkin_LIBRARIES}
+    )
 
 install(TARGETS clear_costmap_recovery
        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -11,6 +11,12 @@ find_package(catkin REQUIRED
             rostest
         )
 
+find_package(Boost REQUIRED
+    COMPONENTS
+        system
+        )
+
+
 catkin_package(
     CATKIN_DEPENDS
         roslib
@@ -20,7 +26,8 @@ catkin_package(
 )
 include_directories( include )
 add_library(image_loader src/image_loader.cpp)
-#target_link_libraries(image_loader SDL SDL_image)
+target_link_libraries(image_loader SDL SDL_image)
+target_link_libraries(image_loader ${Boost_LIBRARIES})
 
 add_executable(map_server src/main.cpp)
 target_link_libraries(map_server

--- a/rotate_recovery/CMakeLists.txt
+++ b/rotate_recovery/CMakeLists.txt
@@ -28,6 +28,10 @@ catkin_package(
 )
 
 add_library(rotate_recovery src/rotate_recovery.cpp)
+target_link_libraries(${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+    )
+
 
 install(TARGETS rotate_recovery
        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/voxel_grid/CMakeLists.txt
+++ b/voxel_grid/CMakeLists.txt
@@ -7,10 +7,6 @@ find_package(catkin REQUIRED
             roscpp
         )
 
-find_package(Boost REQUIRED
-    COMPONENTS
-        thread
-        )
 
 catkin_package(
     INCLUDE_DIRS

--- a/voxel_grid/CMakeLists.txt
+++ b/voxel_grid/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(catkin REQUIRED
             roscpp
         )
 
+find_package(Boost REQUIRED
+    COMPONENTS
+        thread
+        )
+
 catkin_package(
     INCLUDE_DIRS
         include
@@ -20,6 +25,9 @@ catkin_package(
 include_directories(include)
 
 add_library(voxel_grid src/voxel_grid.cpp)
+target_link_libraries(voxel_grid
+    ${catkin_LIBRARIES}
+    )
 
 add_executable(voxel_grid_sample src/voxel_grid_main.cpp)
 target_link_libraries(voxel_grid_sample


### PR DESCRIPTION
Edits necessary for a source compile on OSX with catkin. All are to include necessary linker commands.
