### PR TITLE
Dependencies in runtime due to default parameter settings.

### DIFF
--- a/move_base/package.xml
+++ b/move_base/package.xml
@@ -34,9 +34,11 @@
     <build_depend>base_local_planner</build_depend>
     <build_depend>clear_costmap_recovery</build_depend>
     <build_depend>navfn</build_depend>
+    <build_depend>rotate_recovery</build_depend>
     <run_depend>base_local_planner</run_depend>
     <run_depend>clear_costmap_recovery</run_depend>
     <run_depend>navfn</run_depend>
+    <run_depend>rotate_recovery</run_depend>
 
 <!--  This is commented out until rotate_recovery is ported to layered costmaps. <build_depend>rotate_recovery</build_depend> -->
 

--- a/move_base/package.xml
+++ b/move_base/package.xml
@@ -34,6 +34,10 @@
     <build_depend>base_local_planner</build_depend>
     <build_depend>clear_costmap_recovery</build_depend>
     <build_depend>navfn</build_depend>
+    <run_depend>base_local_planner</run_depend>
+    <run_depend>clear_costmap_recovery</run_depend>
+    <run_depend>navfn</run_depend>
+
 <!--  This is commented out until rotate_recovery is ported to layered costmaps. <build_depend>rotate_recovery</build_depend> -->
 
     <run_depend>actionlib</run_depend>


### PR DESCRIPTION
These packages were brought in as build_depends because of default settings in the code but they're currently only build_depends, so debs are not installed alongside move base, meaning any default launch of move_base fails.

Was this actually an oversight (this pull request fixes), or is there a good logical reason we're all missing here that these have been avoided as runtime dependencies?
