### PR TITLE
Trivial build updates

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -53,15 +53,16 @@ target_link_libraries( rtest
 )
 add_dependencies(rtest nav_msgs_gencpp)
 
-add_executable(map_saver src/map_saver.cpp)
-target_link_libraries( map_saver
+add_executable(map_server-map_saver src/map_saver.cpp)
+set_target_properties(map_server-map_saver PROPERTIES OUTPUT_NAME map_saver)
+target_link_libraries(map_server-map_saver
     ${catkin_LIBRARIES}
     )
 
 add_rostest(test/rtest.xml)
 
 ## Install executables and/or libraries
-install(TARGETS map_saver map_server image_loader
+install(TARGETS map_server-map_saver map_server image_loader
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/robot_pose_ekf/CMakeLists.txt
+++ b/robot_pose_ekf/CMakeLists.txt
@@ -78,7 +78,7 @@ install(
 include(CMakeDetermineSystem)
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
-download_test_data(http://pr.willowgarage.com/data/robot_pose_ekf/ekf_test2_indexed.bag test/ekf_test2.bag 71addef0ed900e05b301e0b4fdca99e2)
+catkin_download_test_data(download_data_ekf_test2_indexed.bag http://pr.willowgarage.com/data/robot_pose_ekf/ekf_test2_indexed.bag FILENAME test/ekf_test2.bag MD5 71addef0ed900e05b301e0b4fdca99e2)
 add_executable(test_robot_pose_ekf test/test_robot_pose_ekf.cpp)
 target_link_libraries(test_robot_pose_ekf
     ${Boost_LIBRARIES}
@@ -88,7 +88,7 @@ target_link_libraries(test_robot_pose_ekf
     )
 add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test_robot_pose_ekf.launch)
 
-download_test_data(http://pr.willowgarage.com/data/robot_pose_ekf/zero_covariance_indexed.bag test/zero_covariance.bag 1f1f4e361a9e0b0f6b1379b2dd011088)
+catkin_download_test_data(download_data_zero_covariance.bag http://pr.willowgarage.com/data/robot_pose_ekf/zero_covariance_indexed.bag FILENAME test/zero_covariance.bag MD5 1f1f4e361a9e0b0f6b1379b2dd011088)
 add_executable(test_robot_pose_ekf_zero_covariance test/test_robot_pose_ekf_zero_covariance.cpp)
 target_link_libraries(test_robot_pose_ekf_zero_covariance
     ${Boost_LIBRARIES}


### PR DESCRIPTION
These aren't high priority.
- Updates the deprecated catkin download function.
- Uniquely names the map_save target (doesn't change resulting filename) so it doesn't clash with map_store's target when building both from source in the same catkin_workspace.
