### PR TITLE
Remove unimplemented method from Costmap

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -78,7 +78,6 @@ public:
    */
   Costmap2DROS(std::string name, tf::TransformListener& tf);
   ~Costmap2DROS();
-  void resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x, double origin_y);
 
   /**
    * @brief  Subscribes to sensor topics if necessary and starts costmap


### PR DESCRIPTION
This screwed me up when I was writing some other code. But it was my own fault. 
