### PR TITLE
Fix bounds on clear costmap recovery

### DIFF
--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -134,7 +134,7 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
 	 }
 	 double ox = costmap->getOriginX(), oy = costmap->getOriginY();
 	 double width = costmap->getSizeInMetersX(), height = costmap->getSizeInMetersY();
-	 costmap->setResetBounds(ox - width/2, ox + width / 2, oy - height / 2, oy + height / 2);
+	 costmap->setResetBounds(ox, ox + width, oy, oy + height);
 	 return;
     }
 

--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -132,7 +132,9 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
 		}
 	    }
 	 }
-	 costmap->setResetBounds(0,0, costmap->getSizeInMetersX(), costmap->getSizeInMetersY());
+	 double ox = costmap->getOriginX(), oy = costmap->getOriginY();
+	 double width = costmap->getSizeInMetersX(), height = costmap->getSizeInMetersY();
+	 costmap->setResetBounds(ox - width/2, ox + width / 2, oy - height / 2, oy + height / 2);
 	 return;
     }
 


### PR DESCRIPTION
Fixing two bugs in one:
Note that the actual order of parameters in setResetBounds is minx, maxx, miny, maxy, not x,y,x,y. 

Also, the new values reflect the actual scope of the map when the origin is not 0,0. 
