### PR TITLE
Improvements to the static map layer to support updates

### DIFF
--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -73,7 +73,7 @@ private:
   void reconfigureCB(costmap_2d::GenericPluginConfig &config, uint32_t level);
 
   std::string global_frame_; ///< @brief The global frame for the costmap
-  bool map_recieved_, map_initialized_;
+  bool map_received_, map_initialized_;
   bool track_unknown_space_;
   ros::Subscriber map_sub_;
 

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -32,16 +32,14 @@ void StaticLayer::onInitialize()
   //we'll subscribe to the latched topic that the map server uses
   ROS_INFO("Requesting the map...");
   map_sub_ = g_nh.subscribe(map_topic, 1, &StaticLayer::incomingMap, this);
-  map_recieved_ = false;
+  map_received_ = false;
 
   ros::Rate r(10);
-  while (!map_recieved_ && g_nh.ok())
+  while (!map_received_ && g_nh.ok())
   {
     ros::spinOnce();
     r.sleep();
   }
-
-  map_initialized_ = false;
 
   dsrv_ = new dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>(nh);
   dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = boost::bind(
@@ -69,10 +67,22 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
 {
   unsigned int size_x = new_map->info.width, size_y = new_map->info.height;
 
-  ROS_INFO("Received a %d X %d map at %f m/pix", size_x, size_y, new_map->info.resolution);
+  ROS_DEBUG("Received a %d X %d map at %f m/pix", size_x, size_y, new_map->info.resolution);
 
-  layered_costmap_->resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x,
-                              new_map->info.origin.position.y, true);
+  // resize costmap if size, resolution or origin do not match
+  Costmap2D* master = layered_costmap_->getCostmap();
+  if (master->getSizeInCellsX() != size_x ||
+      master->getSizeInCellsY() != size_y ||
+      master->getResolution() != new_map->info.resolution ||
+      master->getOriginX() != new_map->info.origin.position.x ||
+      master->getOriginY() != new_map->info.origin.position.y ||
+      !layered_costmap_->isSizeLocked())
+  {
+    ROS_INFO("Resizing costmap to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);
+    layered_costmap_->resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x,
+                                new_map->info.origin.position.y, true);
+  }
+
   unsigned int index = 0;
 
   //initialize the costmap with static data
@@ -92,13 +102,14 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
       ++index;
     }
   }
-  map_recieved_ = true;
+  map_received_ = true;
+  map_initialized_ = false; // force costmap update
 }
 
 void StaticLayer::updateBounds(double origin_x, double origin_y, double origin_z, double* min_x, double* min_y,
                                         double* max_x, double* max_y)
 {
-  if (!map_recieved_ || map_initialized_)
+  if (!map_received_ || map_initialized_)
     return;
 
   mapToWorld(0, 0, *min_x, *min_y);

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -41,6 +41,8 @@ void StaticLayer::onInitialize()
     r.sleep();
   }
 
+  ROS_INFO("Received a %d X %d map at %f m/pix", getSizeInCellsX(), getSizeInCellsY(), getResolution());
+
   dsrv_ = new dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>(nh);
   dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = boost::bind(
       &StaticLayer::reconfigureCB, this, _1, _2);


### PR DESCRIPTION
The current version of the static map layer does not work with dynamic updates as the costmap is not updated any more after the first map has been received. Although costmap_2d is primarily meant for static maps, there are also many use cases where the map is updated throughout the mission, e.g. for exploring unknown environments.

This pull requests contains the following updates:
- Fixed typo in `map_recieved_` variable
- Set `map_initialized_` to false in the map callback to enforce a costmap update
- Only call `layered_costmap_->resizeMap()` if the map parameters (size, resolution, origin) have changed. Otherwise the costmap would be fully reset for each incoming map.
- Changed log type for the "Received a ... map" message from INFO to DEBUG and added another one if the map parameters have changed (to not spam the console for each update).
