### PR TITLE
Added support for YAML-CPP 0.5+.

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -11,6 +11,12 @@ find_package(catkin REQUIRED
 
 find_package(Boost REQUIRED COMPONENTS system)
 
+find_package(PkgConfig)
+pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
+if(NEW_YAMLCPP_FOUND)
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NEW_YAMLCPP_FOUND)
+
 catkin_package(
     INCLUDE_DIRS
         include

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -46,6 +46,16 @@
 #include "nav_msgs/MapMetaData.h"
 #include "yaml-cpp/yaml.h"
 
+#ifdef HAVE_NEW_YAMLCPP
+// The >> operator disappeared in yaml-cpp 0.5, so this function is
+// added to provide support for code written under the yaml-cpp 0.3 API.
+template<typename T>
+void operator >> (const YAML::Node& node, T& i)
+{
+  i = node.as<T>();
+}
+#endif
+
 class MapServer
 {
   public:
@@ -68,9 +78,14 @@ class MapServer
           ROS_ERROR("Map_server could not open %s.", fname.c_str());
           exit(-1);
         }
-        YAML::Parser parser(fin);   
+#ifdef HAVE_NEW_YAMLCPP
+        // The document loading process changed in yaml-cpp 0.5.
+        YAML::Node doc = YAML::Load(fin);
+#else
+        YAML::Parser parser(fin);
         YAML::Node doc;
         parser.GetNextDocument(doc);
+#endif
         try { 
           doc["resolution"] >> res; 
         } catch (YAML::InvalidScalar) { 


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and
it has a new way of loading documents. There's no version hint in the
library's headers, so I'm getting the version number from pkg-config.
