### PR TITLE
check whether costmap is initalized before publishing

### DIFF
--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -122,6 +122,11 @@ public:
     *yn = byn_;
   }
 
+  bool isInitialized()
+  {
+      return initialized_;
+  }
+
   /** @brief Updates the stored footprint, updates the circumscribed
    * and inscribed radii, and calls onFootprintChanged() in all
    * layers. */
@@ -158,6 +163,7 @@ private:
 
   std::vector<boost::shared_ptr<Layer> > plugins_;
 
+  bool initialized_;
   bool size_locked_;
   double circumscribed_radius_, inscribed_radius_;
   std::vector<geometry_msgs::Point> footprint_;

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -541,14 +541,14 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
     double start_t, end_t, t_diff;
     gettimeofday(&start, NULL);
 
-    updateMap();    
+    updateMap();
 
     gettimeofday(&end, NULL);
     start_t = start.tv_sec + double(start.tv_usec) / 1e6;
     end_t = end.tv_sec + double(end.tv_usec) / 1e6;
     t_diff = end_t - start_t;
     ROS_DEBUG("Map update time: %.9f", t_diff);
-    if (publish_cycle.toSec() > 0)
+    if (publish_cycle.toSec() > 0 and layered_costmap_->isInitialized())
     {
       unsigned int x0, y0, xn, yn;
       layered_costmap_->getBounds(&x0, &xn, &y0, &yn);

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -47,7 +47,7 @@ using namespace std;
 namespace costmap_2d
 {
 LayeredCostmap::LayeredCostmap(string global_frame, bool rolling_window, bool track_unknown) :
-    costmap_(), global_frame_(global_frame), rolling_window_(rolling_window), size_locked_(false)
+    costmap_(), global_frame_(global_frame), rolling_window_(rolling_window), initialized_(false), size_locked_(false)
 {
   if (track_unknown)
     costmap_.setDefaultValue(255);
@@ -73,6 +73,7 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
   {
     (*plugin)->matchSize();
   }
+  initialized_ = true;
 }
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -73,7 +73,6 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
   {
     (*plugin)->matchSize();
   }
-  initialized_ = true;
 }
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
@@ -128,6 +127,8 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   bxn_ = xn;
   by0_ = y0;
   byn_ = yn;
+
+  initialized_ = true;
 
 }
 


### PR DESCRIPTION
In the current code, its possible for Costmap2DROS::updateMap() to not actually update the map (for instance when it doesn't have a robot pose yet). in this case, Costmap2DROS::mapUpdateLoop() still tries to publish the costmap, but the sizes are garbage (LayeredCostmap doesn't initialize the size of the map until an update is done). this can cause a segfault, because Costmap2DPublisher tries to iterate over the costmap using the garbage map sizes provided by the layered costmap.

this pull request fixes the problem by checking whether the LayeredCostmap is initialized before trying to publish it.
