### PR TITLE
Keep consistent allignment_cost scale

### DIFF
--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -270,7 +270,8 @@ namespace dwa_local_planner {
     
     // keeping the nose on the path
     if (sq_dist > forward_point_distance_ * forward_point_distance_ * cheat_factor_) {
-      alignment_costs_.setScale(1.0);
+      double resolution = planner_util_->getCostmap()->getResolution();
+      alignment_costs_.setScale(resolution * pdist_scale_ * 0.5);
       // costs for robot being aligned with path (nose on path, not ju
       alignment_costs_.setTargetPoses(global_plan_);
     } else {


### PR DESCRIPTION
Use the configured alignment cost instead of resetting to 1.0. This
condition (farther from goal than forward_point_distance) is probably
met at the start of navigation, it seems this cost should be obeyed
until the robot gets close, then ignored completely.
