### PR TITLE
navfn: fix parallel build error from missing dep

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -71,7 +71,7 @@ catkin_package(
 #set(ROS_COMPILE_FLAGS "-g" ${ROS_COMPILE_FLAGS})
 #set(ROS_LINK_FLAGS "-g" ${ROS_LINK_FLAGS})
 
-add_library(base_local_planner 
+add_library(base_local_planner
 	src/footprint_helper.cpp
 	src/goal_functions.cpp
 	src/map_cell.cpp

--- a/base_local_planner/Makefile
+++ b/base_local_planner/Makefile
@@ -1,5 +1,0 @@
-myrule:
-	@echo "Must clear CMake cache for now."
-	rm -f build/CMakeCache.txt && make all
-
-include $(shell rospack find mk)/cmake.mk

--- a/navfn/CMakeLists.txt
+++ b/navfn/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library (navfn src/navfn.cpp src/navfn_ros.cpp)
 target_link_libraries(navfn
     ${catkin_LIBRARIES}
     )
+add_dependencies(navfn ${PROJECT_NAME}_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
 
 add_executable(navfn_node src/navfn_node.cpp)
 target_link_libraries(navfn_node


### PR DESCRIPTION
When building I would get errors because the messages would not generate their headers before the navfn library build was started.
