### PR TITLE
Reversed the resulting plan vector in global_planner

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -260,8 +260,6 @@ bool PlannerCore::makePlan(const geometry_msgs::PoseStamped& start, const geomet
     }else{
         ROS_ERROR("Failed to get a plan.");
     }
-    
-    reverse(plan.begin(), plan.end());
 
     //publish the plan for visualization purposes
     publishPlan(plan, 0.0, 1.0, 0.0, 0.0);
@@ -328,7 +326,7 @@ bool PlannerCore::getPlanFromPotential(const geometry_msgs::PoseStamped& goal,
     }
 
     ros::Time plan_time = ros::Time::now();
-    for (unsigned int i = 0; i < path.size(); i++) {
+    for (unsigned int i = path.size()-1; i > 0; i--) {
         std::pair<float, float> point = path[i];
         //convert the plan to world coordinates
         double world_x, world_y;

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -260,6 +260,8 @@ bool PlannerCore::makePlan(const geometry_msgs::PoseStamped& start, const geomet
     }else{
         ROS_ERROR("Failed to get a plan.");
     }
+    
+    reverse(plan.begin(), plan.end());
 
     //publish the plan for visualization purposes
     publishPlan(plan, 0.0, 1.0, 0.0, 0.0);


### PR DESCRIPTION
I bumped in a problem that the robot couldn't move, it is detailed here:
http://answers.ros.org/question/120786/global_planner-finds-a-path-but-is-not-able-to-find-a-valid-trajectory

I found out that the plan sent the path points from goal to origin, so I reversed the plan vector to fix it.
I hope there's a better solution but this one works.
