### PR TITLE
Fix for issue #167: hardcoded tf frames

### DIFF
--- a/robot_pose_ekf/include/robot_pose_ekf/odom_estimation.h
+++ b/robot_pose_ekf/include/robot_pose_ekf/odom_estimation.h
@@ -122,6 +122,16 @@ public:
    */
   void addMeasurement(const tf::StampedTransform& meas, const MatrixWrapper::SymmetricMatrix& covar);
 
+  /** set the output frame used by tf
+   * \param output_frame the desired output frame published on /tf (e.g., odom_combined)
+   */
+  void setOutputFrame(const std::string& output_frame);
+
+  /** set the base_footprint frame of the robot used by tf
+   * \param base_frame the desired base frame from which to transform when publishing the combined odometry frame (e.g., base_footprint)
+   */
+  void setBaseFootprintFrame(const std::string& base_frame);
+
 private:
   /// correct for angle overflow
   void angleOverflowCorrect(double& a, double ref);
@@ -160,6 +170,9 @@ private:
 
   // tf transformer
   tf::Transformer transformer_;
+
+  std::string output_frame_;
+  std::string base_footprint_frame_;
 
 }; // class
 

--- a/robot_pose_ekf/robot_pose_ekf.launch
+++ b/robot_pose_ekf/robot_pose_ekf.launch
@@ -2,6 +2,7 @@
 
 <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">
   <param name="output_frame" value="odom_combined"/>
+  <param name="base_footprint_frame" value="base_footprint"/>
   <param name="freq" value="30.0"/>
   <param name="sensor_timeout" value="1.0"/>  
   <param name="odom_used" value="true"/>


### PR DESCRIPTION
This is my suggested fix for issue #167. At the moment, robot_pose_ekf makes use of hardcoded string literals "odom_combined" and "base_footprint" as names for output and base frames. Since support for tf_prefix was dropped, having multiple robots with separate tf trees means having unique frame names (e.g., `robot1_base_footprint`).

The changes are backwards compatible with tf_prefix and hence it would not break any launch file. I have made some tests myself, but I hope someone else can assert these proposed changes.

It is rather straightforward: I added 2 string variables (output_frame_ and base_footprint_frame_) to OdomEstimation class to represent output and base frames, along with 2 mutator methods to set their values after fetching them from the parameter server. Then, the hardcoded references (string literals) to the output ("odom_combined") and base ("base_footprint") frames were replaced with output_frame_ and base_footprint_frame_, respectively.

With these changes it is possible to set the output and base frames using parameters "output_frame" and "base_footprint_frame".

I modified the example launch file to illustrate how to set the base frame as well as the output frame.
