### PR TITLE
Fixes unclean costmap2d shutdown

### DIFF
--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -158,8 +158,8 @@ protected:
 
   laser_geometry::LaserProjection projector_; ///< @brief Used to project laser scans into point clouds
 
-  std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_; ///< @brief Used to make sure that transforms are available for each sensor
   std::vector<boost::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_; ///< @brief Used for the observation message filters
+  std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_; ///< @brief Used to make sure that transforms are available for each sensor
   std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_; ///< @brief Used to store observations from various sensors
   std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_; ///< @brief Used to store observation buffers used for marking obstacles
   std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_; ///< @brief Used to store observation buffers used for clearing obstacles


### PR DESCRIPTION
This change in the order of the declaration of subscriber and message filter resolves an issue we were seeing that caused costmap2d to crash or hang when shutting down.

The cause for the issue was that the message filter was being destructed first and then when the subscriber destructor kicked-in, it would try to unregister from the message filter which triggered a lock on a deleted mutex.

With this minor change now shutdown occurs in the proper order, subscriber is first unregistered when destructed and then the message filter can die and rest in peace.
