### PR TITLE
Only publish costmaps if they have subscribers.

### DIFF
--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -115,7 +115,9 @@ void Costmap2DPublisher::publishCostmap()
   if (always_send_full_costmap_ || grid_.info.resolution != resolution || grid_.info.width != costmap_->getSizeInCellsX())
   {
     prepareGrid();
-    costmap_pub_.publish( grid_ );
+    if (costmap_pub_.getNumSubscribers() > 0) {
+      costmap_pub_.publish( grid_ );
+    }
   }
   else if (x0_ < xn_)
   {
@@ -139,7 +141,9 @@ void Costmap2DPublisher::publishCostmap()
         update.data[i++] = cost_translation_table_[ cost ];
       }
     }
-    costmap_update_pub_.publish(update);
+    if (costmap_update_pub_.getNumSubscribers() > 0) {
+      costmap_update_pub_.publish(update);
+    }
   }
 
   xn_ = yn_ = 0;


### PR DESCRIPTION
This shaves off a few cycles and improves performance.
