### PR TITLE
enhancements to deal with mulit-robot-szenarios by using name spaces for...

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -71,7 +71,6 @@ using namespace amcl;
 * @author Markus Bader <markus.bader@tuwien.ac.at>
 */
 void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
-  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
   if(!variable.empty() && variable.at(0) != '/'){
     boost::trim_right_if(name_space,boost::is_any_of("/"));
     boost::trim_left_if(name_space,boost::is_any_of("/"));
@@ -360,9 +359,9 @@ AmclNode::AmclNode() :
   addNameSpace(nh_.getNamespace(), base_frame_id_);
   addNameSpace(nh_.getNamespace(), global_frame_id_);
   /// added by Markus Bader for debugging
-  ROS_INFO("%s - odom_frame_id: %s", private_nh_.getNamespace().c_str(), odom_frame_id_.c_str());
-  ROS_INFO("%s - odom_frame_id: %s", private_nh_.getNamespace().c_str(), base_frame_id_.c_str());  
-  ROS_INFO("%s - global_frame_id_: %s", private_nh_.getNamespace().c_str(), global_frame_id_.c_str());
+  ROS_DEBUG("%s - odom_frame_id: %s", private_nh_.getNamespace().c_str(), odom_frame_id_.c_str());
+  ROS_DEBUG("%s - odom_frame_id: %s", private_nh_.getNamespace().c_str(), base_frame_id_.c_str());  
+  ROS_DEBUG("%s - global_frame_id_: %s", private_nh_.getNamespace().c_str(), global_frame_id_.c_str());
   
   private_nh_.param("resample_interval", resample_interval_, 2);
   double tmp_tol;

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -1,3 +1,6 @@
+
+#include <boost/algorithm/string.hpp>
+
 #include<costmap_2d/obstacle_layer.h>
 #include<costmap_2d/costmap_math.h>
 
@@ -13,7 +16,27 @@ using costmap_2d::Observation;
 
 namespace costmap_2d
 {
-
+/**
+* Addes the namespace to string if it does not start with a slash
+* @param name_space the namespace (nh_.GetNameSpace()) 
+* @param variable the namespace will be added to this string
+* @param rootSlash on true it adds the slash on the beginning
+* @author Markus Bader <markus.bader@tuwien.ac.at>
+*/
+void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
+  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
+  if(!variable.empty() && variable.at(0) != '/'){
+    boost::trim_right_if(name_space,boost::is_any_of("/"));
+    boost::trim_left_if(name_space,boost::is_any_of("/"));
+    if(!name_space.empty()) {
+      variable = name_space + "/" + variable;
+      if(rootSlash) {
+        variable = "/" + variable;
+      }
+    }
+  }
+}
+  
 void ObstacleLayer::onInitialize()
 {
   ros::NodeHandle nh("~/" + name_), g_nh;
@@ -54,6 +77,12 @@ void ObstacleLayer::onInitialize()
 
     source_node.param("topic", topic, source);
     source_node.param("sensor_frame", sensor_frame, std::string(""));
+    
+    /// added by Markus Bader to deal with namespaces
+    addNameSpace(g_nh.getNamespace(),  sensor_frame, false);
+    /// added by Markus Bader for debugging
+    ROS_DEBUG("%s - sensor_frame: %s", source_node.getNamespace().c_str(), sensor_frame.c_str());
+    
     source_node.param("observation_persistence", observation_keep_time, 0.0);
     source_node.param("expected_update_rate", expected_update_rate, 0.0);
     source_node.param("data_type", data_type, std::string("PointCloud"));

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -57,7 +57,6 @@ namespace costmap_2d
 * @author Markus Bader <markus.bader@tuwien.ac.at>
 */
 void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
-  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
   if(!variable.empty() && variable.at(0) != '/'){
     boost::trim_right_if(name_space,boost::is_any_of("/"));
     boost::trim_left_if(name_space,boost::is_any_of("/"));

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -49,6 +49,27 @@ using namespace std;
 namespace costmap_2d
 {
 
+/**
+* Addes the namespace to string if it does not start with a slash
+* @param name_space the namespace (nh_.GetNameSpace()) 
+* @param variable the namespace will be added to this string
+* @param rootSlash on true it adds the slash on the beginning
+* @author Markus Bader <markus.bader@tuwien.ac.at>
+*/
+void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
+  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
+  if(!variable.empty() && variable.at(0) != '/'){
+    boost::trim_right_if(name_space,boost::is_any_of("/"));
+    boost::trim_left_if(name_space,boost::is_any_of("/"));
+    if(!name_space.empty()) {
+      variable = name_space + "/" + variable;
+      if(rootSlash) {
+        variable = "/" + variable;
+      }
+    }
+  }
+}
+  
 void move_parameter(ros::NodeHandle& old_h, ros::NodeHandle& new_h, std::string name, bool should_delete=true)
 {
   if (!old_h.hasParam(name))
@@ -76,6 +97,14 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
   // get two frames
   private_nh.param("global_frame", global_frame_, std::string("/map"));
   private_nh.param("robot_base_frame", robot_base_frame_, std::string("base_link"));
+  
+  /// added by Markus Bader to deal with namespaces
+  addNameSpace(g_nh.getNamespace(),  global_frame_);
+  addNameSpace(g_nh.getNamespace(),  robot_base_frame_);
+  /// added by Markus Bader for debugging
+  ROS_DEBUG("%s - global_frame: %s", private_nh.getNamespace().c_str(), global_frame_.c_str());
+  ROS_DEBUG("%s - robot_base_frame: %s", private_nh.getNamespace().c_str(), robot_base_frame_.c_str());
+    
 
   // make sure that we set the frames appropriately based on the tf_prefix
   global_frame_ = tf::resolve(tf_prefix, global_frame_);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -57,7 +57,6 @@ namespace dwa_local_planner {
 * @author Markus Bader <markus.bader@tuwien.ac.at>
 */
 void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
-  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
   if(!variable.empty() && variable.at(0) != '/'){
     boost::trim_right_if(name_space,boost::is_any_of("/"));
     boost::trim_left_if(name_space,boost::is_any_of("/"));

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -49,6 +49,27 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 namespace dwa_local_planner {
+/**
+* Addes the namespace to string if it does not start with a slash
+* @param name_space the namespace (nh_.GetNameSpace()) 
+* @param variable the namespace will be added to this string
+* @param rootSlash on true it adds the slash on the beginning
+* @author Markus Bader <markus.bader@tuwien.ac.at>
+*/
+void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
+  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
+  if(!variable.empty() && variable.at(0) != '/'){
+    boost::trim_right_if(name_space,boost::is_any_of("/"));
+    boost::trim_left_if(name_space,boost::is_any_of("/"));
+    if(!name_space.empty()) {
+      variable = name_space + "/" + variable;
+      if(rootSlash) {
+        variable = "/" + variable;
+      }
+    }
+  }
+}
+  
   void DWAPlanner::reconfigure(DWAPlannerConfig &config)
   {
 
@@ -122,6 +143,7 @@ namespace dwa_local_planner {
       alignment_costs_(planner_util->getCostmap())
   {
     ros::NodeHandle private_nh("~/" + name);
+    ros::NodeHandle nh;
 
     goal_front_costs_.setStopOnFailure( false );
     alignment_costs_.setStopOnFailure( false );
@@ -156,6 +178,11 @@ namespace dwa_local_planner {
 
     std::string frame_id;
     private_nh.param("global_frame_id", frame_id, std::string("odom"));
+    /// added by Markus Bader to deal with namespaces
+    addNameSpace(nh.getNamespace(),  frame_id);
+    /// added by Markus Bader for debugging
+    ROS_DEBUG("%s - frame_id: %s", private_nh.getNamespace().c_str(), frame_id.c_str());
+    
 
     traj_cloud_ = new pcl::PointCloud<base_local_planner::MapGridCostPoint>;
     traj_cloud_->header.frame_id = frame_id;

--- a/fake_localization/fake_localization.cpp
+++ b/fake_localization/fake_localization.cpp
@@ -72,6 +72,7 @@
 
 #include <ros/ros.h>
 #include <ros/time.h>
+#include <boost/algorithm/string.hpp>
 
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/PoseArray.h>
@@ -86,6 +87,26 @@
 #include "tf/message_filter.h"
 #include "message_filters/subscriber.h"
 
+/**
+* Addes the namespace to string if it does not start with a slash
+* @param name_space the namespace (nh_.GetNameSpace()) 
+* @param variable the namespace will be added to this string
+* @param rootSlash on true it adds the slash on the beginning
+* @author Markus Bader <markus.bader@tuwien.ac.at>
+*/
+void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
+  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
+  if(!variable.empty() && variable.at(0) != '/'){
+    boost::trim_right_if(name_space,boost::is_any_of("/"));
+    boost::trim_left_if(name_space,boost::is_any_of("/"));
+    if(!name_space.empty()) {
+      variable = name_space + "/" + variable;
+      if(rootSlash) {
+        variable = "/" + variable;
+      }
+    }
+  }
+}
 
 class FakeOdomNode
 {
@@ -99,10 +120,20 @@ class FakeOdomNode
 
       m_base_pos_received = false;
 
-      ros::NodeHandle private_nh("~");
+      ros::NodeHandle private_nh("~"), nh;
       private_nh.param("odom_frame_id", odom_frame_id_, std::string("odom"));
       private_nh.param("base_frame_id", base_frame_id_, std::string("base_link")); 
       private_nh.param("global_frame_id", global_frame_id_, std::string("/map"));
+      
+      /// added by Markus Bader to deal with namespaces
+      addNameSpace(nh.getNamespace(), odom_frame_id_); 
+      addNameSpace(nh.getNamespace(), base_frame_id_);
+      addNameSpace(nh.getNamespace(), global_frame_id_);
+      /// added by Markus Bader for debugging
+      ROS_INFO("%s - odom_frame_id: %s", private_nh.getNamespace().c_str(), odom_frame_id_.c_str());
+      ROS_INFO("%s - odom_frame_id: %s", private_nh.getNamespace().c_str(), base_frame_id_.c_str());  
+      ROS_INFO("%s - global_frame_id_: %s", private_nh.getNamespace().c_str(), global_frame_id_.c_str());
+      
       private_nh.param("delta_x", delta_x_, 0.0);
       private_nh.param("delta_y", delta_y_, 0.0);
       private_nh.param("delta_yaw", delta_yaw_, 0.0);      
@@ -110,7 +141,6 @@ class FakeOdomNode
       m_particleCloud.header.stamp = ros::Time::now();
       m_particleCloud.header.frame_id = global_frame_id_;
       m_particleCloud.poses.resize(1);
-      ros::NodeHandle nh;
 
       m_offsetTf = tf::Transform(tf::createQuaternionFromRPY(0, 0, -delta_yaw_ ), tf::Point(-delta_x_, -delta_y_, 0.0));
 

--- a/fake_localization/fake_localization.cpp
+++ b/fake_localization/fake_localization.cpp
@@ -95,7 +95,6 @@
 * @author Markus Bader <markus.bader@tuwien.ac.at>
 */
 void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
-  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
   if(!variable.empty() && variable.at(0) != '/'){
     boost::trim_right_if(name_space,boost::is_any_of("/"));
     boost::trim_left_if(name_space,boost::is_any_of("/"));
@@ -130,9 +129,9 @@ class FakeOdomNode
       addNameSpace(nh.getNamespace(), base_frame_id_);
       addNameSpace(nh.getNamespace(), global_frame_id_);
       /// added by Markus Bader for debugging
-      ROS_INFO("%s - odom_frame_id: %s", private_nh.getNamespace().c_str(), odom_frame_id_.c_str());
-      ROS_INFO("%s - odom_frame_id: %s", private_nh.getNamespace().c_str(), base_frame_id_.c_str());  
-      ROS_INFO("%s - global_frame_id_: %s", private_nh.getNamespace().c_str(), global_frame_id_.c_str());
+      ROS_DEBUG("%s - odom_frame_id: %s", private_nh.getNamespace().c_str(), odom_frame_id_.c_str());
+      ROS_DEBUG("%s - odom_frame_id: %s", private_nh.getNamespace().c_str(), base_frame_id_.c_str());  
+      ROS_DEBUG("%s - global_frame_id_: %s", private_nh.getNamespace().c_str(), global_frame_id_.c_str());
       
       private_nh.param("delta_x", delta_x_, 0.0);
       private_nh.param("delta_y", delta_y_, 0.0);

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -53,7 +53,6 @@ namespace move_base {
 * @author Markus Bader <markus.bader@tuwien.ac.at>
 */
 void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
-  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
   if(!variable.empty() && variable.at(0) != '/'){
     boost::trim_right_if(name_space,boost::is_any_of("/"));
     boost::trim_left_if(name_space,boost::is_any_of("/"));

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -45,6 +45,27 @@
 
 namespace move_base {
 
+/**
+* Addes the namespace to string if it does not start with a slash
+* @param name_space the namespace (nh_.GetNameSpace()) 
+* @param variable the namespace will be added to this string
+* @param rootSlash on true it adds the slash on the beginning
+* @author Markus Bader <markus.bader@tuwien.ac.at>
+*/
+void addNameSpace(std::string name_space, std::string &variable, bool rootSlash = true){
+  ROS_INFO("addNameSpace(%s, %s)", name_space.c_str(), variable.c_str());
+  if(!variable.empty() && variable.at(0) != '/'){
+    boost::trim_right_if(name_space,boost::is_any_of("/"));
+    boost::trim_left_if(name_space,boost::is_any_of("/"));
+    if(!name_space.empty()) {
+      variable = name_space + "/" + variable;
+      if(rootSlash) {
+        variable = "/" + variable;
+      }
+    }
+  }
+}
+  
   MoveBase::MoveBase(tf::TransformListener& tf) :
     tf_(tf),
     as_(NULL),
@@ -68,6 +89,14 @@ namespace move_base {
     private_nh.param("base_local_planner", local_planner, std::string("base_local_planner/TrajectoryPlannerROS"));
     private_nh.param("global_costmap/robot_base_frame", robot_base_frame_, std::string("base_link"));
     private_nh.param("global_costmap/global_frame", global_frame_, std::string("/map"));
+    
+    /// added by Markus Bader to deal with namespaces
+    addNameSpace(nh.getNamespace(),  robot_base_frame_);
+    addNameSpace(nh.getNamespace(),  global_frame_);
+    /// added by Markus Bader for debugging
+    ROS_DEBUG("%s - global_costmap/robot_base_frame: %s", private_nh.getNamespace().c_str(), robot_base_frame_.c_str());
+    ROS_DEBUG("%s - global_costmap/global_frame: %s", private_nh.getNamespace().c_str(), global_frame_.c_str());  
+    
     private_nh.param("planner_frequency", planner_frequency_, 0.0);
     private_nh.param("controller_frequency", controller_frequency_, 20.0);
     private_nh.param("planner_patience", planner_patience_, 5.0);


### PR DESCRIPTION
Hello

I added some check of the nodes name spaces to deal with multi-robot scenarios. It would be nice if you accept my changes. 

Greetings
Markus

Details:
Name spaces are working perfect to rename topics but most nodes do have shared parameter to name a topic to which should be subscribed and than the problem start :-(
But I solved the problem and my amcl and move base is working now smoothly.
I forked the navigation stack and added a check on shared parameter like amcl: odom_frame_id, base_frame_id, global_frame_id to get the namespace right.
I did the same for the the following nodes
amcl/src/amcl_node.cpp
costmap_2d/plugins/obstacle_layer.cpp
costmap_2d/src/costmap_2d_ros.cpp
dwa_local_planner/src/dwa_planner.cpp
fake_localization/fake_localization.cpp
move_base/src/move_base.cpp

It would be nice if you could accept my pull request, if so I will right short tutorial how one can deal with multiple robots.
