### PR TITLE
fix problem that isGoalReached checked goal without updating current_pose_

### DIFF
--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -141,6 +141,10 @@ namespace dwa_local_planner {
       ROS_ERROR("This planner has not been initialized, please call initialize() before using this planner");
       return false;
     }
+    if ( ! costmap_ros_->getRobotPose(current_pose_)) {
+      ROS_ERROR("Could not get robot pose");
+      return false;
+    }
     if(latchedStopRotateController_.isGoalReached(&planner_util_, odom_helper_, current_pose_)) {
       ROS_INFO("Goal reached");
       return true;


### PR DESCRIPTION
This patch is a part of 
https://github.com/ros-planning/navigation/commit/97c2c7844cc00b489d3daa21b505fe7f080e6d5b

isGoalReached returned true, before updating current_pose.
