### PR TITLE
Created a new parameter to move_base: 'num_spinner_threads'.

### DIFF
--- a/move_base/src/move_base_node.cpp
+++ b/move_base/src/move_base_node.cpp
@@ -29,14 +29,27 @@
 
 #include <move_base/move_base.h>
 
-int main(int argc, char** argv){
+int main(int argc, char** argv) {
   ros::init(argc, argv, "move_base_node");
   tf::TransformListener tf(ros::Duration(10));
 
-  move_base::MoveBase move_base( tf );
+  move_base::MoveBase move_base(tf);
 
-  //ros::MultiThreadedSpinner s;
-  ros::spin();
+  int num_spinner_threads = 1;
+  ros::NodeHandle private_nh("~");
+  private_nh.param("num_spinner_threads", num_spinner_threads, 1);
+  ROS_INFO("move_base: num_spinner_threads = %d", num_spinner_threads);
+
+  if (num_spinner_threads < 2)
+    {
+      ros::spin();
+    }
+  else
+    {
+      ros::AsyncSpinner spinner(num_spinner_threads);
+      spinner.start();
+      ros::waitForShutdown();
+    }
 
   return(0);
 }


### PR DESCRIPTION
Depending upon the value passed to this new parameter, move_base will start up
and run with a single-threaded spinner (current behavior) or if passed a value
of 2 (threads) or greater, move_base will start a multi-threaded spinner (using
ros::AsyncSpinner) with the desired number of threads.

This behavior was created to address a latency issue that is described here:
http://answers.ros.org/question/148171/latency-when-sending-goal-to-move_base-and-it-starting/

I'm not sure of your testing procedure for integrating changes into the project nor move_base's overall thread safety. None-the-less, I thought I'd pass this along to you for review. I'm more than happy to follow proper protocol to get this patch (or similar) integrated to the master in order to have this functionality available in the core ROS move_base.  Thanks, Tom.
