### PR TITLE
Fix classloader warnings on exit of move_base

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -472,6 +472,9 @@ namespace move_base {
     delete planner_plan_;
     delete latest_plan_;
     delete controller_plan_;
+
+    planner_.reset();
+    tc_.reset();
   }
 
   bool MoveBase::makePlan(const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan){


### PR DESCRIPTION
Planners were not being properly unloaded, this commit fixes the following warnings on exit:

```
[amcl-2] killing on exit
[map_server-1] killing on exit
Warning: class_loader::ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
         at line 94 in /tmp/buildd/ros-hydro-class-loader-0.2.3-0precise-20140110-0815/src/class_loader.cpp
Warning: class_loader::ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
         at line 94 in /tmp/buildd/ros-hydro-class-loader-0.2.3-0precise-20140110-0815/src/class_loader.cpp
shutting down processing monitor...
... shutting down processing monitor complete
```
