### PR TITLE
uses odom child_frame_id to set robot_vel frame_id

### DIFF
--- a/base_local_planner/src/odometry_helper_ros.cpp
+++ b/base_local_planner/src/odometry_helper_ros.cpp
@@ -69,9 +69,10 @@ void OdometryHelperRos::getRobotVel(tf::Stamped<tf::Pose>& robot_vel) {
     global_vel.linear.x = base_odom_.twist.twist.linear.x;
     global_vel.linear.y = base_odom_.twist.twist.linear.y;
     global_vel.angular.z = base_odom_.twist.twist.angular.z;
+
+    robot_vel.frame_id_ = base_odom_.child_frame_id;
   }
   robot_vel.setData(tf::Transform(tf::createQuaternionFromYaw(global_vel.angular.z), tf::Vector3(global_vel.linear.x, global_vel.linear.y, 0)));
-  robot_vel.frame_id_ = frame_id_;//costmap_ros_->getBaseFrameID();
   robot_vel.stamp_ = ros::Time();
 }
 


### PR DESCRIPTION
If, instead, we want to take the `robot_frame_id`, we must pass the `costmap_ros_` to take it with

<pre>
costmap_ros_->getBaseFrameID();
</pre>


In that case, should I pass the `costmap_ros_` to the constructor?
Is there any plan or idea to do it?
