### PR TITLE
fixes latch_xy_goal_tolerance param not taken

### DIFF
--- a/base_local_planner/include/base_local_planner/latched_stop_rotate_controller.h
+++ b/base_local_planner/include/base_local_planner/latched_stop_rotate_controller.h
@@ -8,6 +8,8 @@
 #ifndef LATCHED_STOP_ROTATE_CONTROLLER_H_
 #define LATCHED_STOP_ROTATE_CONTROLLER_H_
 
+#include <string>
+
 #include <Eigen/Core>
 
 #include <tf/transform_datatypes.h>
@@ -19,7 +21,7 @@ namespace base_local_planner {
 
 class LatchedStopRotateController {
 public:
-  LatchedStopRotateController();
+  LatchedStopRotateController(const std::string& name = "");
   virtual ~LatchedStopRotateController();
 
   bool isPositionReached(LocalPlannerUtil* planner_util,

--- a/base_local_planner/src/latched_stop_rotate_controller.cpp
+++ b/base_local_planner/src/latched_stop_rotate_controller.cpp
@@ -19,7 +19,10 @@
 
 namespace base_local_planner {
 
-LatchedStopRotateController::LatchedStopRotateController() {
+LatchedStopRotateController::LatchedStopRotateController(const std::string& name) {
+  ros::NodeHandle private_nh("~/" + name);
+  private_nh.param("latch_xy_goal_tolerance", latch_xy_goal_tolerance_, false);
+
   rotating_to_goal_ = false;
 }
 


### PR DESCRIPTION
The `LatchedStopRotateController` does NOT get the `latch_xy_goal_tolerance` param.
Since the default value is `false`, it does nothing!
