### PR TITLE
Fixed costmap_2d clearing from service /move_base/clear_costmaps

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -639,6 +639,8 @@ void Costmap2DROS::resume()
 
 void Costmap2DROS::resetLayers()
 {
+  Costmap2D* top = layered_costmap_->getCostmap();
+  top->resetMap(0, 0, top->getSizeInCellsX(), top->getSizeInCellsY());
   std::vector < boost::shared_ptr<Layer> > *plugins = layered_costmap_->getPlugins();
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins->begin(); plugin != plugins->end();
       ++plugin)


### PR DESCRIPTION
Calling the service /move_base/clear_costmaps had little effect in both Hydro and Indigo.
