### PR TITLE
Remove unused robot_radius parameter

### DIFF
--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -8,7 +8,4 @@ gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
 gen.add("cost_scaling_factor", double_t, 0, "A scaling factor to apply to cost values during inflation.", 10, 0, 100)
 gen.add("inflation_radius", double_t, 0, "The radius in meters to which the map inflates obstacle cost values.", 0.55, 0, 50)
 
-# get dynamically?
-gen.add("robot_radius", double_t, 0, 'The radius of the robot in meters, this parameter should only be set for circular robots, all others should use the footprint parameter described above.', 0.46, 0, 10)
-
 exit(gen.generate("costmap_2d", "costmap_2d", "InflationPlugin"))


### PR DESCRIPTION
@mikeferguson can you confirm this? Looking at the code and experimenting without it, it seems this parameter is unused. Perhaps this was made redundant by the `robot_radius` parameter now in [Costmap2D.cfg](https://github.com/ros-planning/navigation/blob/88e802d89a28d5dbee0ce10ab3c0ab1931830e30/costmap_2d/cfg/Costmap2D.cfg#L20).

For further discussion, see https://github.com/turtlebot/turtlebot_apps/issues/94.
