### PR TITLE
renames acc_lim_th to acc_lim_theta

### DIFF
--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -118,7 +118,7 @@ namespace base_local_planner {
       private_nh.param("xy_goal_tolerance", xy_goal_tolerance_, 0.10);
       private_nh.param("acc_lim_x", acc_lim_x_, 2.5);
       private_nh.param("acc_lim_y", acc_lim_y_, 2.5);
-      private_nh.param("acc_lim_th", acc_lim_theta_, 3.2);
+      private_nh.param("acc_lim_theta", acc_lim_theta_, 3.2);
 
       private_nh.param("stop_time_buffer", stop_time_buffer, 0.2);
 


### PR DESCRIPTION
`acc_lim_th` param is taken in `trajectory_planner_ros.cpp`, but in `trajectory_planner.cpp` and the dynamic reconfigure `cfg` file uses `acc_lim_theta`, so I think this should be renamed.
