### PR TITLE
Trajectory marker

### DIFF
--- a/base_local_planner/cfg/BaseLocalPlanner.cfg
+++ b/base_local_planner/cfg/BaseLocalPlanner.cfg
@@ -52,6 +52,8 @@ gen.add("simple_attractor", bool_t, 0, "Set this to true to allow simple attract
 
 gen.add("y_vels", str_t, 0, "A comma delimited list of the y velocities the controller will explore", "-0.3,-0.1,0.1,-0.3")
 
+gen.add("publish_trajectories",  bool_t, 0, "Publish the trajectories on a marker array", False)
+
 gen.add("restore_defaults",  bool_t, 0, "Retore to the default configuration", False)
 
 exit(gen.generate(PACKAGE, "base_local_planner", "BaseLocalPlanner"))

--- a/base_local_planner/include/base_local_planner/trajectory_planner.h
+++ b/base_local_planner/include/base_local_planner/trajectory_planner.h
@@ -38,6 +38,7 @@
 #define TRAJECTORY_ROLLOUT_TRAJECTORY_PLANNER_H_
 
 #include <vector>
+#include <map>
 #include <cmath>
 
 //for obstacle data access
@@ -60,6 +61,9 @@
 //for creating a local cost grid
 #include <base_local_planner/map_cell.h>
 #include <base_local_planner/map_grid.h>
+
+//for visualizing the trajectories
+#include <visualization_msgs/MarkerArray.h>
 
 namespace base_local_planner {
   /**
@@ -123,7 +127,8 @@ namespace base_local_planner {
           bool simple_attractor = false,
           std::vector<double> y_vels = std::vector<double>(0),
           double stop_time_buffer = 0.2,
-          double sim_period = 0.1, double angular_sim_granularity = 0.025);
+          double sim_period = 0.1, double angular_sim_granularity = 0.025,
+          bool publish_trajectories = false);
 
       /**
        * @brief  Destructs a trajectory controller
@@ -258,7 +263,7 @@ namespace base_local_planner {
       double footprintCost(double x_i, double y_i, double theta_i);
 
       base_local_planner::FootprintHelper footprint_helper_;
-    
+
       MapGrid path_map_; ///< @brief The local map grid where we propagate path distance
       MapGrid goal_map_; ///< @brief The local map grid where we propagate goal distance
       const costmap_2d::Costmap2D& costmap_; ///< @brief Provides access to cost map information
@@ -301,7 +306,7 @@ namespace base_local_planner {
       double oscillation_reset_dist_; ///< @brief The distance the robot must travel before it can explore rotational velocities that were unsuccessful in the past
       double escape_reset_dist_, escape_reset_theta_; ///< @brief The distance the robot must travel before it can leave escape mode
       bool holonomic_robot_; ///< @brief Is the robot holonomic or not? 
-      
+
       double max_vel_x_, min_vel_x_, max_vel_th_, min_vel_th_, min_in_place_vel_th_; ///< @brief Velocity limits for the controller
 
       double backup_vel_; ///< @brief The velocity to use while backing up
@@ -318,7 +323,13 @@ namespace base_local_planner {
 
       double inscribed_radius_, circumscribed_radius_;
 
+      bool publish_trajectories_;
+
       boost::mutex configuration_mutex_;
+
+      ros::Publisher trajectory_pub_;
+      typedef std::map<std::string, visualization_msgs::MarkerArray> MarkerCollection;
+      MarkerCollection trajectory_markers_;
 
       /**
        * @brief  Compute x position based on velocity

--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -231,13 +231,17 @@ namespace base_local_planner {
       world_model_ = new CostmapModel(*costmap_);
       std::vector<double> y_vels = loadYVels(private_nh);
 
+      bool publish_trajectories;
+      private_nh.param("publish_trajectories", publish_trajectories, false);
+
       footprint_spec_ = costmap_ros_->getRobotFootprint();
 
       tc_ = new TrajectoryPlanner(*world_model_, *costmap_, footprint_spec_,
           acc_lim_x_, acc_lim_y_, acc_lim_theta_, sim_time, sim_granularity, vx_samples, vtheta_samples, pdist_scale,
           gdist_scale, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta, holonomic_robot,
           max_vel_x, min_vel_x, max_vel_th_, min_vel_th_, min_in_place_vel_th_, backup_vel,
-          dwa, heading_scoring, heading_scoring_timestep, meter_scoring, simple_attractor, y_vels, stop_time_buffer, sim_period_, angular_sim_granularity);
+          dwa, heading_scoring, heading_scoring_timestep, meter_scoring, simple_attractor, y_vels, stop_time_buffer, sim_period_, angular_sim_granularity,
+          publish_trajectories);
 
       map_viz_.initialize(name, global_frame_, boost::bind(&TrajectoryPlanner::getCellCosts, tc_, _1, _2, _3, _4, _5, _6));
       initialized_ = true;


### PR DESCRIPTION
This adds the possibility to publish a visualization marker array with the trajectories generated.
They are published if `publish_trajectories` param is set to `True` (available on the dynamic reconfigure `cfg` file). The trajectory markers are separated in different namespaces, depending on the logic that generates them.

This implementation shows only the trajectory endpoint; I think that drawing all the trajectory points is not really useful and shows so many points. The trajectory cost is not drawn because there is no clear upper bound for the conversion from cost to RGB.
I'm open to any advice to improve it.

The PR comes with several commits that removes empty lines, trailing white spaces and unused code or trivial changes.

@RainCT This is inspired in some implementation you did to handle markers and draw the trajectories. I've tried to keep the changes minimal, but maybe I should use your implementation at the end, if you agree.
