### PR TITLE
Added option to fix bug that resets particle weights on motion model updates

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -55,7 +55,7 @@ odt = gen.enum([gen.const("diff_const", str_t, "diff", "Use diff odom model"),
                 gen.const("omni_corrected_const", str_t, "omni-corrected", "Use corrected omni odom model")],
                "Odom Models")
 gen.add("odom_model_type", str_t, 0, "Which model to use, diff, omni, diff-corrected, or omni-corrected", "diff", edit_method=odt)
-
+gen.add("fix_particle_weight_discarding", bool_t, 0, "Fix issue that resets particle weights on motion", False)
 gen.add("odom_alpha1", double_t, 0, "Specifies the expected noise in odometry's rotation estimate from the rotational component of the robot's motion.", .2, 0, 10)
 gen.add("odom_alpha2", double_t, 0, "Specifies the expected noise in odometry's rotation estimate from the translational component of the robot's motion.", .2, 0, 10)
 gen.add("odom_alpha3", double_t, 0, "Specifies the expected noise in odometry's translation estimate from the translational component of the robot's motion.", .2, 0, 10)

--- a/amcl/include/amcl/sensors/amcl_odom.h
+++ b/amcl/include/amcl/sensors/amcl_odom.h
@@ -63,20 +63,23 @@ class AMCLOdom : public AMCLSensor
   public: void SetModelDiff(double alpha1, 
                             double alpha2, 
                             double alpha3, 
-                            double alpha4);
+                            double alpha4, 
+			    bool discard_weights = true);
 
   public: void SetModelOmni(double alpha1, 
                             double alpha2, 
                             double alpha3, 
                             double alpha4,
-                            double alpha5);
+                            double alpha5, 
+			    bool discard_weights = true);
 
   public: void SetModel( odom_model_t type,
                          double alpha1,
                          double alpha2,
                          double alpha3,
                          double alpha4,
-                         double alpha5 = 0 );
+                         double alpha5 = 0, 
+			 bool discard_weights = true);
 
   // Update the filter based on the action model.  Returns true if the filter
   // has been updated.
@@ -88,6 +91,8 @@ class AMCLOdom : public AMCLSensor
   // Model type
   private: odom_model_t model_type;
 
+  //Flag to reset particle weights 
+  private: bool discard_weights; 
   // Drift parameters
   private: double alpha1, alpha2, alpha3, alpha4, alpha5;
 };

--- a/amcl/src/amcl/sensors/amcl_odom.cpp
+++ b/amcl/src/amcl/sensors/amcl_odom.cpp
@@ -68,13 +68,15 @@ void
 AMCLOdom::SetModelDiff(double alpha1, 
                        double alpha2, 
                        double alpha3, 
-                       double alpha4)
+                       double alpha4,
+		       bool discard_weights)
 {
   this->model_type = ODOM_MODEL_DIFF;
   this->alpha1 = alpha1;
   this->alpha2 = alpha2;
   this->alpha3 = alpha3;
   this->alpha4 = alpha4;
+  this->discard_weights = discard_weights;
 }
 
 void
@@ -82,7 +84,8 @@ AMCLOdom::SetModelOmni(double alpha1,
                        double alpha2, 
                        double alpha3, 
                        double alpha4,
-                       double alpha5)
+                       double alpha5, 
+		       bool discard_weights)
 {
   this->model_type = ODOM_MODEL_OMNI;
   this->alpha1 = alpha1;
@@ -90,6 +93,7 @@ AMCLOdom::SetModelOmni(double alpha1,
   this->alpha3 = alpha3;
   this->alpha4 = alpha4;
   this->alpha5 = alpha5;
+  this->discard_weights = discard_weights;
 }
 
 void
@@ -98,7 +102,8 @@ AMCLOdom::SetModel( odom_model_t type,
                     double alpha2,
                     double alpha3,
                     double alpha4,
-                    double alpha5 )
+                    double alpha5, 
+		    bool discard_weights)
 {
   this->model_type = type;
   this->alpha1 = alpha1;
@@ -106,6 +111,7 @@ AMCLOdom::SetModel( odom_model_t type,
   this->alpha3 = alpha3;
   this->alpha4 = alpha4;
   this->alpha5 = alpha5;
+  this->discard_weights = discard_weights;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -159,7 +165,8 @@ bool AMCLOdom::UpdateAction(pf_t *pf, AMCLSensorData *data)
       sample->pose.v[1] += (delta_trans_hat * sn_bearing - 
                             delta_strafe_hat * cs_bearing);
       sample->pose.v[2] += delta_rot_hat ;
-      sample->weight = 1.0 / set->sample_count;
+      if(discard_weights)
+	sample->weight = 1.0 / set->sample_count;
     }
   }
   break;
@@ -212,7 +219,8 @@ bool AMCLOdom::UpdateAction(pf_t *pf, AMCLSensorData *data)
       sample->pose.v[1] += delta_trans_hat * 
               sin(sample->pose.v[2] + delta_rot1_hat);
       sample->pose.v[2] += delta_rot1_hat + delta_rot2_hat;
-      sample->weight = 1.0 / set->sample_count;
+      if(discard_weights)
+	sample->weight = 1.0 / set->sample_count;
     }
   }
   break;
@@ -252,7 +260,8 @@ bool AMCLOdom::UpdateAction(pf_t *pf, AMCLSensorData *data)
       sample->pose.v[1] += (delta_trans_hat * sn_bearing - 
                             delta_strafe_hat * cs_bearing);
       sample->pose.v[2] += delta_rot_hat ;
-      sample->weight = 1.0 / set->sample_count;
+      if(discard_weights)
+	sample->weight = 1.0 / set->sample_count;
     }
   }
   break;
@@ -305,7 +314,8 @@ bool AMCLOdom::UpdateAction(pf_t *pf, AMCLSensorData *data)
       sample->pose.v[1] += delta_trans_hat * 
               sin(sample->pose.v[2] + delta_rot1_hat);
       sample->pose.v[2] += delta_rot1_hat + delta_rot2_hat;
-      sample->weight = 1.0 / set->sample_count;
+      if(discard_weights)
+	sample->weight = 1.0 / set->sample_count;
     }
   }
   break;


### PR DESCRIPTION
There's a bug in amcl's motion model--the particle weights are reset in the motion model after the particles are propagated.  This isn't a problem if resampling happens on every step, but if you are using a resample_interval >1, amcl will essentially ignore all but the last observation before the resample.  

Just in case anyone is using resample_interval>1 and has a system working _with_ the bug, we made it an optional param that defaults to the old behavior.  (Feel free to debate which way it should go, or whether it should just be a fix and not a param at all.)
