### PR TITLE
Added planner_overclock_ratio param to move_base

### DIFF
--- a/move_base/cfg/MoveBase.cfg
+++ b/move_base/cfg/MoveBase.cfg
@@ -2,7 +2,7 @@
 
 PACKAGE = 'move_base'
 
-from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, str_t, double_t, bool_t
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, str_t, double_t, bool_t, int_t
 
 gen = ParameterGenerator()
 
@@ -12,6 +12,7 @@ gen.add("base_local_planner", str_t, 0, "The name of the plugin for the local pl
 #gen.add("recovery_behaviors", str_t, 0, "A list of recovery behavior plugins to use with move_base.", "[{name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery}, {name: rotate_recovery, type: rotate_recovery/RotateRecovery}, {name: aggressive_reset, type: clear_costmap_recovery/ClearCostmapRecovery}]")
 
 gen.add("planner_frequency", double_t, 0, "The rate in Hz at which to run the planning loop.", 0, 0, 100)
+gen.add("planner_overclock_ratio", int_t, 0, "This times planner_frequency is the new frequency at which the planning loop checks if it should replan based on an event (e.g., getting a new goal or the controller failing).", 1, 1, 100)
 gen.add("controller_frequency", double_t, 0, "The rate in Hz at which to run the control loop and send velocity commands to the base.", 20, 0, 100)
 gen.add("planner_patience", double_t, 0, "How long the planner will wait in seconds in an attempt to find a valid plan before space-clearing operations are performed.", 5.0, 0, 100)
 gen.add("controller_patience", double_t, 0, "How long the controller will wait in seconds without receiving a valid control before space-clearing operations are performed.", 5.0, 0, 100)

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -183,6 +183,7 @@ namespace move_base {
 
       tf::Stamped<tf::Pose> global_pose_;
       double planner_frequency_, controller_frequency_, inscribed_radius_, circumscribed_radius_;
+      int planner_overclock_ratio_;
       double planner_patience_, controller_patience_;
       double conservative_reset_dist_, clearing_radius_;
       ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_;
@@ -222,6 +223,7 @@ namespace move_base {
       move_base::MoveBaseConfig default_config_;
       bool setup_, p_freq_change_, c_freq_change_;
       bool new_global_plan_;
+      bool have_new_goal, replan_goal; 
   };
 };
 #endif


### PR DESCRIPTION
This param times the planner_frequency is the new frequency for the planning loop.  At this frequency, it checks if a new plan is needed based on a new goal or a stuck controller (or if it's time to plan again based on the old planner_frequency).

This eliminates the problem where you ask the robot to go to a new location, or the controller is unable to execute the plan, and instead of replanning, the robot stops and waits for the next planner loop (at a potentially very slow planner_frequency).

(Thanks to Sachi Hemachandra.)
