### PR TITLE
Fix for issue where trajectory_planner returns false to isGoalReached() even when internally it is done

### DIFF
--- a/base_local_planner/include/base_local_planner/trajectory_planner_ros.h
+++ b/base_local_planner/include/base_local_planner/trajectory_planner_ros.h
@@ -214,6 +214,7 @@ namespace base_local_planner {
       double acc_lim_x_, acc_lim_y_, acc_lim_theta_;
       double sim_period_;
       bool rotating_to_goal_;
+      bool reached_goal_;
       bool latch_xy_goal_tolerance_, xy_tolerance_latch_;
 
       ros::Publisher g_plan_pub_, l_plan_pub_;


### PR DESCRIPTION
When move_base calls isGoalReached() for trajectory_planner, the trajectory_planner's current implementation uses the base class method to return the value. However, this is sometimes different than what its control logic uses to decide at goal - causing move_base to recall the planner. This leads to the robot to turn towards the goal - stop and start turning the other direction (because it's given a new plan). 

Fix removes the call to the base class method - and returns a flag that is set in the control loop when the robot is within the tolerances.
