### PR TITLE
A new sensor model which calculates the observation likelihood in a probabilistic manner 

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -23,6 +23,10 @@ gen.add("transform_tolerance", double_t, 0, "Time with which to post-date the tr
 gen.add("recovery_alpha_slow", double_t, 0, "Exponential decay rate for the slow average weight filter, used in deciding when to recover by adding random poses. A good value might be 0.001.", 0, 0, .5)
 gen.add("recovery_alpha_fast", double_t, 0, "Exponential decay rate for the fast average weight filter, used in deciding when to recover by adding random poses. A good value might be 0.1.", 0, 0, 1)
 
+gen.add("do_beamskip", bool_t, 0, "When true skips laser scans when a scan doesnt work for a majority of particles", False)
+gen.add("beam_skip_distance", double_t, 0, "Distance from a valid map point before scan is considered invalid", 0, 2, 0.5)
+gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scans are valid to consider as valid scan", 0, 1, 0.3)
+
 gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via TF.  When false, do not.", True)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)
 gen.add("save_pose_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used on subsequent runs to initialize the filter. -1.0 to disable.", .5, 0, 10)

--- a/amcl/include/amcl/pf/pf.h
+++ b/amcl/include/amcl/pf/pf.h
@@ -103,7 +103,7 @@ typedef struct _pf_sample_set_t
   // Filter statistics
   pf_vector_t mean;
   pf_matrix_t cov;
-
+  int converged; 
 } pf_sample_set_t;
 
 
@@ -130,6 +130,9 @@ typedef struct _pf_t
   // Function used to draw random pose samples
   pf_init_model_fn_t random_pose_fn;
   void *random_pose_data;
+
+  double dist_threshold; //distance threshold in each axis over which the pf is considered to not be converged
+  int converged; 
 } pf_t;
 
 
@@ -175,6 +178,13 @@ void pf_draw_cep_stats(pf_t *pf, struct _rtk_fig_t *fig);
 
 // Draw the cluster statistics
 void pf_draw_cluster_stats(pf_t *pf, struct _rtk_fig_t *fig);
+
+//calculate if the particle filter has converged - 
+//and sets the converged flag in the current set and the pf 
+int pf_update_converged(pf_t *pf);
+
+//sets the current set and pf converged values to zero
+void pf_init_converged(pf_t *pf);
 
 #ifdef __cplusplus
 }

--- a/amcl/include/amcl/sensors/amcl_laser.h
+++ b/amcl/include/amcl/sensors/amcl_laser.h
@@ -38,7 +38,8 @@ namespace amcl
 typedef enum
 {
   LASER_MODEL_BEAM,
-  LASER_MODEL_LIKELIHOOD_FIELD
+  LASER_MODEL_LIKELIHOOD_FIELD,
+  LASER_MODEL_LIKELIHOOD_FIELD_PROB
 } laser_model_t;
 
 // Laser sensor data
@@ -60,6 +61,8 @@ class AMCLLaser : public AMCLSensor
   // Default constructor
   public: AMCLLaser(size_t max_beams, map_t* map);
 
+  public: virtual ~AMCLLaser(); 
+
   public: void SetModelBeam(double z_hit,
                             double z_short,
                             double z_max,
@@ -72,7 +75,17 @@ class AMCLLaser : public AMCLSensor
                                        double z_rand,
                                        double sigma_hit,
                                        double max_occ_dist);
-  
+
+  //a more probabilistically correct model - also with the option to do beam skipping
+  public: void SetModelLikelihoodFieldProb(double z_hit,
+					   double z_rand,
+					   double sigma_hit,
+					   double max_occ_dist, 
+					   bool do_beamskip, 
+					   double beam_skip_distance, 
+					   double beam_skip_threshold, 
+					   double beam_skip_error_threshold);
+
   // Update the filter based on the sensor model.  Returns true if the
   // filter has been updated.
   public: virtual bool UpdateSensor(pf_t *pf, AMCLSensorData *data);
@@ -88,6 +101,12 @@ class AMCLLaser : public AMCLSensor
   private: static double LikelihoodFieldModel(AMCLLaserData *data, 
                                               pf_sample_set_t* set);
 
+  // Determine the probability for the given pose - more probablistic model 
+  private: static double LikelihoodFieldModelProb(AMCLLaserData *data, 
+					     pf_sample_set_t* set);
+
+  private: void reallocTempData(int max_samples, int max_obs);
+
   private: laser_model_t model_type;
 
   // Current data timestamp
@@ -101,6 +120,19 @@ class AMCLLaser : public AMCLSensor
   
   // Max beams to consider
   private: int max_beams;
+
+  // Beam skipping parameters (used by LikelihoodFieldModelProb model)
+  private: bool do_beamskip; 
+  private: double beam_skip_distance; 
+  private: double beam_skip_threshold; 
+  //threshold for the ratio of invalid beams - at which all beams are integrated to the likelihoods 
+  //this would be an error condition 
+  private: double beam_skip_error_threshold;
+
+  //temp data that is kept before observations are integrated to each particle (requried for beam skipping)
+  private: int max_samples;
+  private: int max_obs;
+  private: double **temp_obs;
 
   // Laser model params
   //

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -70,6 +70,7 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   // distrubition will be less than [err].
   pf->pop_err = 0.01;
   pf->pop_z = 3;
+  pf->dist_threshold = 0.5; 
   
   pf->current_set = 0;
   for (j = 0; j < 2; j++)
@@ -105,9 +106,11 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   pf->alpha_slow = alpha_slow;
   pf->alpha_fast = alpha_fast;
 
+  //set converged to 0
+  pf_init_converged(pf);
+
   return pf;
 }
-
 
 // Free an existing filter
 void pf_free(pf_t *pf)
@@ -124,7 +127,6 @@ void pf_free(pf_t *pf)
   
   return;
 }
-
 
 // Initialize the filter using a guassian
 void pf_init(pf_t *pf, pf_vector_t mean, pf_matrix_t cov)
@@ -159,7 +161,10 @@ void pf_init(pf_t *pf, pf_vector_t mean, pf_matrix_t cov)
   pf_pdf_gaussian_free(pdf);
     
   // Re-compute cluster statistics
-  pf_cluster_stats(pf, set);
+  pf_cluster_stats(pf, set); 
+
+  //set converged to 0
+  pf_init_converged(pf);
 
   return;
 }
@@ -195,9 +200,51 @@ void pf_init_model(pf_t *pf, pf_init_model_fn_t init_fn, void *init_data)
   // Re-compute cluster statistics
   pf_cluster_stats(pf, set);
   
+  //set converged to 0
+  pf_init_converged(pf);
+
   return;
 }
 
+void pf_init_converged(pf_t *pf){
+  pf_sample_set_t *set;
+  set = pf->sets + pf->current_set;
+  set->converged = 0; 
+  pf->converged = 0; 
+}
+
+int pf_update_converged(pf_t *pf)
+{
+  int i;
+  pf_sample_set_t *set;
+  pf_sample_t *sample;
+  double total;
+
+  set = pf->sets + pf->current_set;
+  double mean_x = 0, mean_y = 0;
+
+  for (i = 0; i < set->sample_count; i++){
+    sample = set->samples + i;
+
+    mean_x += sample->pose.v[0];
+    mean_y += sample->pose.v[1];
+  }
+  mean_x /= set->sample_count;
+  mean_y /= set->sample_count;
+  
+  for (i = 0; i < set->sample_count; i++){
+    sample = set->samples + i;
+    if(fabs(sample->pose.v[0] - mean_x) > pf->dist_threshold || 
+       fabs(sample->pose.v[1] - mean_y) > pf->dist_threshold){
+      set->converged = 0; 
+      pf->converged = 0; 
+      return 0;
+    }
+  }
+  set->converged = 1; 
+  pf->converged = 1; 
+  return 1; 
+}
 
 // Update the filter with some new action
 void pf_update_action(pf_t *pf, pf_action_model_fn_t action_fn, void *action_data)
@@ -251,8 +298,6 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
   }
   else
   {
-    //PLAYER_WARN("pdf has zero probability");
-
     // Handle zero total
     for (i = 0; i < set->sample_count; i++)
     {
@@ -391,7 +436,9 @@ void pf_update_resample(pf_t *pf)
   pf_cluster_stats(pf, set_b);
 
   // Use the newly created sample set
-  pf->current_set = (pf->current_set + 1) % 2;
+  pf->current_set = (pf->current_set + 1) % 2; 
+
+  pf_update_converged(pf);
 
   free(c);
   return;

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -39,7 +39,9 @@ using namespace amcl;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Default constructor
-AMCLLaser::AMCLLaser(size_t max_beams, map_t* map) : AMCLSensor()
+AMCLLaser::AMCLLaser(size_t max_beams, map_t* map) : AMCLSensor(), 
+						     max_samples(0), max_obs(0), 
+						     temp_obs(NULL)
 {
   this->time = 0.0;
 
@@ -47,6 +49,16 @@ AMCLLaser::AMCLLaser(size_t max_beams, map_t* map) : AMCLSensor()
   this->map = map;
 
   return;
+}
+
+AMCLLaser::~AMCLLaser()
+{
+  if(temp_obs){
+	for(int k=0; k < max_samples; k++){
+	  delete [] temp_obs[k];
+	}
+	delete []temp_obs; 
+  }
 }
 
 void 
@@ -82,6 +94,27 @@ AMCLLaser::SetModelLikelihoodField(double z_hit,
   map_update_cspace(this->map, max_occ_dist);
 }
 
+void 
+AMCLLaser::SetModelLikelihoodFieldProb(double z_hit,
+				       double z_rand,
+				       double sigma_hit,
+				       double max_occ_dist,
+				       bool do_beamskip,
+				       double beam_skip_distance,
+				       double beam_skip_threshold, 
+				       double beam_skip_error_threshold)
+{
+  this->model_type = LASER_MODEL_LIKELIHOOD_FIELD_PROB;
+  this->z_hit = z_hit;
+  this->z_rand = z_rand;
+  this->sigma_hit = sigma_hit;
+  this->do_beamskip = do_beamskip;
+  this->beam_skip_distance = beam_skip_distance;
+  this->beam_skip_threshold = beam_skip_threshold;
+  this->beam_skip_error_threshold = beam_skip_error_threshold;
+  map_update_cspace(this->map, max_occ_dist);
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // Apply the laser sensor model
@@ -94,7 +127,9 @@ bool AMCLLaser::UpdateSensor(pf_t *pf, AMCLSensorData *data)
   if(this->model_type == LASER_MODEL_BEAM)
     pf_update_sensor(pf, (pf_sensor_model_fn_t) BeamModel, data);
   else if(this->model_type == LASER_MODEL_LIKELIHOOD_FIELD)
-    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModel, data);
+    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModel, data);  
+  else if(this->model_type == LASER_MODEL_LIKELIHOOD_FIELD_PROB)
+    pf_update_sensor(pf, (pf_sensor_model_fn_t) LikelihoodFieldModelProb, data);  
   else
     pf_update_sensor(pf, (pf_sensor_model_fn_t) BeamModel, data);
 
@@ -263,4 +298,211 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
   }
 
   return(total_weight);
+}
+
+double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t* set)
+{
+  AMCLLaser *self;
+  int i, j, step;
+  double z, pz;
+  double log_p;
+  double obs_range, obs_bearing;
+  double total_weight;
+  pf_sample_t *sample;
+  pf_vector_t pose;
+  pf_vector_t hit;
+
+  self = (AMCLLaser*) data->sensor;
+
+  total_weight = 0.0;
+
+  step = ceil((data->range_count) / static_cast<double>(self->max_beams)); 
+  
+  // Step size must be at least 1
+  if(step < 1)
+    step = 1;
+
+  // Pre-compute a couple of things
+  double z_hit_denom = 2 * self->sigma_hit * self->sigma_hit;
+  double z_rand_mult = 1.0/data->range_max;
+
+  double max_dist_prob = exp(-(self->map->max_occ_dist * self->map->max_occ_dist) / z_hit_denom);
+
+  //Beam skipping - ignores beams for which a majoirty of particles do not agree with the map
+  //prevents correct particles from getting down weighted because of unexpected obstacles 
+  //such as humans 
+
+  bool do_beamskip = self->do_beamskip;
+  double beam_skip_distance = self->beam_skip_distance;
+  double beam_skip_threshold = self->beam_skip_threshold;
+  
+  //we only do beam skipping if the filter has converged 
+  if(do_beamskip && !set->converged){
+    do_beamskip = false;
+  }
+
+  //we need a count the no of particles for which the beam agreed with the map 
+  int *obs_count = new int[self->max_beams]();
+
+  //we also need a mask of which observations to integrate (to decide which beams to integrate to all particles) 
+  bool *obs_mask = new bool[self->max_beams]();
+  
+  int beam_ind = 0;
+  
+  //realloc indicates if we need to reallocate the temp data structure needed to do beamskipping 
+  bool realloc = false; 
+
+  if(do_beamskip){
+    if(self->max_obs < self->max_beams){
+      realloc = true;
+    }
+
+    if(self->max_samples < set->sample_count){
+      realloc = true;
+    }
+
+    if(realloc){
+      self->reallocTempData(set->sample_count, self->max_beams);     
+      fprintf(stderr, "Reallocing temp weights %d - %d\n", self->max_samples, self->max_obs);
+    }
+  }
+
+  // Compute the sample weights
+  for (j = 0; j < set->sample_count; j++)
+  {
+    sample = set->samples + j;
+    pose = sample->pose;
+
+    // Take account of the laser pose relative to the robot
+    pose = pf_vector_coord_add(self->laser_pose, pose);
+
+    log_p = 0;
+    
+    beam_ind = 0;
+    
+    for (i = 0; i < data->range_count; i += step, beam_ind++)
+    {
+      obs_range = data->ranges[i][0];
+      obs_bearing = data->ranges[i][1];
+
+      // This model ignores max range readings
+      if(obs_range >= data->range_max){
+        continue;
+      }
+
+      // Check for NaN
+      if(obs_range != obs_range){
+        continue;
+      }
+
+      pz = 0.0;
+
+      // Compute the endpoint of the beam
+      hit.v[0] = pose.v[0] + obs_range * cos(pose.v[2] + obs_bearing);
+      hit.v[1] = pose.v[1] + obs_range * sin(pose.v[2] + obs_bearing);
+
+      // Convert to map grid coords.
+      int mi, mj;
+      mi = MAP_GXWX(self->map, hit.v[0]);
+      mj = MAP_GYWY(self->map, hit.v[1]);
+      
+      // Part 1: Get distance from the hit to closest obstacle.
+      // Off-map penalized as max distance
+      
+      if(!MAP_VALID(self->map, mi, mj)){
+	pz += self->z_hit * max_dist_prob;
+      }
+      else{
+	z = self->map->cells[MAP_INDEX(self->map,mi,mj)].occ_dist;
+	if(z < beam_skip_distance){
+	  obs_count[beam_ind] += 1;
+	}
+	pz += self->z_hit * exp(-(z * z) / z_hit_denom);
+      }
+       
+      // Gaussian model
+      // NOTE: this should have a normalization of 1/(sqrt(2pi)*sigma)
+      
+      // Part 2: random measurements
+      pz += self->z_rand * z_rand_mult;
+
+      assert(pz <= 1.0); 
+      assert(pz >= 0.0);
+
+      // TODO: outlier rejection for short readings
+            
+      if(!do_beamskip){
+	log_p += log(pz);
+      }
+      else{
+	self->temp_obs[j][beam_ind] = pz; 
+      }
+    }
+    if(!do_beamskip){
+      sample->weight *= exp(log_p);
+      total_weight += sample->weight;
+    }
+  }
+  
+  if(do_beamskip){
+    int skipped_beam_count = 0; 
+    for (beam_ind = 0; beam_ind < self->max_beams; beam_ind++){
+      if((obs_count[beam_ind] / static_cast<double>(set->sample_count)) > beam_skip_threshold){
+	obs_mask[beam_ind] = true;
+      }
+      else{
+	obs_mask[beam_ind] = false;
+	skipped_beam_count++; 
+      }
+    }
+
+    //we check if there is at least a critical number of beams that agreed with the map 
+    //otherwise it probably indicates that the filter converged to a wrong solution
+    //if that's the case we integrate all the beams and hope the filter might converge to 
+    //the right solution
+    bool error = false; 
+
+    if(skipped_beam_count >= (beam_ind * self->beam_skip_error_threshold)){
+      fprintf(stderr, "Over %f%% of the observations were not in the map - pf may have converged to wrong pose - integrating all observations\n", (100 * self->beam_skip_error_threshold));
+      error = true; 
+    }
+
+    for (j = 0; j < set->sample_count; j++)
+      {
+	sample = set->samples + j;
+	pose = sample->pose;
+
+	log_p = 0;
+
+	for (beam_ind = 0; beam_ind < self->max_beams; beam_ind++){
+	  if(error || obs_mask[beam_ind]){
+	    log_p += log(self->temp_obs[j][beam_ind]);
+	  }
+	}
+	
+	sample->weight *= exp(log_p);
+	
+	total_weight += sample->weight;
+      }      
+  }
+
+  delete [] obs_count; 
+  delete [] obs_mask;
+  return(total_weight);
+}
+
+void AMCLLaser::reallocTempData(int new_max_samples, int new_max_obs){
+  if(temp_obs){
+    for(int k=0; k < max_samples; k++){
+      delete [] temp_obs[k];
+    }
+    delete []temp_obs; 
+  }
+  max_obs = new_max_obs; 
+  max_samples = fmax(max_samples, new_max_samples); 
+
+  temp_obs = new double*[max_samples]();
+  for(int k=0; k < max_samples; k++){
+    temp_obs[k] = new double[max_obs]();
+  }
 }


### PR DESCRIPTION
A new likelihood model where the observation likelihoods are calculated in a probabilistic manner (joint likelihood is taken) 
New Model Type : LASER_MODEL_LIKELIHOOD_FIELD_PROB

This results in better/faster convergence of robot's pose to the correct location. (we are working on generating numbers for comparison).

Also includes the option to do beam-skipping (to better handle observations from dynamic obstacles)
Beam skipping will prevent incorporating beam likelihoods if for a majority of particles that beam doesn't agree with the map. This should prevent the pf from getting confused when the world doesn't look close to the map (e.g., when people are walking around the robot). Only applies this when the pf has converged. 

Enable beam skipping by setting do_beamskip= true
