### PR TITLE
Fixed GridPath::getPath

### DIFF
--- a/global_planner/src/grid_path.cpp
+++ b/global_planner/src/grid_path.cpp
@@ -48,8 +48,8 @@ bool GridPath::getPath(float* potential, double start_x, double start_y, double 
     int start_index = getIndex(start_x, start_y);
 
     path.push_back(current);
+    float min_val = 1e10;
     while (getIndex(current.first, current.second) != start_index) {
-        float min_val = 1e10;
         int min_x = 0, min_y = 0;
         for (int xd = -1; xd <= 1; xd++) {
             for (int yd = -1; yd <= 1; yd++) {


### PR DESCRIPTION
The algorithm must not walk upwards, thus the minimum value must be saved between loops.

(The old method breaks, when start position equals end position)
