### PR TITLE
Global planner fix

### DIFF
--- a/global_planner/include/global_planner/dijkstra.h
+++ b/global_planner/include/global_planner/dijkstra.h
@@ -51,8 +51,6 @@
 #define push_cur(n)  { if (n>=0 && n<ns_ && !pending_[n] && getCost(costs, n)<lethal_cost_ && currentEnd_<PRIORITYBUFSIZE){ currentBuffer_[currentEnd_++]=n; pending_[n]=true; }}
 #define push_next(n) { if (n>=0 && n<ns_ && !pending_[n] && getCost(costs, n)<lethal_cost_ &&    nextEnd_<PRIORITYBUFSIZE){    nextBuffer_[   nextEnd_++]=n; pending_[n]=true; }}
 #define push_over(n) { if (n>=0 && n<ns_ && !pending_[n] && getCost(costs, n)<lethal_cost_ &&    overEnd_<PRIORITYBUFSIZE){    overBuffer_[   overEnd_++]=n; pending_[n]=true; }}
-// potential defs
-#define POT_HIGH 1.0e10        // unassigned cell potential
 
 namespace global_planner {
 class DijkstraExpansion : public Expander {

--- a/global_planner/include/global_planner/expander.h
+++ b/global_planner/include/global_planner/expander.h
@@ -38,6 +38,7 @@
 #ifndef _EXPANDER_H
 #define _EXPANDER_H
 #include <global_planner/potential_calculator.h>
+#include <global_planner/planner_core.h>
 
 namespace global_planner {
 
@@ -78,6 +79,8 @@ class Expander {
             for(int i=-s;i<=s;i++){
             for(int j=-s;j<=s;j++){
                 int n = startCell+i+nx_*j;
+                if(potential[n]<POT_HIGH)
+                    continue;
                 float c = costs[n]+neutral_cost_;
                 float pot = p_calc_->calculatePotential(potential, c, n);
                 potential[n] = pot;

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -37,6 +37,7 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
+#define POT_HIGH 1.0e10        // unassigned cell potential
 #include <ros/ros.h>
 #include <costmap_2d/costmap_2d.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -52,7 +53,6 @@
 #include <global_planner/traceback.h>
 #include <global_planner/GlobalPlannerConfig.h>
 
-#define POT_HIGH 1.0e10        // unassigned cell potential
 namespace global_planner {
 
 class Expander;

--- a/global_planner/src/grid_path.cpp
+++ b/global_planner/src/grid_path.cpp
@@ -48,6 +48,9 @@ bool GridPath::getPath(float* potential, double start_x, double start_y, double 
     int start_index = getIndex(start_x, start_y);
 
     path.push_back(current);
+    int c = 0;
+    int ns = xs_ * ys_;
+    
     while (getIndex(current.first, current.second) != start_index) {
         float min_val = 1e10;
         int min_x = 0, min_y = 0;
@@ -69,6 +72,10 @@ bool GridPath::getPath(float* potential, double start_x, double start_y, double 
         current.first = min_x;
         current.second = min_y;
         path.push_back(current);
+        
+        if(c++>ns*4){
+            return false;
+        }
 
     }
     return true;


### PR DESCRIPTION
Fix for the bug reported in #241. 

The actual problem was the adjustment I make to the end of the found path (expander.clearEndpoint) which overwrote previous potentials calculated by the algorithm. When the end of the path is sufficiently close to the start (as @mistoll reported) , this behavior would overwrite the starting minimum, causing the algorithm to loop forever. This PR fixes the overwriting problem, and in my experiments fixes the infinite looping. 

Just to be on the safe side, I also added a loop counter to GridPath to avoid the infinite loop in the chance that it occurs in some other case. 
