### PR TITLE
costmap_2d: export library layers

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -62,7 +62,7 @@ catkin_package(
         include
         ${EIGEN_INCLUDE_DIRS}
         ${PCL_INCLUDE_DIRS}
-    LIBRARIES costmap_2d
+    LIBRARIES costmap_2d layers
     CATKIN_DEPENDS
         dynamic_reconfigure
         geometry_msgs


### PR DESCRIPTION
Many layer plugins also instantiate a FootprintLayer. Layers created outside the costmap_2d package were not able to link against liblayers. The outside layers would still compile, but loading an outside layer before a layer in costmap_2d caused a plugin load error.
