### PR TITLE
catkin provides gtest, no need for find_package

### DIFF
--- a/clear_costmap_recovery/CMakeLists.txt
+++ b/clear_costmap_recovery/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(clear_costmap_recovery layers ${catkin_LIBRARIES})
 if(CATKIN_ENABLE_TESTING)
   # Find package test dependencies
   find_package(rostest REQUIRED)
-  find_package(gtest)
 
   # Add the test folder to the include directories
   include_directories(test)

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -140,7 +140,6 @@ target_link_libraries(costmap_2d_node
 if(CATKIN_ENABLE_TESTING)
   # Find package test dependencies
   find_package(rostest REQUIRED)
-  find_package(gtest)
 
   # Add the test folder to the include directories
   include_directories(test)


### PR DESCRIPTION
Proper fix for #242 (see comments from dirk), replaces #244 
