### PR TITLE
base_local_planner: adds waitForTransform

### DIFF
--- a/base_local_planner/src/goal_functions.cpp
+++ b/base_local_planner/src/goal_functions.cpp
@@ -104,9 +104,12 @@ namespace base_local_planner {
 
       // get plan_to_global_transform from plan frame to global_frame
       tf::StampedTransform plan_to_global_transform;
-      tf.lookupTransform(global_frame, ros::Time(), 
-          plan_pose.header.frame_id, plan_pose.header.stamp, 
-          plan_pose.header.frame_id, plan_to_global_transform);
+      tf.waitForTransform(global_frame, ros::Time::now(),
+                          plan_pose.header.frame_id, plan_pose.header.stamp,
+                          plan_pose.header.frame_id, ros::Duration(0.5));
+      tf.lookupTransform(global_frame, ros::Time(),
+                         plan_pose.header.frame_id, plan_pose.header.stamp, 
+                         plan_pose.header.frame_id, plan_to_global_transform);
 
       //let's get the pose of the robot in the frame of the plan
       tf::Stamped<tf::Pose> robot_pose;
@@ -183,9 +186,12 @@ namespace base_local_planner {
       }
 
       tf::StampedTransform transform;
+      tf.waitForTransform(global_frame, ros::Time::now(),
+                          plan_goal_pose.header.frame_id, plan_goal_pose.header.stamp,
+                          plan_goal_pose.header.frame_id, ros::Duration(0.5));
       tf.lookupTransform(global_frame, ros::Time(),
-          plan_goal_pose.header.frame_id, plan_goal_pose.header.stamp,
-          plan_goal_pose.header.frame_id, transform);
+                         plan_goal_pose.header.frame_id, plan_goal_pose.header.stamp,
+                         plan_goal_pose.header.frame_id, transform);
 
       poseStampedMsgToTF(plan_goal_pose, goal_pose);
       goal_pose.setData(transform * goal_pose);


### PR DESCRIPTION
The first waitForTransform (Line 107 - 112) resolves #196. I also added the second one to avoid similiar issues in other situations.

An alternative to using `waitForTransform` could be requesting the latest available transform (`ros::Time(0)`). If applicable, I generally prefer this alternative, but since I'm not too familiar with the various parts of the navi stack, I decided to stick as close to the current code and logic as possible.
