### PR TITLE
costmap_2d: tf_prefix support in obstacle_layer

### DIFF
--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -38,6 +38,10 @@ void ObstacleLayer::onInitialize()
   nh.param("observation_sources", topics_string, std::string(""));
   ROS_INFO("    Subscribed to Topics: %s", topics_string.c_str());
 
+  // get our tf prefix
+  ros::NodeHandle prefix_nh;
+  const std::string tf_prefix = tf::getPrefixParam(prefix_nh);
+
   //now we need to split the topics based on whitespace which we can use a stringstream for
   std::stringstream ss(topics_string);
 
@@ -61,6 +65,8 @@ void ObstacleLayer::onInitialize()
     source_node.param("inf_is_valid", inf_is_valid, false);
     source_node.param("clearing", clearing, false);
     source_node.param("marking", marking, true);
+
+    sensor_frame = tf::resolve(tf_prefix, sensor_frame);
 
     if (!(data_type == "PointCloud2" || data_type == "PointCloud" || data_type == "LaserScan"))
     {

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -66,7 +66,10 @@ void ObstacleLayer::onInitialize()
     source_node.param("clearing", clearing, false);
     source_node.param("marking", marking, true);
 
-    sensor_frame = tf::resolve(tf_prefix, sensor_frame);
+    if (!sensor_frame.empty())
+    {
+      sensor_frame = tf::resolve(tf_prefix, sensor_frame);
+    }
 
     if (!(data_type == "PointCloud2" || data_type == "PointCloud" || data_type == "LaserScan"))
     {


### PR DESCRIPTION
`costmap_2d` supports `tf_prefix` for `global_frame` and `robot_base_frame` [(1)](https://github.com/ros-planning/navigation/blob/e9c3ac822ac4ddb9af2605493fd7c37044cdf2d8/costmap_2d/src/costmap_2d_ros.cpp#L81), however the`obstacle_layer` does not. This PR adds `tf_prefix` support to `obstacle_layer`.
