### PR TITLE
prevent div by zero in raytraceLine

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -371,7 +371,7 @@ protected:
 
       //we need to chose how much to scale our dominant dimension, based on the maximum length of the line
       double dist = hypot(dx, dy);
-      double scale = std::min(1.0, max_length / dist);
+      double scale = (dist == 0.0) ? 1.0 : std::min(1.0, max_length / dist);
 
       //if x is dominant
       if (abs_dx >= abs_dy)


### PR DESCRIPTION
While mapping a polygon from world to map with costmap_2d woldToMap it might happen that two consecutive points end-up with the same coordinates, transforming a segment into a single point.
Then calling polygonOutlineCells calls raytraceLine which raises a signal Floating point exception -> floating point divide by zero.
