### PR TITLE
Add DepthImage observation source

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -19,6 +19,8 @@ find_package(catkin REQUIRED
             std_msgs
             tf
             voxel_grid
+            image_transport
+            image_geometry
         )
 
 find_package(PCL REQUIRED)
@@ -78,6 +80,8 @@ catkin_package(
         std_msgs
         tf
         voxel_grid
+        image_transport
+        image_geometry
     DEPENDS
         PCL
         Eigen

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -21,11 +21,13 @@ find_package(catkin REQUIRED
             voxel_grid
             image_transport
             image_geometry
+            depth_image_proc
         )
 
 find_package(PCL REQUIRED)
 find_package(Eigen REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)
+
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
@@ -82,6 +84,7 @@ catkin_package(
         voxel_grid
         image_transport
         image_geometry
+        depth_image_proc
     DEPENDS
         PCL
         Eigen

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -48,12 +48,15 @@
 #include <laser_geometry/laser_geometry.h>
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/point_cloud_conversion.h>
 #include <tf/message_filter.h>
 #include <message_filters/subscriber.h>
 #include <dynamic_reconfigure/server.h>
 #include <costmap_2d/ObstaclePluginConfig.h>
 #include <costmap_2d/footprint_layer.h>
+#include <image_geometry/pinhole_camera_model.h>
 
 namespace costmap_2d
 {
@@ -107,6 +110,26 @@ public:
   void pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr& message,
                            const boost::shared_ptr<costmap_2d::ObservationBuffer>& buffer);
 
+  /**
+   * @brief  A callback to handle buffering depth Image messages
+   * @param message The message returned from a message notifier
+   * @param model The pinhole camera model
+   * @param range_max The maximum range of the depth sensor, for filling in empty readings
+   * @param buffer A pointer to the observation buffer to update
+   */
+  void depthImageCallback(const sensor_msgs::ImageConstPtr& message,
+                          const boost::shared_ptr<image_geometry::PinholeCameraModel>& model,
+                          double range_max,
+                          const boost::shared_ptr<costmap_2d::ObservationBuffer>& buffer);
+
+  /**
+   * @brief  A callback to retrieve the camera info messages
+   * @param message The camera info message
+   * @param model The pinhole camera model
+   */
+  void cameraInfoCallback(const sensor_msgs::CameraInfoConstPtr& message,
+                          boost::shared_ptr<image_geometry::PinholeCameraModel>& model);
+
   // for testing purposes
   void addStaticObservation(costmap_2d::Observation& obs, bool marking, bool clearing);
   void clearStaticObservations(bool marking, bool clearing);
@@ -141,7 +164,7 @@ protected:
                                  double* max_x, double* max_y);
 
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
-			    double* max_x, double* max_y);
+                            double* max_x, double* max_y);
 
   /** @brief Overridden from superclass Layer to pass new footprint into footprint_layer_. */
   virtual void onFootprintChanged();
@@ -164,7 +187,7 @@ protected:
   dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig> *dsrv_;
 
   FootprintLayer footprint_layer_; ///< @brief clears the footprint in this obstacle layer.
-  
+
   int combination_method_;
 
 private:

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -39,6 +39,8 @@
     <build_depend>tf</build_depend>
     <build_depend>visualization_msgs</build_depend>
     <build_depend>voxel_grid</build_depend>
+    <build_depend>image_transport</build_depend>
+    <build_depend>image_geometry</build_depend>
 
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>geometry_msgs</run_depend>
@@ -58,6 +60,8 @@
     <run_depend>tf</run_depend>
     <run_depend>visualization_msgs</run_depend>
     <run_depend>voxel_grid</run_depend>
+    <run_depend>image_transport</run_depend>
+    <run_depend>image_geometry</run_depend>
 
     <test_depend>map_server</test_depend>
     <test_depend>rosbag</test_depend>

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -41,6 +41,7 @@
     <build_depend>voxel_grid</build_depend>
     <build_depend>image_transport</build_depend>
     <build_depend>image_geometry</build_depend>
+    <build_depend>depth_image_proc</build_depend>
 
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>geometry_msgs</run_depend>
@@ -62,6 +63,7 @@
     <run_depend>voxel_grid</run_depend>
     <run_depend>image_transport</run_depend>
     <run_depend>image_geometry</run_depend>
+    <run_depend>depth_image_proc</run_depend>
 
     <test_depend>map_server</test_depend>
     <test_depend>rosbag</test_depend>


### PR DESCRIPTION
This allows to generate the clearing `xyz` points using the `PinholeCameraModel` of the depth images, for those pixels/points where there's no "echo"/"return" (invalid pixels).

See https://github.com/ros-perception/image_pipeline/pull/104

This PR also needs https://github.com/ros-perception/image_pipeline/pull/108 to be merged before, since it tries to avoid copying code from `depth_image_proc`. This other PR simply exports some headers and extends the `convert` function to allow for setting `range_max` for invalid pixels.
