### PR TITLE
Call deleteMaps before initMaps

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -64,6 +64,7 @@ void Costmap2D::deleteMaps()
 void Costmap2D::initMaps(unsigned int size_x, unsigned int size_y)
 {
   boost::unique_lock < boost::shared_mutex > lock(*access_);
+  delete[] costmap_;
   costmap_ = new unsigned char[size_x * size_y];
 }
 


### PR DESCRIPTION
It seems it was a memory leak, because calling `initMaps` allocates new memory for `costmap_` without de-allocating the previous one!
