### PR TITLE
Global planner heuristic

### DIFF
--- a/global_planner/src/astar.cpp
+++ b/global_planner/src/astar.cpp
@@ -84,7 +84,7 @@ void AStarExpansion::add(unsigned char* costs, float* potential, float prev_pote
 
     potential[next_i] = p_calc_->calculatePotential(potential, costs[next_i] + neutral_cost_, next_i, prev_potential);
     int x = next_i % nx_, y = next_i / nx_;
-    float distance = abs(end_x - x) + abs(end_y - y);
+    float distance = hypot(end_x - x, end_y - y);
 
     queue_.push_back(Index(next_i, potential[next_i] + distance * neutral_cost_));
     std::push_heap(queue_.begin(), queue_.end(), greater1());

--- a/global_planner/src/gradient_path.cpp
+++ b/global_planner/src/gradient_path.cpp
@@ -81,7 +81,7 @@ bool GradientPath::getPath(float* potential, double start_x, double start_y, dou
         // check if near goal
         double nx = stc % xs_ + dx, ny = stc / xs_ + dy;
 
-        if (fabs(nx - start_x) < .5 && fabs(ny - start_y) < .5) {
+        if (fabs(nx - start_x) <= .5 && fabs(ny - start_y) <= .5) {
             current.first = start_x;
             current.second = start_y;
             path.push_back(current);


### PR DESCRIPTION
As pointed out by @KaijenHsiao and mateus03 (from answers.ros.org), global planner plans in Euclidean space, but used a Manhattan Distance heuristic, when using the A\* option. This pull request fixes that and changes one edge case so that it always finds a path when one is available. 
