### PR TITLE
Added waitForTransform to solve extrapolation into the future exception

### DIFF
--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -141,6 +141,7 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
   {
     //given these observations come from sensors... we'll need to store the origin pt of the sensor
     Stamped < tf::Vector3 > local_origin(tf::Vector3(0, 0, 0), pcl_conversions::fromPCL(cloud.header).stamp, origin_frame);
+    tf_.waitForTransform(global_frame_, local_origin.frame_id_, local_origin.stamp_, ros::Duration(0.5));
     tf_.transformPoint(global_frame_, local_origin, global_origin);
     observation_list_.front().origin_.x = global_origin.getX();
     observation_list_.front().origin_.y = global_origin.getY();


### PR DESCRIPTION
Similarly to https://github.com/ros-planning/navigation/pull/254 and https://github.com/ros-planning/navigation/issues/196 the extrapolating into the future exception appears all the time in bufferCloud. Adding waitfortransform solves this problem.
