### PR TITLE
Fixed setting child_frame_id in base_local_planner::OdometryHelperRos

### DIFF
--- a/base_local_planner/src/odometry_helper_ros.cpp
+++ b/base_local_planner/src/odometry_helper_ros.cpp
@@ -50,6 +50,7 @@ void OdometryHelperRos::odomCallback(const nav_msgs::Odometry::ConstPtr& msg) {
   base_odom_.twist.twist.linear.x = msg->twist.twist.linear.x;
   base_odom_.twist.twist.linear.y = msg->twist.twist.linear.y;
   base_odom_.twist.twist.angular.z = msg->twist.twist.angular.z;
+  base_odom_.child_frame_id = msg->child_frame_id;
 //  ROS_DEBUG_NAMED("dwa_local_planner", "In the odometry callback with velocity values: (%.2f, %.2f, %.2f)",
 //      base_odom_.twist.twist.linear.x, base_odom_.twist.twist.linear.y, base_odom_.twist.twist.angular.z);
 }


### PR DESCRIPTION
`child_frame_id` should be copied from incoming Odometry message because it is being used in `getRobotVel()` function.
