### PR TITLE
Fix voxel grid update when robot base moves

### DIFF
--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -86,6 +86,8 @@ public:
 protected:
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
 
+  virtual void resetMaps();
+
 private:
   void reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t level);
   void clearNonLethal(double wx, double wy, double w_size_x, double w_size_y, bool clear_no_info);

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -69,6 +69,12 @@ void VoxelLayer::reset()
   activate();
 }
 
+void VoxelLayer::resetMaps()
+{
+  Costmap2D::resetMaps();
+  voxel_grid_.reset();
+}
+
 void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
                                        double* min_y, double* max_x, double* max_y)
 {


### PR DESCRIPTION
While the costmap is correct, the underlying voxel grid ends up being incorrect when the robot moves as the underlying voxel_grid is not cleared out prior to copying the data back into the new location.

I went back through the history, and found https://github.com/ros-planning/navigation/commit/b6d26e8e14051b1073619d2f1ef1b6b66025053a, which shows that resetMaps used to also clear the voxel_grid_ prior to plugin re-write.

I do need to test this fully to make sure that it doesn't cause issues (note the deactivate/activate wrapped around reset() function right above it), but wanted to open a PR so I could put in this extra information and links.
