### PR TITLE
Fix double free corruption in Costmap2D

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -59,6 +59,7 @@ void Costmap2D::deleteMaps()
   //clean up data
   boost::unique_lock < boost::shared_mutex > lock(*access_);
   delete[] costmap_;
+  costmap_ = NULL;
 }
 
 void Costmap2D::initMaps(unsigned int size_x, unsigned int size_y)


### PR DESCRIPTION
Fix double free using after https://github.com/ros-planning/navigation/pull/266 by setting `costmap_` to `NULL` after deleting it.
