### PR TITLE
adding lock to planner makePlan fail case

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -649,12 +649,14 @@ namespace move_base {
         ros::Time attempt_end = last_valid_plan_ + ros::Duration(planner_patience_);
 
         //check if we've tried to make a plan for over our time limit
-        if(ros::Time::now() > attempt_end){
+	lock.lock();
+        if(ros::Time::now() > attempt_end && runPlanner_){
           //we'll move into our obstacle clearing mode
           state_ = CLEARING;
           publishZeroVelocity();
           recovery_trigger_ = PLANNING_R;
         }
+	lock.unlock();
       }
 
       if(!p_freq_change_ && planner_frequency_ > 0)


### PR DESCRIPTION
A planner mutex is created in the [planner thread](https://github.com/phil0stine/navigation/blob/35eba4f3d02efd6a5c14c2ac4244bdb6dd3b9027/move_base/src/move_base.cpp#L598-619), then locked and unlocked.

`makePlan` is called _after_ the mutex is unlocked, and in the meantime, it is possible the controller has executed its recovery behaviors, set `runPlanner_` to [false](https://github.com/phil0stine/navigation/blob/35eba4f3d02efd6a5c14c2ac4244bdb6dd3b9027/move_base/src/move_base.cpp#L987-989), and called [resetState](https://github.com/phil0stine/navigation/blob/35eba4f3d02efd6a5c14c2ac4244bdb6dd3b9027/move_base/src/move_base.cpp#L1145-1149), which sets `state_` to PLANNING from CLEARING.

Now, when `makePlan` returns, if `gotPlan` is false, it will fall into the second [condition](https://github.com/phil0stine/navigation/blob/35eba4f3d02efd6a5c14c2ac4244bdb6dd3b9027/move_base/src/move_base.cpp#L647), since `state_` has just been set to PLANNING.

Then, it will set `state_` to CLEARING, which will be the current state the next time a goal is sent to move_base. Even if the new goal is valid, a recovery behavior will be performed.
