### PR TITLE
use timer rather than rate for immediate wakeup

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -168,6 +168,11 @@ namespace move_base {
 
       geometry_msgs::PoseStamped goalToGlobalFrame(const geometry_msgs::PoseStamped& goal_pose_msg);
 
+      /**
+       * @brief This is used to wake the planner at periodic intervals.
+       */
+      void wakePlanner(const ros::TimerEvent& event);
+
       tf::TransformListener& tf_;
 
       MoveBaseActionServer* as_;


### PR DESCRIPTION
This is an alternative to #234.

I don't usually use a planner_frequency > 0, so I haven't been able to test this, but in theory it allows you to _immediately_ wake the planner when a new plan comes in, without adding additional parameters or even waiting for any amount of time.

@KaijenHsiao would you have time to possibly test this?
