### PR TITLE
adding makePlan function with returned cost to base_global_planner

### DIFF
--- a/nav_core/include/nav_core/base_global_planner.h
+++ b/nav_core/include/nav_core/base_global_planner.h
@@ -58,6 +58,22 @@ namespace nav_core {
           const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan) = 0;
 
       /**
+       * @brief Given a goal pose in the world, compute a plan
+       * @param start The start pose 
+       * @param goal The goal pose 
+       * @param plan The plan... filled by the planner
+       * @param cost The plans calculated cost
+       * @return True if a valid plan was found, false otherwise
+       */
+      virtual bool makePlan(const geometry_msgs::PoseStamped& start, 
+                            const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan,
+                            double& cost)
+      {
+        cost = 0;
+        makePlan(start, goal, plan);
+      }
+
+      /**
        * @brief  Initialization function for the BaseGlobalPlanner
        * @param  name The name of this planner
        * @param  costmap_ros A pointer to the ROS wrapper of the costmap to use for planning


### PR DESCRIPTION
Request an additional function to base global planner interface that allows the user to call makePlan and get the cost associated with a successful plan. An example use case is one where the user has a handful of potential goals and wishes to choose between them. 

Though the costs themselves may not have intuitive value, they can be compared against one another when choosing between different goals.

NavfnROS has some similar functions, but these are unique to that particular class and are therefore not extensible when testing other planners using pluginlib. Whether or not this is the adopted interface, I think there should be some way to query global planner costs for given goals.
