### PR TITLE
prevent inf loop

### DIFF
--- a/map_server/src/map_saver.cpp
+++ b/map_server/src/map_saver.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
   
   MapGenerator mg(mapname);
 
-  while(!mg.saved_map_)
+  while(!mg.saved_map_ && ros::ok())
     ros::spinOnce();
 
   return 0;


### PR DESCRIPTION
Simply allows to kill map_saver node with ctrl-c
