### PR TITLE
Accurate Bresenham raytracing implementation and clearing for corner cases

### DIFF
--- a/costmap_2d/cfg/VoxelPlugin.cfg
+++ b/costmap_2d/cfg/VoxelPlugin.cfg
@@ -19,5 +19,6 @@ combo_enum = gen.enum([ gen.const("Overwrite", int_t, 0, "b"),
 gen.add("combination_method", int_t, 0, "Method for combining two layers", 1, 0, 2, edit_method=combo_enum)
 gen.add("clear_corner_cases", bool_t, 0, "Whether to also clear corner cases or not, might over clear (but under clears without)", False)
 gen.add("accuracy_multiplier_bits", int_t, 0, "Number of bits which are used for increasing raytracing accuracy for clearing", 10, 0, 28)
+gen.add("use_cached_updating", bool_t, 0, "Whether to use a cached approach for updating which can be faster in case of 3d sensors and is needed for clear_corner_cases", False)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "VoxelPlugin"))

--- a/costmap_2d/cfg/VoxelPlugin.cfg
+++ b/costmap_2d/cfg/VoxelPlugin.cfg
@@ -17,5 +17,7 @@ combo_enum = gen.enum([ gen.const("Overwrite", int_t, 0, "b"),
                       "Method for combining layers enum")
 
 gen.add("combination_method", int_t, 0, "Method for combining two layers", 1, 0, 2, edit_method=combo_enum)
+gen.add("clear_corner_cases", bool_t, 0, "Whether to also clear corner cases or not, might over clear (but under clears without)", False)
+gen.add("accuracy_multiplier_bits", int_t, 0, "Number of bits which are used for increasing raytracing accuracy for clearing", 10, 0, 28)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "VoxelPlugin"))

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -169,6 +169,8 @@ protected:
   
   int combination_method_;
 
+  double max_raytrace_range_;
+
 private:
   void reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint32_t level);
 };
@@ -176,3 +178,4 @@ private:
 }  // namespace costmap_2d
 
 #endif  // COSTMAP_2D_OBSTACLE_LAYER_H_
+

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -93,6 +93,7 @@ private:
   void clearNonLethal(double wx, double wy, double w_size_x, double w_size_y, bool clear_no_info);
   virtual void raytraceFreespace(const costmap_2d::Observation& clearing_observation, double* min_x, double* min_y,
                                  double* max_x, double* max_y);
+  virtual void convertFromMapToWorld(sensor_msgs::PointCloud& point_cloud);
 
   dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig> *dsrv_;
 
@@ -111,12 +112,15 @@ private:
   **/
   bool clear_corner_cases_;
 
+  bool use_cached_updating_;
+
   bool publish_voxel_;
   ros::Publisher voxel_pub_;
   voxel_grid::VoxelGrid voxel_grid_;
   double z_resolution_, origin_z_;
   unsigned int unknown_threshold_, mark_threshold_, size_z_;
   ros::Publisher clearing_endpoints_pub_;
+  ros::Publisher cleared_points_pub_;
   sensor_msgs::PointCloud clearing_endpoints_;
 
   inline bool worldToMap3DFloat(double wx, double wy, double wz, double& mx, double& my, double& mz)

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -96,6 +96,21 @@ private:
 
   dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig> *dsrv_;
 
+  /**
+   * @brief Include corner cases or not.
+   *
+   * The raytracing works with the Bresenham algorithm on discrete cells.
+   * raytrace_corner_cases_ includes additional cells at the transition of one row / column to the next:
+   *
+   * |   |   |   |   |
+   * -----------------  Legend:
+   * |   | # | = | = |          = : Cells added by original Bresenham
+   * -----------------          # : Additional cells added with raytrace_corner_cases_
+   * | = | = | # |   |
+   * -----------------
+  **/
+  bool clear_corner_cases_;
+
   bool publish_voxel_;
   ros::Publisher voxel_pub_;
   voxel_grid::VoxelGrid voxel_grid_;

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -79,6 +79,8 @@ void ObstacleLayer::onInitialize()
   ros::NodeHandle prefix_nh;
   const std::string tf_prefix = tf::getPrefixParam(prefix_nh);
 
+  max_raytrace_range_ = 0.0;
+
   //now we need to split the topics based on whitespace which we can use a stringstream for
   std::stringstream ss(topics_string);
 
@@ -129,6 +131,9 @@ void ObstacleLayer::onInitialize()
     {
       source_node.getParam(raytrace_range_param_name, raytrace_range);
     }
+
+    if(raytrace_range > max_raytrace_range_)
+          max_raytrace_range_ = raytrace_range;
 
     ROS_DEBUG("Creating an observation buffer for source %s, topic %s, frame %s", source.c_str(), topic.c_str(),
               sensor_frame.c_str());

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -38,6 +38,8 @@
 #include <costmap_2d/voxel_layer.h>
 #include <pluginlib/class_list_macros.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <voxel_grid/simple_clearer.h>
+#include <voxel_grid/cached_clearer.h>
 
 #define VOXEL_BITS 16
 PLUGINLIB_EXPORT_CLASS(costmap_2d::VoxelLayer, costmap_2d::Layer)
@@ -68,6 +70,13 @@ void VoxelLayer::onInitialize()
   int accuracy_multiplier_bits = 10;
   private_nh.param("accuracy_multiplier_bits", accuracy_multiplier_bits, 10);
   voxel_grid_.setAccuracyMultiplierBits(accuracy_multiplier_bits);
+
+  private_nh.param("use_cached_updating", use_cached_updating_, false);
+  cleared_points_pub_ = private_nh.advertise<sensor_msgs::PointCloud>("cleared_voxels", 1);
+
+  //we need to use cached updating in case of clearing corners, or else we get overflows
+  if(clear_corner_cases_)
+    use_cached_updating_ = true;
 }
 
 void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
@@ -91,11 +100,19 @@ void VoxelLayer::reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t l
   size_z_ = config.z_voxels;
   origin_z_ = config.origin_z;
   z_resolution_ = config.z_resolution;
+
   unknown_threshold_ = config.unknown_threshold + (VOXEL_BITS - size_z_);
   mark_threshold_ = config.mark_threshold;
   combination_method_ = config.combination_method;
+
   clear_corner_cases_ = config.clear_corner_cases;
   voxel_grid_.setAccuracyMultiplierBits(config.accuracy_multiplier_bits);
+  use_cached_updating_ = config.use_cached_updating;
+
+  //we need to use cached updating in case of clearing corners, or else we get overflows
+  if(clear_corner_cases_)
+    use_cached_updating_ = true;
+
   matchSize();
 }
 
@@ -285,6 +302,38 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     return;
   }
 
+  boost::shared_ptr<voxel_grid::AbstractGridUpdater> voxel_clearer;
+  double start_offset_x;
+  double start_offset_y;
+  unsigned int cached_update_area_width;
+
+  if (use_cached_updating_)
+  {
+    unsigned int max_raytrace_range_in_cells = std::floor(max_raytrace_range_ / resolution_);
+    unsigned int update_area_center = max_raytrace_range_in_cells; //for readability
+    cached_update_area_width = max_raytrace_range_in_cells * 2 + 1; //+1 to have a center point
+
+    int offset_x = update_area_center - (int)sensor_x;
+    int offset_y = update_area_center - (int)sensor_y;
+
+    //we raytrace in the cache to skip the "slow" transformation between real world and cache coordinates
+    //sub-cell accuracy of start point has to be the same, so add the fractional part
+    double temp = 0;
+    start_offset_x = update_area_center + fabs(modf(sensor_x, &temp));
+    start_offset_y = update_area_center + fabs(modf(sensor_y, &temp));
+
+    voxel_clearer = boost::shared_ptr<voxel_grid::CachedClearer>(
+        new voxel_grid::CachedClearer(voxel_grid_.getData(), costmap_, voxel_grid_.sizeX(), voxel_grid_.sizeY(),
+                                        offset_x, offset_y, cached_update_area_width, clear_corner_cases_, unknown_threshold_,
+                                        mark_threshold_, FREE_SPACE, NO_INFORMATION));
+  }
+  else
+  {
+    voxel_clearer = boost::shared_ptr<voxel_grid::SimpleClearer>(
+        new voxel_grid::SimpleClearer(voxel_grid_.getData(), costmap_, unknown_threshold_,
+                                      mark_threshold_, FREE_SPACE, NO_INFORMATION));
+  }
+
   bool publish_clearing_points = (clearing_endpoints_pub_.getNumSubscribers() > 0);
   if( publish_clearing_points )
   {
@@ -356,9 +405,18 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     {
       unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
 
-      voxel_grid_.clearVoxelLineInMap(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z, costmap_,
-                                      unknown_threshold_, mark_threshold_, FREE_SPACE, NO_INFORMATION,
-                                      cell_raytrace_range, clear_corner_cases_);
+      if (use_cached_updating_)
+      {
+        //the line goes from the start point to the end point which is start point + distance
+        voxel_grid_.clearVoxelLineInMap(start_offset_x, start_offset_y, sensor_z, start_offset_x + (point_x - sensor_x),
+                                        start_offset_y + (point_y - sensor_y), point_z, costmap_, &(*voxel_clearer),
+                                        cached_update_area_width, cell_raytrace_range, clear_corner_cases_);
+      }
+      else
+      {
+        voxel_grid_.clearVoxelLineInMap(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z, costmap_, &(*voxel_clearer),
+                                        voxel_grid_.sizeX(), cell_raytrace_range, clear_corner_cases_);
+      }
 
       updateRaytraceBounds(ox, oy, wpx, wpy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
 
@@ -373,6 +431,25 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     }
   }
 
+  if (use_cached_updating_)
+  {
+    boost::shared_ptr<voxel_grid::CachedClearer> cached_clearer = boost::static_pointer_cast
+        < voxel_grid::CachedClearer > (voxel_clearer);
+
+    cached_clearer->update();
+
+    bool publish_cleared_points = (cleared_points_pub_.getNumSubscribers() > 0);
+    if (publish_cleared_points)
+    {
+      sensor_msgs::PointCloud cleared_voxels = cached_clearer->getClearedVoxels();
+      convertFromMapToWorld(cleared_voxels);
+
+      cleared_voxels.header.frame_id = global_frame_;
+      cleared_voxels.header.stamp = ros::Time::now();
+      cleared_points_pub_.publish(cleared_voxels);
+    }
+  }
+
   if( publish_clearing_points )
   {
     clearing_endpoints_.header.frame_id = global_frame_;
@@ -380,6 +457,22 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     clearing_endpoints_.header.seq = clearing_observation.cloud_->header.seq;
 
     clearing_endpoints_pub_.publish( clearing_endpoints_ );
+  }
+}
+
+void VoxelLayer::convertFromMapToWorld(sensor_msgs::PointCloud& point_cloud)
+{
+  for (int i = 0; i < point_cloud.points.size(); ++i)
+  {
+    double x = 0;
+    double y = 0;
+    double z = 0;
+
+    mapToWorld3D(point_cloud.points[i].x, point_cloud.points[i].y, point_cloud.points[i].z, x, y, z);
+
+    point_cloud.points[i].x = x;
+    point_cloud.points[i].y = y;
+    point_cloud.points[i].z = z;
   }
 }
 

--- a/voxel_grid/include/voxel_grid/abstract_grid_updater.h
+++ b/voxel_grid/include/voxel_grid/abstract_grid_updater.h
@@ -1,0 +1,48 @@
+#ifndef VOXEL_GRID_ABSTRACT_GRID_UPDATER_H_
+#define VOXEL_GRID_ABSTRACT_GRID_UPDATER_H_
+
+namespace voxel_grid
+{
+
+class AbstractGridUpdater
+{
+public:
+  AbstractGridUpdater(uint32_t* voxel_grid_data, unsigned char* costmap, unsigned int unknown_clear_threshold,
+                  unsigned int marked_clear_threshold, unsigned char free_cost = 0, unsigned char unknown_cost = 255) :
+      voxel_grid_data_(voxel_grid_data), costmap_(costmap)
+  {
+    unknown_clear_threshold_ = unknown_clear_threshold;
+    marked_clear_threshold_ = marked_clear_threshold;
+    free_cost_ = free_cost;
+    unknown_cost_ = unknown_cost;
+  }
+
+  virtual ~AbstractGridUpdater() {};
+
+  virtual void operator()(unsigned int offset, uint32_t z_mask) =0;
+
+protected:
+  static inline bool bitsBelowThreshold(unsigned int bits, unsigned int bit_threshold)
+  {
+    unsigned int bit_count;
+    for (bit_count = 0; bits;)
+    {
+      ++bit_count;
+      if (bit_count > bit_threshold)
+      {
+        return false;
+      }
+      bits &= bits - 1; //clear the least significant bit set
+    }
+    return true;
+  }
+
+  uint32_t* voxel_grid_data_;
+  unsigned char* costmap_;
+  unsigned int unknown_clear_threshold_, marked_clear_threshold_;
+  unsigned char free_cost_, unknown_cost_;
+};
+
+} //end namespace
+
+#endif /* VOXEL_GRID_ABSTRACT_GRID_UPDATER_H_ */

--- a/voxel_grid/include/voxel_grid/cached_clearer.h
+++ b/voxel_grid/include/voxel_grid/cached_clearer.h
@@ -1,0 +1,188 @@
+#ifndef VOXEL_GRID_CACHED_CLEARER_H_
+#define VOXEL_GRID_CACHED_CLEARER_H_
+
+#include <list>
+#include <utility> // std::pair, std::make_pair
+#include <boost/shared_ptr.hpp>
+#include <geometry_msgs/Point32.h>
+#include <sensor_msgs/PointCloud.h>
+#include <ros/console.h>
+#include <voxel_grid/abstract_grid_updater.h>
+#include <bitset>
+
+namespace voxel_grid
+{
+
+class CachedClearer : public AbstractGridUpdater
+{
+public:
+  CachedClearer(uint32_t* voxel_grid_data, unsigned char* costmap, unsigned int costmap_size_x,
+                  unsigned int costmap_size_y, int offset_from_costmap_x, int offset_from_costmap_y,
+                  unsigned int cache_width, bool z_is_offset, unsigned int unknown_clear_threshold, unsigned int marked_clear_threshold,
+                  unsigned char free_cost = 0, unsigned char unknown_cost = 255) :
+      AbstractGridUpdater(voxel_grid_data, costmap, unknown_clear_threshold, marked_clear_threshold, free_cost,
+                          unknown_cost)
+  {
+    costmap_size_x_ = costmap_size_x;
+    costmap_size_y_ = costmap_size_y;
+
+    offset_from_costmap_x_ = offset_from_costmap_x;
+    offset_from_costmap_y_ = offset_from_costmap_y;
+    cache_width_ = cache_width;
+    z_is_offset_ = z_is_offset;
+
+    unsigned int cache_size = cache_width_ * cache_width_;
+    clearing_masks_cache_ = boost::shared_ptr<uint32_t[]>(new uint32_t[cache_size]);
+
+    uint32_t empty_mask = (uint32_t)0;
+    for (int i = 0; i < cache_size; ++i)
+      clearing_masks_cache_[i] = empty_mask;
+  }
+  ;
+
+  inline virtual void operator()(unsigned int offset, uint32_t z_mask)
+  {
+    clearing_masks_cache_[offset] |= z_mask;
+  }
+
+  virtual void update()
+  {
+    updated_cells_indices_.clear();
+    cleared_voxels_ = sensor_msgs::PointCloud();
+
+    unsigned int cache_size_x = cache_width_; //for readability
+    unsigned int cache_size_y = cache_width_; //for readability
+    unsigned int linear_cache_index = 0;
+    unsigned int linear_costmap_index = 0;
+    int costmap_x = 0;
+    int costmap_y = 0;
+
+    for (unsigned int y_index = 0; y_index < cache_size_y; ++y_index)
+    {
+      linear_cache_index = y_index * cache_size_x;
+      costmap_y = y_index - offset_from_costmap_y_;
+
+      if (costmap_y < 0)
+        continue;
+
+      if (costmap_y >= costmap_size_y_)
+        break;
+
+      costmap_x = -offset_from_costmap_x_;
+
+      linear_costmap_index = costmap_y * costmap_size_x_ + costmap_x;
+
+      for (unsigned int x_index = 0; x_index < cache_size_x; ++x_index)
+      {
+        uint32_t clearing_mask = clearing_masks_cache_[linear_cache_index];
+
+        if (clearing_mask == (uint32_t)0)
+        { //not updated
+          costmap_x++;
+          linear_costmap_index++;
+          linear_cache_index++;
+          continue;
+        }
+
+        if(z_is_offset_)
+          clearing_mask = undo_clearing_mask_offset(clearing_mask);
+
+        if (costmap_x < 0)
+        { //In case of underflow because of corner cases
+          costmap_x++;
+          linear_costmap_index++;
+          linear_cache_index++;
+          continue;
+        }
+
+        if (costmap_x >= costmap_size_x_)
+        { //In case of overflow because of corner cases
+          break;
+        }
+
+        uint32_t* voxel_column = &voxel_grid_data_[linear_costmap_index];
+
+        *voxel_column &= ~(clearing_mask); //clear unknown and clear cell
+
+        updateCostmap(*voxel_column, linear_costmap_index);
+        updated_cells_indices_.push_back(std::make_pair(costmap_x, costmap_y));
+
+        updateClearedVoxels(costmap_x, costmap_y, clearing_mask);
+
+        costmap_x++;
+        linear_costmap_index++;
+        linear_cache_index++;
+      }
+    }
+  }
+
+  inline virtual uint32_t undo_clearing_mask_offset(uint32_t clearing_mask)
+  {
+    clearing_mask >>= 1;
+    uint32_t lower_bits_mask = ~((uint32_t)0)>>16;
+
+    return (clearing_mask << 16) | (clearing_mask & lower_bits_mask);
+  }
+
+  std::list<std::pair<unsigned int, unsigned int> > getClearedCellsIndices()
+  {
+    return updated_cells_indices_;
+  }
+
+  sensor_msgs::PointCloud getClearedVoxels()
+  {
+    return cleared_voxels_;
+  }
+
+protected:
+  virtual void updateCostmap(uint32_t voxel_column, unsigned int costmap_index)
+  {
+    unsigned int unknown_bits = uint16_t(voxel_column >> 16) ^ uint16_t(voxel_column);
+    unsigned int marked_bits = voxel_column >> 16;
+
+    if (bitsBelowThreshold(marked_bits, marked_clear_threshold_))
+    {
+      if (bitsBelowThreshold(unknown_bits, unknown_clear_threshold_))
+      {
+        costmap_[costmap_index] = free_cost_;
+      }
+      else
+      {
+        costmap_[costmap_index] = unknown_cost_;
+      }
+    }
+  }
+
+  virtual void updateClearedVoxels(unsigned int x, unsigned int y, uint32_t clearing_mask)
+  {
+    for (int z_index = 0; z_index < 16; ++z_index)
+    {
+      if ((clearing_mask & 1) != 0)
+      {
+        geometry_msgs::Point32 point;
+        point.x = x;
+        point.y = y;
+        point.z = z_index;
+        cleared_voxels_.points.push_back(point);
+      }
+      clearing_mask >>= 1;
+    }
+  }
+
+private:
+  unsigned int costmap_size_x_;
+  unsigned int costmap_size_y_;
+
+  int offset_from_costmap_x_;
+  int offset_from_costmap_y_;
+  unsigned int cache_width_;
+  bool z_is_offset_;
+
+  boost::shared_ptr<uint32_t[]> clearing_masks_cache_;
+  std::list<std::pair<unsigned int, unsigned int> > updated_cells_indices_;
+  sensor_msgs::PointCloud cleared_voxels_;
+};
+
+} //end namespace
+
+#endif /* VOXEL_GRID_CACHED_CLEARER_H_ */

--- a/voxel_grid/include/voxel_grid/plain_clearer.h
+++ b/voxel_grid/include/voxel_grid/plain_clearer.h
@@ -1,0 +1,26 @@
+#ifndef VOXEL_GRID_PLAIN_CLEARER_H_
+#define VOXEL_GRID_PLAIN_CLEARER_H_
+
+#include <voxel_grid/abstract_grid_updater.h>
+
+namespace voxel_grid
+{
+
+class PlainClearer : public AbstractGridUpdater
+{
+public:
+  PlainClearer(uint32_t* voxel_grid_data) :
+      AbstractGridUpdater(voxel_grid_data, NULL, 0, 0, 0, 0)
+  {
+  }
+
+  inline virtual void operator()(unsigned int offset, uint32_t z_mask)
+  {
+    voxel_grid_data_[offset] &= ~(z_mask);
+  }
+
+};
+
+} //end namespace
+
+#endif /* VOXEL_GRID_PLAIN_CLEARER_H_ */

--- a/voxel_grid/include/voxel_grid/plain_marker.h
+++ b/voxel_grid/include/voxel_grid/plain_marker.h
@@ -1,0 +1,25 @@
+#ifndef VOXEL_GRID_PLAIN_MARKER_H_
+#define VOXEL_GRID_PLAIN_MARKER_H_
+
+#include <voxel_grid/abstract_grid_updater.h>
+
+namespace voxel_grid
+{
+
+class PlainMarker : public AbstractGridUpdater
+{
+public:
+  PlainMarker(uint32_t* voxel_grid_data) :
+      AbstractGridUpdater(voxel_grid_data, NULL, 0, 0, 0, 0)
+  {
+  }
+
+  inline virtual void operator()(unsigned int offset, uint32_t z_mask)
+  {
+    voxel_grid_data_[offset] |= ~(z_mask);
+  }
+};
+
+} //end namespace
+
+#endif /* VOXEL_GRID_PLAIN_MARKER_H_ */

--- a/voxel_grid/include/voxel_grid/simple_clearer.h
+++ b/voxel_grid/include/voxel_grid/simple_clearer.h
@@ -1,0 +1,43 @@
+#ifndef VOXEL_GRID_SIMPLE_CLEARER_H_
+#define VOXEL_GRID_SIMPLE_CLEARER_H_
+
+#include <voxel_grid/abstract_grid_updater.h>
+
+namespace voxel_grid
+{
+
+class SimpleClearer : public AbstractGridUpdater
+{
+public:
+  SimpleClearer(uint32_t* voxel_grid_data, unsigned char* costmap, unsigned int unknown_clear_threshold,
+                unsigned int marked_clear_threshold, unsigned char free_cost = 0, unsigned char unknown_cost = 255) :
+      AbstractGridUpdater(voxel_grid_data, costmap, unknown_clear_threshold, marked_clear_threshold, free_cost,
+                          unknown_cost)
+  {
+  }
+
+  inline virtual void operator()(unsigned int offset, uint32_t z_mask)
+  {
+    uint32_t* col = &voxel_grid_data_[offset];
+    *col &= ~(z_mask); //clear unknown and clear cell
+
+    unsigned int unknown_bits = uint16_t(*col >> 16) ^ uint16_t(*col);
+    unsigned int marked_bits = *col >> 16;
+
+    if (bitsBelowThreshold(marked_bits, marked_clear_threshold_))
+    {
+      if (bitsBelowThreshold(unknown_bits, unknown_clear_threshold_))
+      {
+        costmap_[offset] = free_cost_;
+      }
+      else
+      {
+        costmap_[offset] = unknown_cost_;
+      }
+    }
+  }
+};
+
+} //end namespace
+
+#endif /* VOXEL_GRID_SIMPLE_CLEARER_H_ */

--- a/voxel_grid/include/voxel_grid/voxel_grid.h
+++ b/voxel_grid/include/voxel_grid/voxel_grid.h
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <ros/console.h>
 #include <ros/assert.h>
+#include <voxel_grid/abstract_grid_updater.h>
 
 /**
  * @class VoxelGrid
@@ -229,9 +230,8 @@ public:
   void markVoxelLine(double x0, double y0, double z0, double x1, double y1, double z1, unsigned int max_length = UINT_MAX);
   void clearVoxelLine(double x0, double y0, double z0, double x1, double y1, double z1, unsigned int max_length = UINT_MAX);
   void clearVoxelLineInMap(double x0, double y0, double z0, double x1, double y1, double z1, unsigned char *map_2d,
-                           unsigned int unknown_threshold, unsigned int mark_threshold,
-                           unsigned char free_cost = 0, unsigned char unknown_cost = 255, unsigned int max_length = UINT_MAX,
-                           bool include_corner_cases = false);
+                           AbstractGridUpdater* clearer, unsigned int area_width,
+                           unsigned int max_length = UINT_MAX, bool include_corner_cases = false);
 
   VoxelStatus getVoxel(unsigned int x, unsigned int y, unsigned int z);
 
@@ -253,10 +253,8 @@ public:
    * http://graphics.idav.ucdavis.edu/education/GraphicsNotes/CAGDNotes/Bresenhams-Algorithm.pdf
    *
   **/
-  template <class ActionType>
-  inline void raytraceLine(
-    ActionType at, double x0, double y0, double z0,
-    double x1, double y1, double z1, unsigned int max_length = UINT_MAX, bool include_corner_cases = false)
+  inline void raytraceLine(AbstractGridUpdater* clearer, double x0, double y0, double z0, double x1,
+                           double y1, double z1, unsigned int width, unsigned int max_length = UINT_MAX, bool include_corner_cases = false)
   {
     double dx = x1 - x0;
     double dy = y1 - y0;
@@ -266,17 +264,21 @@ public:
     double abs_dy = fabs(accuracy_multiplier_ * dy);
     double abs_dz = fabs(accuracy_multiplier_ * dz);
 
-    if(abs_dx > INT_MAX || abs_dy > INT_MAX || abs_dz > INT_MAX)
+    if (abs_dx > INT_MAX || abs_dy > INT_MAX || abs_dz > INT_MAX)
     {
-      ROS_ERROR_THROTTLE(1.0, "Voxel grid: Accuracy multiplier is set too high. Possible integer overflow while clearing.");
+      ROS_ERROR_THROTTLE(1.0,
+                         "Voxel grid: Accuracy multiplier is set too high. Possible integer overflow while clearing.");
     }
 
     int offset_dx = sign(dx);
-    int offset_dy = sign(dy) * size_x_;
+    int offset_dy = sign(dy) * width;
     int offset_dz = sign(dz);
 
     unsigned int z_mask = ((1 << 16) | 1) << (unsigned int)z0;
-    unsigned int offset = (unsigned int)y0 * size_x_ + (unsigned int)x0;
+    if(include_corner_cases)
+      z_mask <<= 1; //to prevent underflows, is undone later
+
+    unsigned int offset = (unsigned int)y0 * width + (unsigned int)x0;
 
     GridOffset index_updater_xy(offset);
     ZOffset index_updater_z(z_mask);
@@ -295,17 +297,16 @@ public:
       int error_z = (int)(abs_dz * x_lost_rounding - abs_dx * z_lost_rounding);
       unsigned int number_of_steps = scale * abs(int(x0) - int(x1));
 
-      if(include_corner_cases)
+      if (include_corner_cases)
       {
-        bresenham3DIncludingCorners(at, index_updater_xy, index_updater_xy, index_updater_z,
-                             abs_dx, abs_dy, abs_dz, error_y, error_z, offset_dx, offset_dy, offset_dz, offset, z_mask,
-                             number_of_steps);
+        bresenham3DIncludingCorners(clearer, index_updater_xy, index_updater_xy, index_updater_z, abs_dx, abs_dy, abs_dz,
+                                    error_y, error_z, offset_dx, offset_dy, offset_dz, offset, z_mask,
+                                    number_of_steps);
         return;
       }
 
-      bresenham3D(at, index_updater_xy, index_updater_xy, index_updater_z,
-                     abs_dx, abs_dy, abs_dz, error_y, error_z, offset_dx, offset_dy, offset_dz, offset, z_mask,
-                     number_of_steps);
+      bresenham3D(clearer, index_updater_xy, index_updater_xy, index_updater_z, abs_dx, abs_dy, abs_dz, error_y, error_z,
+                  offset_dx, offset_dy, offset_dz, offset, z_mask, number_of_steps);
       return;
     }
 
@@ -313,52 +314,49 @@ public:
     {
       int error_x = (int)(abs_dx * y_lost_rounding - abs_dy * x_lost_rounding);
       int error_z = (int)(abs_dz * y_lost_rounding - abs_dy * z_lost_rounding);
-      unsigned int number_of_steps = scale * abs(int(x0) - int(x1));
+      unsigned int number_of_steps = scale * abs(int(y0) - int(y1));
 
-      if(include_corner_cases)
+      if (include_corner_cases)
       {
-        bresenham3DIncludingCorners(at, index_updater_xy, index_updater_xy, index_updater_z,
-                             abs_dy, abs_dx, abs_dz, error_x, error_z, offset_dy, offset_dx, offset_dz, offset, z_mask,
-                             number_of_steps);
+        bresenham3DIncludingCorners(clearer, index_updater_xy, index_updater_xy, index_updater_z, abs_dy, abs_dx, abs_dz,
+                                    error_x, error_z, offset_dy, offset_dx, offset_dz, offset, z_mask,
+                                    number_of_steps);
         return;
       }
 
-      bresenham3D(at, index_updater_xy, index_updater_xy, index_updater_z,
-                     abs_dy, abs_dx, abs_dz, error_x, error_z, offset_dy, offset_dx, offset_dz, offset, z_mask,
-                     number_of_steps);
+      bresenham3D(clearer, index_updater_xy, index_updater_xy, index_updater_z, abs_dy, abs_dx, abs_dz, error_x, error_z,
+                  offset_dy, offset_dx, offset_dz, offset,  z_mask, number_of_steps);
       return;
     }
 
     int error_x = (int)(abs_dx * z_lost_rounding - abs_dz * x_lost_rounding);
     int error_y = (int)(abs_dy * z_lost_rounding - abs_dz * y_lost_rounding);
-    unsigned int number_of_steps = scale * abs(int(x0) - int(x1));
+    unsigned int number_of_steps = scale * abs(int(z0) - int(z1));
 
-    if(include_corner_cases)
+    if (include_corner_cases)
     {
-      bresenham3DIncludingCorners(at, index_updater_z, index_updater_xy, index_updater_xy,
-                         abs_dz, abs_dx, abs_dy, error_x, error_y, offset_dz, offset_dx, offset_dy, offset, z_mask,
-                         number_of_steps);
+      bresenham3DIncludingCorners(clearer, index_updater_z, index_updater_xy, index_updater_xy, abs_dz, abs_dx, abs_dy,
+                                  error_x, error_y, offset_dz, offset_dx, offset_dy, offset, z_mask,
+                                  number_of_steps);
       return;
     }
 
-    bresenham3D(at, index_updater_z, index_updater_xy, index_updater_xy,
-                   abs_dz, abs_dx, abs_dy, error_x, error_y, offset_dz, offset_dx, offset_dy, offset, z_mask,
-                   number_of_steps);
+    bresenham3D(clearer, index_updater_z, index_updater_xy, index_updater_xy, abs_dz, abs_dx, abs_dy, error_x, error_y,
+                offset_dz, offset_dx, offset_dy, offset,  z_mask, number_of_steps);
   }
 
 private:
   //the real work is done here... 3D bresenham implementation
-  template <class ActionType, class OffA, class OffB, class OffC>
-  inline void bresenham3D(
-    ActionType at, OffA off_a, OffB off_b, OffC off_c,
-    unsigned int abs_da, unsigned int abs_db, unsigned int abs_dc,
-    int error_b, int error_c, int offset_a, int offset_b, int offset_c, unsigned int &offset,
-    unsigned int &z_mask, unsigned int number_of_steps)
+  template<class OffA, class OffB, class OffC>
+  inline void bresenham3D(AbstractGridUpdater* clearer, OffA off_a, OffB off_b, OffC off_c,
+                          unsigned int abs_da, unsigned int abs_db, unsigned int abs_dc, int error_b, int error_c,
+                          int offset_a, int offset_b, int offset_c, unsigned int &offset,
+                          unsigned int &z_mask, unsigned int number_of_steps)
   {
 
     for (unsigned int i = 0; i < number_of_steps; ++i)
     {
-      at(offset, z_mask);
+      (*clearer)(offset, z_mask);
       off_a(offset_a);
 
       if (error_b >= 0)
@@ -390,28 +388,29 @@ private:
    * | = | = | # |   |
    * -----------------
   **/
-  template<class ActionType, class OffA, class OffB, class OffC>
-  inline void bresenham3DIncludingCorners(ActionType at, OffA off_a, OffB off_b, OffC off_c, unsigned int abs_da,
-                                          unsigned int abs_db, unsigned int abs_dc, int error_b, int error_c,
-                                          int offset_a, int offset_b, int offset_c, unsigned int &offset,
-                                          unsigned int &z_mask, unsigned int number_of_steps)
+  template<class OffA, class OffB, class OffC>
+  inline void bresenham3DIncludingCorners(AbstractGridUpdater* clearer, OffA off_a, OffB off_b,
+                                          OffC off_c, unsigned int abs_da, unsigned int abs_db, unsigned int abs_dc,
+                                          int error_b, int error_c, int offset_a, int offset_b, int offset_c,
+                                          unsigned int &offset, unsigned int &z_mask,
+                                          unsigned int number_of_steps)
   {
 
     //-1 because we don't want to clear the corners _after_ the last cell
     //last cell is cleared after the loop
     for (unsigned int i = 0; i < number_of_steps - 1; ++i)
     {
-      at(offset, z_mask);
+      (*clearer)(offset, z_mask);
       off_a(offset_a);
 
       if (error_b >= 0)
       {
         //adjusted not original Bresenham
-        at(offset, z_mask); //set voxel on the same row
+        (*clearer)(offset, z_mask); //set voxel on the same row
 
         off_b(offset_b); //go one row up
         off_a(-offset_a); //go one column back
-        at(offset, z_mask); //set voxel
+        (*clearer)(offset, z_mask); //set voxel
 
         off_a(offset_a); //go back to next column
 
@@ -421,11 +420,11 @@ private:
       if (error_c >= 0)
       {
         //adjusted not original Bresenham
-        at(offset, z_mask); //set voxel on the same row
+        (*clearer)(offset, z_mask); //set voxel on the same row
 
         off_c(offset_c); //go one row up
         off_a(-offset_a); //go one column back
-        at(offset, z_mask); //set voxel
+        (*clearer)(offset, z_mask); //set voxel
 
         off_a(offset_a); //go back to next column
 
@@ -463,86 +462,6 @@ private:
    *
    **/
   unsigned int accuracy_multiplier_;
-
-  //Aren't functors so much fun... used to recreate the Bresenham macro Eric wrote in the original version, but in "proper" c++
-  class MarkVoxel
-  {
-  public:
-    MarkVoxel(uint32_t* data): data_(data){}
-    inline void operator()(unsigned int offset, unsigned int z_mask)
-    {
-      data_[offset] |= z_mask; //clear unknown and mark cell
-    }
-  private:
-    uint32_t* data_;
-  };
-
-  class ClearVoxel
-  {
-  public:
-    ClearVoxel(uint32_t* data): data_(data){}
-    inline void operator()(unsigned int offset, unsigned int z_mask)
-    {
-      data_[offset] &= ~(z_mask); //clear unknown and clear cell
-    }
-  private:
-    uint32_t* data_;
-  };
-
-  class ClearVoxelInMap
-  {
-  public:
-    ClearVoxelInMap(
-      uint32_t* data, unsigned char *costmap,
-      unsigned int unknown_clear_threshold, unsigned int marked_clear_threshold,
-      unsigned char free_cost = 0, unsigned char unknown_cost = 255): data_(data), costmap_(costmap),
-      unknown_clear_threshold_(unknown_clear_threshold), marked_clear_threshold_(marked_clear_threshold),
-      free_cost_(free_cost), unknown_cost_(unknown_cost)
-    {
-    }
-
-    inline void operator()(unsigned int offset, unsigned int z_mask)
-    {
-      uint32_t* col = &data_[offset];
-      *col &= ~(z_mask); //clear unknown and clear cell
-
-      unsigned int unknown_bits = uint16_t(*col>>16) ^ uint16_t(*col);
-      unsigned int marked_bits = *col>>16;
-
-      //make sure the number of bits in each is below our thesholds
-      if (bitsBelowThreshold(marked_bits, marked_clear_threshold_))
-      {
-        if (bitsBelowThreshold(unknown_bits, unknown_clear_threshold_))
-        {
-          costmap_[offset] = free_cost_;
-        }
-        else
-        {
-          costmap_[offset] = unknown_cost_;
-        }
-      }
-    }
-  private:
-    inline bool bitsBelowThreshold(unsigned int n, unsigned int bit_threshold)
-    {
-      unsigned int bit_count;
-      for (bit_count = 0; n;)
-      {
-        ++bit_count;
-        if (bit_count > bit_threshold)
-        {
-          return false;
-        }
-        n &= n - 1; //clear the least significant bit set
-      }
-      return true;
-    }
-
-    uint32_t* data_;
-    unsigned char *costmap_;
-    unsigned int unknown_clear_threshold_, marked_clear_threshold_;
-    unsigned char free_cost_, unknown_cost_;
-  };
 
   class GridOffset
   {

--- a/voxel_grid/src/voxel_grid.cpp
+++ b/voxel_grid/src/voxel_grid.cpp
@@ -46,9 +46,11 @@ namespace voxel_grid {
     size_z_ = size_z; 
 
     if(size_z_ > 16){
-      ROS_INFO("Error, this implementation can only support up to 16 z values (%d)", size_z_); 
+      ROS_ERROR("Error, this implementation can only support up to 16 z values (%d)", size_z_);
       size_z_ = 16;
     }
+
+    accuracy_multiplier_ = 1;
 
     data_ = new uint32_t[size_x_ * size_y_];
     uint32_t unknown_col = ~((uint32_t)0)>>16;
@@ -122,8 +124,11 @@ namespace voxel_grid {
     raytraceLine(cv, x0, y0, z0, x1, y1, z1, max_length);
   }
 
-  void VoxelGrid::clearVoxelLineInMap(double x0, double y0, double z0, double x1, double y1, double z1, unsigned char *map_2d, 
-      unsigned int unknown_threshold, unsigned int mark_threshold, unsigned char free_cost, unsigned char unknown_cost, unsigned int max_length){
+  void VoxelGrid::clearVoxelLineInMap(double x0, double y0, double z0, double x1, double y1, double z1,
+                                      unsigned char *map_2d, unsigned int unknown_threshold, unsigned int mark_threshold,
+                                      unsigned char free_cost, unsigned char unknown_cost, unsigned int max_length,
+                                      bool include_corner_cases)
+  {
     costmap = map_2d;
     if(map_2d == NULL){
       clearVoxelLine(x0, y0, z0, x1, y1, z1, max_length);
@@ -137,7 +142,7 @@ namespace voxel_grid {
     }
 
     ClearVoxelInMap cvm(data_, costmap, unknown_threshold, mark_threshold, free_cost, unknown_cost);
-    raytraceLine(cvm, x0, y0, z0, x1, y1, z1, max_length);
+    raytraceLine(cvm, x0, y0, z0, x1, y1, z1, max_length, include_corner_cases);
   }
 
   VoxelStatus VoxelGrid::getVoxel(unsigned int x, unsigned int y, unsigned int z)


### PR DESCRIPTION
Changes / fixes clearing with Bresenham raytracing using a more accurate version
Adds parameters for accuracy settings
Adds parameter for including corner cases into clearing

See also https://github.com/ros-planning/navigation/issues/267

Implementation based on: http://graphics.idav.ucdavis.edu/education/GraphicsNotes/CAGDNotes/Bresenhams-Algorithm.pdf
