### PR TITLE
Stop global planner at reset, preventing unwanted movement towards old goal

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -181,8 +181,6 @@ namespace move_base {
       controller_costmap_ros_->stop();
     }
 
-    ROS_ERROR_NAMED("move_base","Okke changed this mothafuckas");
-
     //load any user specified recovery behaviors, and if that fails load the defaults
     if(!loadRecoveryBehaviors(private_nh)){
       loadDefaultRecoveryBehaviors();

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1151,6 +1151,12 @@ namespace move_base {
   }
 
   void MoveBase::resetState(){
+    // Disable the planner thread
+    boost::unique_lock<boost::mutex> lock(planner_mutex_);
+    runPlanner_ = false;
+    lock.unlock();
+
+    // Reset statemachine
     state_ = PLANNING;
     recovery_index_ = 0;
     recovery_trigger_ = PLANNING_R;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1155,7 +1155,6 @@ namespace move_base {
   void MoveBase::resetState(){
     // Disable the planner thread
     boost::unique_lock<boost::mutex> lock(planner_mutex_);
-    lock.lock();
     runPlanner_ = false;
     lock.unlock();
 

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -181,6 +181,8 @@ namespace move_base {
       controller_costmap_ros_->stop();
     }
 
+    ROS_ERROR_NAMED("move_base","Okke changed this mothafuckas");
+
     //load any user specified recovery behaviors, and if that fails load the defaults
     if(!loadRecoveryBehaviors(private_nh)){
       loadDefaultRecoveryBehaviors();
@@ -1151,6 +1153,13 @@ namespace move_base {
   }
 
   void MoveBase::resetState(){
+    // Disable the planner thread
+    boost::unique_lock<boost::mutex> lock(planner_mutex_);
+    lock.lock();
+    runPlanner_ = false;
+    lock.unlock();
+
+    // Reset statemachine
     state_ = PLANNING;
     recovery_index_ = 0;
     recovery_trigger_ = PLANNING_R;


### PR DESCRIPTION
The robot keeps navigating towards an old goal, either for undetermined period of time or until the global planner finds a new path. 

In order to recreate this:
- Give a navigation goal
- While the robot is navigating, preempt the goal.
- Give another navigation goal to a point which is, at that moment, unreachable (such that the global planner cannot plan a path immediately). It will then continue to move toward the old goal. 

Even when the global planner does not find a goal at all, the local planner will still follow the last plan it got.

This happens, in my believe, due to the fact that the planThread in move base (https://github.com/ros-planning/navigation/blob/hydro-devel/move_base/src/move_base.cpp) can generate a new plan after the goal has been preempted and thereby advances the move_base state-machine to the CONTROLLING state (https://github.com/ros-planning/navigation/blob/hydro-devel/move_base/src/move_base.cpp#L643).

This happens even though the state-machine has been reset to PLANNING (https://github.com/ros-planning/navigation/blob/hydro-devel/move_base/src/move_base.cpp#L753, https://github.com/ros-planning/navigation/blob/hydro-devel/move_base/src/move_base.cpp#L1154).

In order to fix this runPlanner_ should be set to false at the resetState function, before setting the state-machine to PLANNING.
