### PR TITLE
Swap map service

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -6,20 +6,29 @@ find_package(catkin REQUIRED
             roscpp
             tf
             dynamic_reconfigure
+            nav_msgs
+            geometry_msgs
         )
 
 find_package(Boost REQUIRED)
+
+# add service files
+add_service_files(FILES
+  SwapMap.srv)
 
 # dynamic reconfigure
 generate_dynamic_reconfigure_options(
     cfg/AMCL.cfg
 )
 
+generate_messages(DEPENDENCIES nav_msgs geometry_msgs)
+
 catkin_package(
     CATKIN_DEPENDS
         roscpp
         dynamic_reconfigure
         tf
+        message_runtime
   INCLUDE_DIRS include
   LIBRARIES amcl_sensors amcl_map amcl_pf
 )

--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -7,21 +7,14 @@ find_package(catkin REQUIRED
             tf
             dynamic_reconfigure
             nav_msgs
-            geometry_msgs
         )
 
 find_package(Boost REQUIRED)
-
-# add service files
-add_service_files(FILES
-  SwapMap.srv)
 
 # dynamic reconfigure
 generate_dynamic_reconfigure_options(
     cfg/AMCL.cfg
 )
-
-generate_messages(DEPENDENCIES nav_msgs geometry_msgs)
 
 catkin_package(
     CATKIN_DEPENDS

--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -21,7 +21,6 @@ catkin_package(
         roscpp
         dynamic_reconfigure
         tf
-        message_runtime
   INCLUDE_DIRS include
   LIBRARIES amcl_sensors amcl_map amcl_pf
 )

--- a/amcl/package.xml
+++ b/amcl/package.xml
@@ -30,14 +30,12 @@
     <build_depend>std_srvs</build_depend>
     <build_depend>tf</build_depend>
     <build_depend>nav_msgs</build_depend>
-    <build_depend>geometry_msgs</build_depend>
     <build_depend>message_generation</build_depend>
 
     <run_depend>roscpp</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>tf</run_depend>
     <run_depend>nav_msgs</run_depend>
-    <run_depend>run_msgs</run_depend>
     <run_depend>message_runtime</run_depend>
 
     <test_depend>map_server</test_depend>

--- a/amcl/package.xml
+++ b/amcl/package.xml
@@ -29,10 +29,16 @@
     <build_depend>rostest</build_depend>
     <build_depend>std_srvs</build_depend>
     <build_depend>tf</build_depend>
+    <build_depend>nav_msgs</build_depend>
+    <build_depend>geometry_msgs</build_depend>
+    <build_depend>message_generation</build_depend>
 
     <run_depend>roscpp</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>tf</run_depend>
+    <run_depend>nav_msgs</run_depend>
+    <run_depend>run_msgs</run_depend>
+    <run_depend>message_runtime</run_depend>
 
     <test_depend>map_server</test_depend>
     <test_depend>rosbag</test_depend>

--- a/amcl/package.xml
+++ b/amcl/package.xml
@@ -30,13 +30,11 @@
     <build_depend>std_srvs</build_depend>
     <build_depend>tf</build_depend>
     <build_depend>nav_msgs</build_depend>
-    <build_depend>message_generation</build_depend>
 
     <run_depend>roscpp</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>tf</run_depend>
     <run_depend>nav_msgs</run_depend>
-    <run_depend>message_runtime</run_depend>
 
     <test_depend>map_server</test_depend>
     <test_depend>rosbag</test_depend>

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1350,6 +1350,8 @@ AmclNode::applyInitialPose()
 
 bool AmclNode::swapMapCallback(amcl::SwapMapRequest &request, amcl::SwapMapResponse& response)
 {
+  boost::recursive_mutex::scoped_lock l(configuration_mutex_);
+  
   if(request.map_msg.info.width == 0 || request.map_msg.info.height == 0)
   {
     ROS_ERROR("Map dimensions cannot be zero");
@@ -1371,6 +1373,7 @@ bool AmclNode::swapMapCallback(amcl::SwapMapRequest &request, amcl::SwapMapRespo
   pf_init_pose_mean.v[2] = yaw;
   pf_matrix_t pf_init_pose_cov = pf_matrix_zero();
 
+  // These are the same default values used in updatePoseFromServer() above
   pf_init_pose_cov.m[0][0] = 0.5*0.5;
   pf_init_pose_cov.m[1][1] = 0.5*0.5;
   pf_init_pose_cov.m[2][2] = (M_PI/12.0) * (M_PI/12.0);
@@ -1383,5 +1386,7 @@ bool AmclNode::swapMapCallback(amcl::SwapMapRequest &request, amcl::SwapMapRespo
   applyInitialPose();
 
   response.success = true;
+
+  return true;
 }
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -142,7 +142,7 @@ class AmclNode
 
     double getYaw(tf::Pose& t);
 
-    bool swapMapCallback(nav_msgs::SetMapRequest &request, nav_msgs::SetMapResponse& response);
+    bool setMapCallback(nav_msgs::SetMapRequest &request, nav_msgs::SetMapResponse& response);
 
     //parameter for what odom to use
     std::string odom_frame_id_;
@@ -208,7 +208,7 @@ class AmclNode
     ros::Publisher particlecloud_pub_;
     ros::ServiceServer global_loc_srv_;
     ros::ServiceServer nomotion_update_srv_; //to let amcl update samples without requiring motion
-    ros::ServiceServer swap_map_srv_;
+    ros::ServiceServer set_map_srv_;
     ros::Subscriber initial_pose_sub_old_;
     ros::Subscriber map_sub_;
 
@@ -368,7 +368,7 @@ AmclNode::AmclNode() :
 					 &AmclNode::globalLocalizationCallback,
                                          this);
   nomotion_update_srv_= nh_.advertiseService("request_nomotion_update", &AmclNode::nomotionUpdateCallback, this);
-  swap_map_srv_ = nh_.advertiseService("swap_map", &AmclNode::swapMapCallback, this);
+  set_map_srv_ = nh_.advertiseService("set_map", &AmclNode::setMapCallback, this);
   laser_scan_sub_ = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100);
   laser_scan_filter_ = 
           new tf::MessageFilter<sensor_msgs::LaserScan>(*laser_scan_sub_, 
@@ -1348,7 +1348,7 @@ AmclNode::applyInitialPose()
   }
 }
 
-bool AmclNode::swapMapCallback(nav_msgs::SetMapRequest &request, nav_msgs::SetMapResponse& response)
+bool AmclNode::setMapCallback(nav_msgs::SetMapRequest &request, nav_msgs::SetMapResponse& response)
 {
   boost::recursive_mutex::scoped_lock l(configuration_mutex_);
   

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -58,7 +58,7 @@
 #include "amcl/AMCLConfig.h"
 
 // Services
-#include "amcl/SwapMap.h"
+#include "nav_msgs/SetMap.h"
 
 #define NEW_UNIFORM_SAMPLING 1
 
@@ -142,7 +142,7 @@ class AmclNode
 
     double getYaw(tf::Pose& t);
 
-    bool swapMapCallback(amcl::SwapMapRequest &request, amcl::SwapMapResponse& response);
+    bool swapMapCallback(nav_msgs::SetMapRequest &request, nav_msgs::SetMapResponse& response);
 
     //parameter for what odom to use
     std::string odom_frame_id_;
@@ -1348,17 +1348,17 @@ AmclNode::applyInitialPose()
   }
 }
 
-bool AmclNode::swapMapCallback(amcl::SwapMapRequest &request, amcl::SwapMapResponse& response)
+bool AmclNode::swapMapCallback(nav_msgs::SetMapRequest &request, nav_msgs::SetMapResponse& response)
 {
   boost::recursive_mutex::scoped_lock l(configuration_mutex_);
   
-  if(request.map_msg.info.width == 0 || request.map_msg.info.height == 0)
+  if(request.map.info.width == 0 || request.map.info.height == 0)
   {
     ROS_ERROR("Map dimensions cannot be zero");
     response.success = false;
     return false;
   } 
-  handleMapMessage(request.map_msg);
+  handleMapMessage(request.map);
 
   double x = request.initial_pose.position.x;
   double y = request.initial_pose.position.y;

--- a/amcl/srv/SwapMap.srv
+++ b/amcl/srv/SwapMap.srv
@@ -1,5 +1,0 @@
- nav_msgs/OccupancyGrid map_msg
- geometry_msgs/Pose initial_pose
- ---
- bool success
-

--- a/amcl/srv/SwapMap.srv
+++ b/amcl/srv/SwapMap.srv
@@ -1,0 +1,5 @@
+ nav_msgs/OccupancyGrid map_msg
+ geometry_msgs/Pose initial_pose
+ ---
+ bool success
+


### PR DESCRIPTION
Adds a service which a client can use to send a new map (nav_msgs/OccupancyGrid) and new initial pose (geometry_msgs/Pose) for amcl to load and localize against. 
