### PR TITLE
Global planner orientation

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(${PROJECT_NAME}
   src/astar.cpp
   src/grid_path.cpp
   src/gradient_path.cpp
+  src/orientation_filter.cpp
   src/planner_core.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/global_planner/cfg/GlobalPlanner.cfg
+++ b/global_planner/cfg/GlobalPlanner.cfg
@@ -10,4 +10,13 @@ gen.add("neutral_cost", int_t,   0, "Neutral Cost",  50, 1, 255)
 gen.add("cost_factor", double_t, 0, "Factor to multiply each cost from costmap by", 3.0, 0.01, 5.0)
 gen.add("publish_potential", bool_t, 0, "Publish Potential Costmap", True)
 
+orientation_enum = gen.enum([ 
+    gen.const("None",        int_t, 0, "No orientations added except goal orientation"),
+    gen.const("Forward",     int_t, 1, "Orientations point to the next point on the path"),
+    gen.const("Interpolate", int_t, 2, "Orientations are a linear blend of start and goal pose"),
+                            ], "How to set the orientation of each point")
+
+gen.add("orientation_mode",  int_t, 0, "How to set the orientation of each point", 1, 0, 2,
+        edit_method=orientation_enum)
+
 exit(gen.generate(PACKAGE, "global_planner", "GlobalPlanner"))

--- a/global_planner/cfg/GlobalPlanner.cfg
+++ b/global_planner/cfg/GlobalPlanner.cfg
@@ -14,9 +14,10 @@ orientation_enum = gen.enum([
     gen.const("None",        int_t, 0, "No orientations added except goal orientation"),
     gen.const("Forward",     int_t, 1, "Orientations point to the next point on the path"),
     gen.const("Interpolate", int_t, 2, "Orientations are a linear blend of start and goal pose"),
+    gen.const("Mixture",     int_t, 3, "Forward orientation until last straightaway"),
                             ], "How to set the orientation of each point")
 
-gen.add("orientation_mode",  int_t, 0, "How to set the orientation of each point", 1, 0, 2,
+gen.add("orientation_mode",  int_t, 0, "How to set the orientation of each point", 1, 0, 3,
         edit_method=orientation_enum)
 
 exit(gen.generate(PACKAGE, "global_planner", "GlobalPlanner"))

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -9,7 +9,8 @@ namespace global_planner {
 
 class OrientationFilter {
     public:
-        virtual void processPath(std::vector<geometry_msgs::PoseStamped>& path){}
+        virtual void processPath(const geometry_msgs::PoseStamped& start,
+                                 std::vector<geometry_msgs::PoseStamped>& path);
 };
 
 } //end namespace global_planner

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -7,13 +7,24 @@
 
 namespace global_planner {
 
+enum OrientationMode { NONE, FORWARD, INTERPOLATE };
+
 class OrientationFilter {
     public:
+        OrientationFilter() : omode_(NONE) {}
+    
+    
         virtual void processPath(const geometry_msgs::PoseStamped& start,
                                  std::vector<geometry_msgs::PoseStamped>& path);
                                  
         void pointToNext(std::vector<geometry_msgs::PoseStamped>& path, int index);
-        
+        void interpolate(std::vector<geometry_msgs::PoseStamped>& path, 
+                         int start_index, int end_index);
+                         
+        void setMode(OrientationMode new_mode){ omode_ = new_mode; }
+        void setMode(int new_mode){ setMode((OrientationMode) new_mode); }
+    protected:
+        OrientationMode omode_;        
 };
 
 } //end namespace global_planner

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -7,7 +7,7 @@
 
 namespace global_planner {
 
-enum OrientationMode { NONE, FORWARD, INTERPOLATE };
+enum OrientationMode { NONE, FORWARD, INTERPOLATE, MIXTURE };
 
 class OrientationFilter {
     public:

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -11,6 +11,9 @@ class OrientationFilter {
     public:
         virtual void processPath(const geometry_msgs::PoseStamped& start,
                                  std::vector<geometry_msgs::PoseStamped>& path);
+                                 
+        void pointToNext(std::vector<geometry_msgs::PoseStamped>& path, int index);
+        
 };
 
 } //end namespace global_planner

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -1,0 +1,16 @@
+/*********************************************************************
+ * Author: David V. Lu!!
+ *********************************************************************/
+#ifndef _ORIENTATION_FILTER_H
+#define _ORIENTATION_FILTER_H
+#include <nav_msgs/Path.h>
+
+namespace global_planner {
+
+class OrientationFilter {
+    public:
+        virtual void processPath(std::vector<geometry_msgs::PoseStamped>& path){}
+};
+
+} //end namespace global_planner
+#endif

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -51,6 +51,7 @@
 #include <global_planner/potential_calculator.h>
 #include <global_planner/expander.h>
 #include <global_planner/traceback.h>
+#include <global_planner/orientation_filter.h>
 #include <global_planner/GlobalPlannerConfig.h>
 
 namespace global_planner {
@@ -185,6 +186,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         PotentialCalculator* p_calc_;
         Expander* planner_;
         Traceback* path_maker_;
+        OrientationFilter* o_filter_;
 
         bool publish_potential_;
         ros::Publisher potential_pub_;

--- a/global_planner/src/orientation_filter.cpp
+++ b/global_planner/src/orientation_filter.cpp
@@ -1,10 +1,30 @@
 
 #include <global_planner/orientation_filter.h>
+#include <tf/tf.h>
 
 namespace global_planner {
-    void OrientationFilter::processPath(const geometry_msgs::PoseStamped& start, 
-                                        std::vector<geometry_msgs::PoseStamped>& path)
-    {
-        
+
+void set_angle(geometry_msgs::PoseStamped* pose, double angle)
+{
+    pose->pose.orientation = tf::createQuaternionMsgFromYaw(angle); 
+}
+
+void OrientationFilter::processPath(const geometry_msgs::PoseStamped& start, 
+                                    std::vector<geometry_msgs::PoseStamped>& path)
+{
+    for(int i=0;i<path.size()-1;i++){
+        pointToNext(path, i);
     }
+}
+    
+void OrientationFilter::pointToNext(std::vector<geometry_msgs::PoseStamped>& path, int index)
+{
+  double x0 = path[ index ].pose.position.x, 
+         y0 = path[ index ].pose.position.y,
+         x1 = path[index+1].pose.position.x,
+         y1 = path[index+1].pose.position.y;
+         
+  double angle = atan2(y1-y0,x1-x0);
+  set_angle(&path[index], angle);
+}
 };

--- a/global_planner/src/orientation_filter.cpp
+++ b/global_planner/src/orientation_filter.cpp
@@ -1,0 +1,10 @@
+
+#include <global_planner/orientation_filter.h>
+
+namespace global_planner {
+    void OrientationFilter::processPath(const geometry_msgs::PoseStamped& start, 
+                                        std::vector<geometry_msgs::PoseStamped>& path)
+    {
+        
+    }
+};

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -120,6 +120,8 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
             path_maker_ = new GridPath(p_calc_);
         else
             path_maker_ = new GradientPath(p_calc_);
+            
+        o_filter_ = new OrientationFilter();
 
         plan_pub_ = private_nh.advertise<nav_msgs::Path>("plan", 1);
         potential_pub_ = private_nh.advertise<nav_msgs::OccupancyGrid>("potential", 1);
@@ -303,6 +305,9 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
         ROS_ERROR("Failed to get a plan.");
     }
 
+    // add orientations if needed
+    o_filter_->processPath(plan);
+    
     //publish the plan for visualization purposes
     publishPlan(plan);
     delete potential_array_;

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -306,7 +306,7 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     }
 
     // add orientations if needed
-    o_filter_->processPath(plan);
+    o_filter_->processPath(start, plan);
     
     //publish the plan for visualization purposes
     publishPlan(plan);

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -159,6 +159,7 @@ void GlobalPlanner::reconfigureCB(global_planner::GlobalPlannerConfig& config, u
     planner_->setNeutralCost(config.neutral_cost);
     planner_->setFactor(config.cost_factor);
     publish_potential_ = config.publish_potential;
+    o_filter_->setMode(config.orientation_mode);
 }
 
 void GlobalPlanner::clearRobotCell(const tf::Stamped<tf::Pose>& global_pose, unsigned int mx, unsigned int my) {


### PR DESCRIPTION
Create a variety of options for outputting orientations from the global planner. 

By default, each point will have no orientation, which is the current behavior. 

The "Forward" mode orients the robot toward the next point on the path. 

The "Interpolation" mode interpolates between the first and last pose. 

The "Mixture" model points forward most of the time until the last straightaway, whereupon it starts interpolating to its final position. 
