### PR TITLE
Add Orientation Filter to Global Planner

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(${PROJECT_NAME}
   src/astar.cpp
   src/grid_path.cpp
   src/gradient_path.cpp
+  src/orientation_filter.cpp
   src/planner_core.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/global_planner/cfg/GlobalPlanner.cfg
+++ b/global_planner/cfg/GlobalPlanner.cfg
@@ -10,4 +10,15 @@ gen.add("neutral_cost", int_t,   0, "Neutral Cost",  50, 1, 255)
 gen.add("cost_factor", double_t, 0, "Factor to multiply each cost from costmap by", 3.0, 0.01, 5.0)
 gen.add("publish_potential", bool_t, 0, "Publish Potential Costmap", True)
 
+orientation_enum = gen.enum([ 
+    gen.const("None",        int_t, 0, "No orientations added except goal orientation"),
+    gen.const("Forward",     int_t, 1, "Orientations point to the next point on the path"),
+    gen.const("Interpolate", int_t, 2, "Orientations are a linear blend of start and goal pose"),
+    gen.const("ForwardThenInterpolate", 
+                             int_t, 3, "Forward orientation until last straightaway, then a linear blend until the goal pose"),
+                            ], "How to set the orientation of each point")
+
+gen.add("orientation_mode",  int_t, 0, "How to set the orientation of each point", 1, 0, 3,
+        edit_method=orientation_enum)
+
 exit(gen.generate(PACKAGE, "global_planner", "GlobalPlanner"))

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -1,0 +1,64 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, David V. Lu!!
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of David V. Lu nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: David V. Lu!!
+ *********************************************************************/
+#ifndef GLOBAL_PLANNER_ORIENTATION_FILTER_H
+#define GLOBAL_PLANNER_ORIENTATION_FILTER_H
+#include <nav_msgs/Path.h>
+
+namespace global_planner {
+
+enum OrientationMode { NONE, FORWARD, INTERPOLATE, FORWARDTHENINTERPOLATE };
+
+class OrientationFilter {
+    public:
+        OrientationFilter() : omode_(NONE) {}
+    
+    
+        virtual void processPath(const geometry_msgs::PoseStamped& start,
+                                 std::vector<geometry_msgs::PoseStamped>& path);
+                                 
+        void pointToNext(std::vector<geometry_msgs::PoseStamped>& path, int index);
+        void interpolate(std::vector<geometry_msgs::PoseStamped>& path, 
+                         int start_index, int end_index);
+                         
+        void setMode(OrientationMode new_mode){ omode_ = new_mode; }
+        void setMode(int new_mode){ setMode((OrientationMode) new_mode); }
+    protected:
+        OrientationMode omode_;        
+};
+
+} //end namespace global_planner
+#endif

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -51,6 +51,7 @@
 #include <global_planner/potential_calculator.h>
 #include <global_planner/expander.h>
 #include <global_planner/traceback.h>
+#include <global_planner/orientation_filter.h>
 #include <global_planner/GlobalPlannerConfig.h>
 
 namespace global_planner {
@@ -185,6 +186,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         PotentialCalculator* p_calc_;
         Expander* planner_;
         Traceback* path_maker_;
+        OrientationFilter* orientation_filter_;
 
         bool publish_potential_;
         ros::Publisher potential_pub_;

--- a/global_planner/src/orientation_filter.cpp
+++ b/global_planner/src/orientation_filter.cpp
@@ -1,0 +1,114 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, David V. Lu!!
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of David V. Lu nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: David V. Lu!!
+ *********************************************************************/
+#include <global_planner/orientation_filter.h>
+#include <tf/tf.h>
+#include <angles/angles.h>
+
+namespace global_planner {
+
+void set_angle(geometry_msgs::PoseStamped* pose, double angle)
+{
+    pose->pose.orientation = tf::createQuaternionMsgFromYaw(angle); 
+}
+
+double getYaw(geometry_msgs::PoseStamped pose)
+{
+    return tf::getYaw(pose.pose.orientation);
+}
+
+void OrientationFilter::processPath(const geometry_msgs::PoseStamped& start, 
+                                    std::vector<geometry_msgs::PoseStamped>& path)
+{
+    int n = path.size();
+    switch(omode_) {
+        case FORWARD:
+            for(int i=0;i<n-1;i++){
+                pointToNext(path, i);
+            }
+            break;
+        case INTERPOLATE:
+            path[0].pose.orientation = start.pose.orientation;
+            interpolate(path, 0, n-1);
+            break;
+        case FORWARDTHENINTERPOLATE:
+            for(int i=0;i<n-1;i++){
+                pointToNext(path, i);
+            }
+            
+            int i=n-3;
+            double last = getYaw(path[i]);
+            while( i>0 ){
+                double new_angle = getYaw(path[i-1]);
+                double diff = fabs(angles::shortest_angular_distance(new_angle, last));
+                if( diff>0.35)
+                    break;
+                else
+                    i--;
+            }
+            
+            path[0].pose.orientation = start.pose.orientation;
+            interpolate(path, i, n-1);
+            break;           
+    }
+}
+    
+void OrientationFilter::pointToNext(std::vector<geometry_msgs::PoseStamped>& path, int index)
+{
+  double x0 = path[ index ].pose.position.x, 
+         y0 = path[ index ].pose.position.y,
+         x1 = path[index+1].pose.position.x,
+         y1 = path[index+1].pose.position.y;
+         
+  double angle = atan2(y1-y0,x1-x0);
+  set_angle(&path[index], angle);
+}
+
+void OrientationFilter::interpolate(std::vector<geometry_msgs::PoseStamped>& path, 
+                                    int start_index, int end_index)
+{
+    double start_yaw = getYaw(path[start_index]),
+           end_yaw   = getYaw(path[end_index  ]);
+    double diff = angles::shortest_angular_distance(start_yaw, end_yaw);
+    double increment = diff/(end_index-start_index);
+    for(int i=start_index; i<=end_index; i++){
+        double angle = start_yaw + increment * i;
+        set_angle(&path[i], angle);
+    }
+}
+                                   
+
+};

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -120,6 +120,8 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
             path_maker_ = new GridPath(p_calc_);
         else
             path_maker_ = new GradientPath(p_calc_);
+            
+        orientation_filter_ = new OrientationFilter();
 
         plan_pub_ = private_nh.advertise<nav_msgs::Path>("plan", 1);
         potential_pub_ = private_nh.advertise<nav_msgs::OccupancyGrid>("potential", 1);
@@ -157,6 +159,7 @@ void GlobalPlanner::reconfigureCB(global_planner::GlobalPlannerConfig& config, u
     planner_->setNeutralCost(config.neutral_cost);
     planner_->setFactor(config.cost_factor);
     publish_potential_ = config.publish_potential;
+    orientation_filter_->setMode(config.orientation_mode);
 }
 
 void GlobalPlanner::clearRobotCell(const tf::Stamped<tf::Pose>& global_pose, unsigned int mx, unsigned int my) {
@@ -303,6 +306,9 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
         ROS_ERROR("Failed to get a plan.");
     }
 
+    // add orientations if needed
+    orientation_filter_->processPath(start, plan);
+    
     //publish the plan for visualization purposes
     publishPlan(plan);
     delete potential_array_;


### PR DESCRIPTION
Redraft of #304 

Create a variety of options for outputting orientations from the global planner.

By default, each point will have no orientation, which is the current behavior.

The "Forward" mode orients the robot toward the next point on the path.

The "Interpolation" mode interpolates between the first and last pose.

The "ForwardThenInterpolate" model points forward most of the time until the last straightaway, whereupon it starts interpolating to its final position. (Formerly called Mixture)
