### PR TITLE
Fixing memory leak and clean up freeing operations

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -182,6 +182,7 @@ private:
   double resolution_;
 
   bool* seen_;
+  int seen_size_;
 
   unsigned char** cached_costs_;
   double** cached_distances_;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -55,6 +55,9 @@ InflationLayer::InflationLayer()
   , cell_inflation_radius_(0)
   , cached_cell_inflation_radius_(0)
   , dsrv_(NULL)
+  , seen_(NULL)
+  , cached_costs_(NULL)
+  , cached_distances_(NULL)
 {
   access_ = new boost::shared_mutex();
 }
@@ -65,7 +68,10 @@ void InflationLayer::onInitialize()
     boost::unique_lock < boost::shared_mutex > lock(*access_);
     ros::NodeHandle nh("~/" + name_), g_nh;
     current_ = true;
+    if (seen_)
+      delete[] seen_;
     seen_ = NULL;
+    seen_size_ = 0;
     need_reinflation_ = false;
 
     dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig>::CallbackType cb = boost::bind(
@@ -113,8 +119,9 @@ void InflationLayer::matchSize()
 
   unsigned int size_x = costmap->getSizeInCellsX(), size_y = costmap->getSizeInCellsY();
   if (seen_)
-    delete seen_;
-  seen_ = new bool[size_x * size_y];
+    delete[] seen_;
+  seen_size_ = size_x * size_y;
+  seen_ = new bool[seen_size_];
 }
 
 void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
@@ -157,6 +164,18 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
   unsigned char* master_array = master_grid.getCharMap();
   unsigned int size_x = master_grid.getSizeInCellsX(), size_y = master_grid.getSizeInCellsY();
 
+  if (seen_ == NULL) {
+    ROS_WARN("InflationLayer::updateCosts(): seen_ array is NULL");
+    seen_size_ = size_x * size_y;
+    seen_ = new bool[seen_size_];
+  }
+  else if (seen_size_ != size_x * size_y)
+  {
+    ROS_WARN("InflationLayer::updateCosts(): seen_ array size is wrong");
+    delete[] seen_;
+    seen_size_ = size_x * size_y;
+    seen_ = new bool[seen_size_];
+  }
   memset(seen_, false, size_x * size_y * sizeof(bool));
 
   // We need to include in the inflation cells outside the bounding
@@ -210,6 +229,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     if (my < size_y - 1)
       enqueue(master_array, index + size_x, mx, my + 1, sx, sy);
   }
+
 }
 
 /**
@@ -258,8 +278,7 @@ void InflationLayer::computeCaches()
   //based on the inflation radius... compute distance and cost caches
   if(cell_inflation_radius_ != cached_cell_inflation_radius_)
   {
-    if(cached_cell_inflation_radius_ > 0)
-      deleteKernels();
+    deleteKernels();
 
     cached_costs_ = new unsigned char*[cell_inflation_radius_ + 2];
     cached_distances_ = new double*[cell_inflation_radius_ + 2];
@@ -292,18 +311,24 @@ void InflationLayer::deleteKernels()
   {
     for (unsigned int i = 0; i <= cached_cell_inflation_radius_ + 1; ++i)
     {
-      delete[] cached_distances_[i];
+      if (cached_distances_[i])
+        delete[] cached_distances_[i];
     }
-    delete[] cached_distances_;
+    if (cached_distances_)
+      delete[] cached_distances_;
+    cached_distances_ = NULL;
   }
 
   if (cached_costs_ != NULL)
   {
     for (unsigned int i = 0; i <= cached_cell_inflation_radius_ + 1; ++i)
     {
-      delete[] cached_costs_[i];
+      if (cached_costs_[i])
+        delete[] cached_costs_[i];
     }
-    delete[] cached_costs_;
+    if (cached_costs_)
+      delete[] cached_costs_;
+    cached_costs_ = NULL;
   }
 }
 

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -326,8 +326,7 @@ void InflationLayer::deleteKernels()
       if (cached_costs_[i])
         delete[] cached_costs_[i];
     }
-    if (cached_costs_)
-      delete[] cached_costs_;
+    delete[] cached_costs_;
     cached_costs_ = NULL;
   }
 }

--- a/global_planner/include/global_planner/dijkstra.h
+++ b/global_planner/include/global_planner/dijkstra.h
@@ -56,6 +56,7 @@ namespace global_planner {
 class DijkstraExpansion : public Expander {
     public:
         DijkstraExpansion(PotentialCalculator* p_calc, int nx, int ny);
+        ~DijkstraExpansion();
         bool calculatePotentials(unsigned char* costs, double start_x, double start_y, double end_x, double end_y, int cycles,
                                 float* potential);
 

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -79,6 +79,11 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         GlobalPlanner(std::string name, costmap_2d::Costmap2D* costmap, std::string frame_id);
 
         /**
+         * @brief  Default deconstructor for the PlannerCore object
+         */
+        ~GlobalPlanner();
+
+        /**
          * @brief  Initialization function for the PlannerCore object
          * @param  name The name of this planner
          * @param  costmap_ros A pointer to the ROS wrapper of the costmap to use for planning
@@ -155,9 +160,6 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
          * @brief  Publish a path for visualization purposes
          */
         void publishPlan(const std::vector<geometry_msgs::PoseStamped>& path);
-
-        ~GlobalPlanner() {
-        }
 
         bool makePlanService(nav_msgs::GetPlan::Request& req, nav_msgs::GetPlan::Response& resp);
 

--- a/global_planner/src/dijkstra.cpp
+++ b/global_planner/src/dijkstra.cpp
@@ -49,6 +49,15 @@ DijkstraExpansion::DijkstraExpansion(PotentialCalculator* p_calc, int nx, int ny
     priorityIncrement_ = 2 * neutral_cost_;
 }
 
+DijkstraExpansion::~DijkstraExpansion() {
+  printf("Dijkstra deconstruct \n");
+  delete[] buffer1_;
+  delete[] buffer2_;
+  delete[] buffer3_;
+  if (pending_)
+      delete[] pending_;
+}
+
 //
 // Set/Reset map size
 //

--- a/global_planner/src/dijkstra.cpp
+++ b/global_planner/src/dijkstra.cpp
@@ -50,7 +50,6 @@ DijkstraExpansion::DijkstraExpansion(PotentialCalculator* p_calc, int nx, int ny
 }
 
 DijkstraExpansion::~DijkstraExpansion() {
-  printf("Dijkstra deconstruct \n");
   delete[] buffer1_;
   delete[] buffer2_;
   delete[] buffer3_;

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -77,6 +77,17 @@ GlobalPlanner::GlobalPlanner(std::string name, costmap_2d::Costmap2D* costmap, s
     initialize(name, costmap, frame_id);
 }
 
+GlobalPlanner::~GlobalPlanner() {
+    if (p_calc_)
+        delete p_calc_;
+    if (planner_)
+        delete planner_;
+    if (path_maker_)
+        delete path_maker_;
+    if (dsrv_)
+        delete dsrv_;
+}
+
 void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros) {
     initialize(name, costmap_ros->getCostmap(), costmap_ros->getGlobalFrameID());
 }
@@ -316,7 +327,7 @@ void GlobalPlanner::publishPlan(const std::vector<geometry_msgs::PoseStamped>& p
         return;
     }
 
-    //create a message for the plan 
+    //create a message for the plan
     nav_msgs::Path gui_path;
     gui_path.poses.resize(path.size());
 
@@ -414,7 +425,7 @@ void GlobalPlanner::publishPotential(float* potential)
     for (unsigned int i = 0; i < grid.data.size(); i++) {
         if (potential_array_[i] >= POT_HIGH) {
             grid.data[i] = -1;
-        } else 
+        } else
             grid.data[i] = potential_array_[i] * publish_scale_ / max;
     }
     potential_pub_.publish(grid);

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -494,6 +494,8 @@ namespace move_base {
     planner_thread_->interrupt();
     planner_thread_->join();
 
+    delete planner_thread_;
+
     delete planner_plan_;
     delete latest_plan_;
     delete controller_plan_;


### PR DESCRIPTION
Main fix is to a memory leak that was present in the costmap_2d/inflation_layer. Also includes other clean up to explicitly free memory that was allocated and ensure memory is allocated when needed.
