### PR TITLE
link only libraries found with find_package

### DIFF
--- a/dwa_local_planner/CMakeLists.txt
+++ b/dwa_local_planner/CMakeLists.txt
@@ -42,7 +42,7 @@ catkin_package(
 )
 
 add_library(dwa_local_planner src/dwa_planner.cpp src/dwa_planner_ros.cpp)
-target_link_libraries(dwa_local_planner base_local_planner ${catkin_LIBRARIES})
+target_link_libraries(dwa_local_planner ${catkin_LIBRARIES})
 add_dependencies(dwa_local_planner dwa_local_planner_gencfg)
 add_dependencies(dwa_local_planner nav_msgs_gencpp)
 


### PR DESCRIPTION
When cross-compiling dwa_local_planner with the OpenEmbedded layer
for ROS, meta-ros [1], I stumbled over the following issue. During
'Linking CXX shared library devel/lib/libdwa_local_planner.so', the
g++ call for this linking step includes amongst many other arguments
these two arguments in this order:

  -lbase_local_planner /[...]/sysroots/qemux86/opt/ros/hydro/lib/libbase_local_planner.so

In the meta-ros setup, the linker aborts with:
  .../sysroots/x86_64-linux/usr/libexec/i586-oe-linux/gcc/i586-oe-linux/4.9.1/ld: cannot find -lbase_local_planner

The linking fails, because in the cross-compiling scenario,
-lbase_local_planner is not resolved. However, cmake and the
find_package command is set up such that the pathes are resolved
correctly in this setting. To use these correct pathes, the
link_target_libraries should not hard-code the library name, but
only use the libraries found with find_package.

Probably, this has not been noticed before, as in the common setup,
find_package resolved to the hard-coded value.

[1] https://github.com/bmwcarit/meta-ros/

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
