### PR TITLE
Remove unused dependencies in move_base_msgs.

### DIFF
--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -3,11 +3,9 @@ project(move_base_msgs)
 
 find_package(catkin REQUIRED
     COMPONENTS
-        roscpp
         message_generation
         actionlib_msgs
         geometry_msgs
-        std_msgs
         )
 
 
@@ -21,7 +19,6 @@ add_action_files(
 generate_messages(
     DEPENDENCIES
         actionlib_msgs
-        std_msgs
         geometry_msgs
 )
 

--- a/move_base_msgs/package.xml
+++ b/move_base_msgs/package.xml
@@ -15,12 +15,10 @@
 
     <buildtool_depend>catkin</buildtool_depend>
 
-    <build_depend>roscpp</build_depend>
     <build_depend>actionlib_msgs</build_depend>
     <build_depend>geometry_msgs</build_depend>
     <build_depend>message_generation</build_depend>
 
-    <run_depend>roscpp</run_depend>
     <run_depend>actionlib_msgs</run_depend>
     <run_depend>geometry_msgs</run_depend>
     <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
The roscpp one in particular is heavy - this gets in the way of easily
generating messages from almost no dependencies.
