### PR TITLE
stops voxel_layer and obstacle_layer from deleting the same dynamic_reconfigure server

### DIFF
--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -94,7 +94,7 @@ private:
   virtual void raytraceFreespace(const costmap_2d::Observation& clearing_observation, double* min_x, double* min_y,
                                  double* max_x, double* max_y);
 
-  dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig> *dsrv_;
+  dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig> *voxel_dsrv_;
 
   bool publish_voxel_;
   ros::Publisher voxel_pub_;

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -224,6 +224,7 @@ void ObstacleLayer::onInitialize()
 
   }
 
+  dsrv_ = NULL;
   setupDynamicReconfigure(nh);
   footprint_layer_.initialize( layered_costmap_, name_ + "_footprint", tf_);
 }

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -66,16 +66,16 @@ void VoxelLayer::onInitialize()
 
 void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
 {
-  dsrv_ = new dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>(nh);
+  voxel_dsrv_ = new dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>(nh);
   dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>::CallbackType cb = boost::bind(
       &VoxelLayer::reconfigureCB, this, _1, _2);
-  dsrv_->setCallback(cb);
+  voxel_dsrv_->setCallback(cb);
 }
 
 VoxelLayer::~VoxelLayer()
 {
-  if(dsrv_)
-    delete dsrv_;
+  if(voxel_dsrv_)
+    delete voxel_dsrv_;
 }
 
 void VoxelLayer::reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t level)


### PR DESCRIPTION
Without this fix, you get segfaults when destructing voxel_layer. 

A very basic test of voxel_layer that segfaults without the fix and doesn't with can be found here:
https://github.com/KaijenHsiao/navigation/tree/voxel_layer_tests
