### PR TITLE
adds the set_map service to AMCL

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED
             roscpp
             tf
             dynamic_reconfigure
+            nav_msgs
         )
 
 find_package(Boost REQUIRED)

--- a/amcl/package.xml
+++ b/amcl/package.xml
@@ -33,6 +33,7 @@
     <run_depend>roscpp</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>tf</run_depend>
+    <run_depend>nav_msgs</run_depend>
 
     <test_depend>map_server</test_depend>
     <test_depend>rosbag</test_depend>

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -47,6 +47,7 @@
 #include "geometry_msgs/PoseArray.h"
 #include "geometry_msgs/Pose.h"
 #include "nav_msgs/GetMap.h"
+#include "nav_msgs/SetMap.h"
 #include "std_srvs/Empty.h"
 
 // For transform support
@@ -130,9 +131,12 @@ class AmclNode
                                     std_srvs::Empty::Response& res);
     bool nomotionUpdateCallback(std_srvs::Empty::Request& req,
                                     std_srvs::Empty::Response& res);
+    bool setMapCallback(nav_msgs::SetMap::Request& req,
+                        nav_msgs::SetMap::Response& res);
 
     void laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan);
     void initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedConstPtr& msg);
+    void handleInitialPoseMessage(const geometry_msgs::PoseWithCovarianceStamped& msg);
     void mapReceived(const nav_msgs::OccupancyGridConstPtr& msg);
 
     void handleMapMessage(const nav_msgs::OccupancyGrid& msg);
@@ -211,6 +215,7 @@ class AmclNode
     ros::Publisher particlecloud_pub_;
     ros::ServiceServer global_loc_srv_;
     ros::ServiceServer nomotion_update_srv_; //to let amcl update samples without requiring motion
+    ros::ServiceServer set_map_srv_;
     ros::Subscriber initial_pose_sub_old_;
     ros::Subscriber map_sub_;
 
@@ -383,6 +388,7 @@ AmclNode::AmclNode() :
 					 &AmclNode::globalLocalizationCallback,
                                          this);
   nomotion_update_srv_= nh_.advertiseService("request_nomotion_update", &AmclNode::nomotionUpdateCallback, this);
+  set_map_srv_= nh_.advertiseService("set_map", &AmclNode::setMapCallback, this);
 
   laser_scan_sub_ = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, scan_topic_, 100);
   laser_scan_filter_ = 
@@ -894,6 +900,16 @@ AmclNode::nomotionUpdateCallback(std_srvs::Empty::Request& req,
 	return true;
 }
 
+bool
+AmclNode::setMapCallback(nav_msgs::SetMap::Request& req,
+                         nav_msgs::SetMap::Response& res)
+{
+  handleMapMessage(req.map);
+  handleInitialPoseMessage(req.initial_pose);
+  res.success = true;
+  return true;
+}
+
 void
 AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
 {
@@ -1282,17 +1298,23 @@ AmclNode::getYaw(tf::Pose& t)
 void
 AmclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedConstPtr& msg)
 {
+  handleInitialPoseMessage(*msg);
+}
+
+void
+AmclNode::handleInitialPoseMessage(const geometry_msgs::PoseWithCovarianceStamped& msg)
+{
   boost::recursive_mutex::scoped_lock prl(configuration_mutex_);
-  if(msg->header.frame_id == "")
+  if(msg.header.frame_id == "")
   {
     // This should be removed at some point
     ROS_WARN("Received initial pose with empty frame_id.  You should always supply a frame_id.");
   }
   // We only accept initial pose estimates in the global frame, #5148.
-  else if(tf_->resolve(msg->header.frame_id) != tf_->resolve(global_frame_id_))
+  else if(tf_->resolve(msg.header.frame_id) != tf_->resolve(global_frame_id_))
   {
     ROS_WARN("Ignoring initial pose in frame \"%s\"; initial poses must be in the global frame, \"%s\"",
-             msg->header.frame_id.c_str(),
+             msg.header.frame_id.c_str(),
              global_frame_id_.c_str());
     return;
   }
@@ -1303,7 +1325,7 @@ AmclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedCons
   try
   {
     tf_->lookupTransform(base_frame_id_, ros::Time::now(),
-                         base_frame_id_, msg->header.stamp,
+                         base_frame_id_, msg.header.stamp,
                          global_frame_id_, tx_odom);
   }
   catch(tf::TransformException e)
@@ -1318,7 +1340,7 @@ AmclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedCons
   }
 
   tf::Pose pose_old, pose_new;
-  tf::poseMsgToTF(msg->pose.pose, pose_old);
+  tf::poseMsgToTF(msg.pose.pose, pose_old);
   pose_new = tx_odom.inverse() * pose_old;
 
   // Transform into the global frame
@@ -1339,10 +1361,10 @@ AmclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedCons
   {
     for(int j=0; j<2; j++)
     {
-      pf_init_pose_cov.m[i][j] = msg->pose.covariance[6*i+j];
+      pf_init_pose_cov.m[i][j] = msg.pose.covariance[6*i+j];
     }
   }
-  pf_init_pose_cov.m[2][2] = msg->pose.covariance[6*5+5];
+  pf_init_pose_cov.m[2][2] = msg.pose.covariance[6*5+5];
 
   delete initial_pose_hyp_;
   initial_pose_hyp_ = new amcl_hyp_t();


### PR DESCRIPTION
This adds the new nav_msgs/SetMap service to AMCL.

I added a new method `void handleInitialPoseMessage(const geometry_msgs::PoseWithCovarianceStamped& msg);` to be able to use the same code for the service and the standard incoming message on `/initialpose`.
