### PR TITLE
Static layer works in rolling window

### DIFF
--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -64,8 +64,6 @@ public:
                              double* max_y);
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
-  virtual void matchSize();
-
 private:
   /**
    * @brief  Callback to update the costmap's map from the map_server

--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -64,6 +64,8 @@ public:
                              double* max_y);
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
+  virtual void matchSize();
+
 private:
   /**
    * @brief  Callback to update the costmap's map from the map_server

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -52,8 +52,8 @@ StaticLayer::StaticLayer() : dsrv_(NULL) {}
 
 StaticLayer::~StaticLayer()
 {
-    if(dsrv_)
-        delete dsrv_;
+  if(dsrv_)
+    delete dsrv_;
 }
 
 void StaticLayer::onInitialize()
@@ -166,10 +166,12 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
     ROS_INFO("Resizing costmap to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);
     layered_costmap_->resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x,
                                 new_map->info.origin.position.y, true);
-  }else if(size_x_ != size_x || size_y_ != size_y ||
-      resolution_ != new_map->info.resolution ||
-      origin_x_ != new_map->info.origin.position.x ||
-      origin_y_ != new_map->info.origin.position.y){
+  }
+  else if (size_x_ != size_x || size_y_ != size_y ||
+           resolution_ != new_map->info.resolution ||
+           origin_x_ != new_map->info.origin.position.x ||
+           origin_y_ != new_map->info.origin.position.y)
+  {
     ROS_INFO("Resizing static layer to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);
     resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x, new_map->info.origin.position.y);
   }
@@ -195,39 +197,39 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
 
 void StaticLayer::incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr& update)
 {
-    unsigned int di = 0;
-    for (unsigned int y = 0; y < update->height ; y++)
+  unsigned int di = 0;
+  for (unsigned int y = 0; y < update->height ; y++)
+  {
+    unsigned int index_base = (update->y + y) * size_x_;
+    for (unsigned int x = 0; x < update->width ; x++)
     {
-        unsigned int index_base = (update->y + y) * size_x_;
-        for (unsigned int x = 0; x < update->width ; x++)
-        {
-            unsigned int index = index_base + x + update->x;
-            costmap_[index] = interpretValue( update->data[di++] );
-        }
+      unsigned int index = index_base + x + update->x;
+      costmap_[index] = interpretValue( update->data[di++] );
     }
-    x_ = update->x;
-    y_ = update->y;
-    width_ = update->width;
-    height_ = update->height;
-    has_updated_data_ = true;
+  }
+  x_ = update->x;
+  y_ = update->y;
+  width_ = update->width;
+  height_ = update->height;
+  has_updated_data_ = true;
 }
 
 void StaticLayer::activate()
 {
-    onInitialize();
+  onInitialize();
 }
 
 void StaticLayer::deactivate()
 {
-    map_sub_.shutdown();
-    if (subscribe_to_updates_)
-        map_update_sub_.shutdown();
+  map_sub_.shutdown();
+  if (subscribe_to_updates_)
+    map_update_sub_.shutdown();
 }
 
 void StaticLayer::reset()
 {
-    deactivate();
-    activate();
+  deactivate();
+  activate();
 }
 
 void StaticLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
@@ -274,7 +276,7 @@ void StaticLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int
         layered_costmap_->getCostmap()->mapToWorld(i, j, wx, wy);
         if (worldToMap(wx, wy, mx, my))
         {
-          if(!use_maximum_)
+          if (!use_maximum_)
             master_grid.setCost(i, j, getCost(mx, my));
           else
             master_grid.setCost(i, j, std::max(getCost(mx, my), master_grid.getCost(i, j)));

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -121,6 +121,17 @@ void StaticLayer::reconfigureCB(costmap_2d::GenericPluginConfig &config, uint32_
   }
 }
 
+void StaticLayer::matchSize()
+{
+  // If we are using rolling costmap, the static map should not match
+  if (!layered_costmap_->isRolling())
+  {
+    Costmap2D* master = layered_costmap_->getCostmap();
+    resizeMap(master->getSizeInCellsX(), master->getSizeInCellsY(), master->getResolution(),
+              master->getOriginX(), master->getOriginY());
+  }
+}
+
 unsigned char StaticLayer::interpretValue(unsigned char value)
 {
   //check if the static value is above the unknown or lethal thresholds
@@ -159,6 +170,7 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
       resolution_ != new_map->info.resolution ||
       origin_x_ != new_map->info.origin.position.x ||
       origin_y_ != new_map->info.origin.position.y){
+    ROS_INFO("Resizing static layer to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);
     resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x, new_map->info.origin.position.y);
   }
 

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -66,7 +66,7 @@ void StaticLayer::onInitialize()
   std::string map_topic;
   nh.param("map_topic", map_topic, std::string("map"));
   nh.param("subscribe_to_updates", subscribe_to_updates_, false);
-  
+
   nh.param("track_unknown_space", track_unknown_space_, true);
   nh.param("use_maximum", use_maximum_, false);
 
@@ -91,7 +91,7 @@ void StaticLayer::onInitialize()
   }
 
   ROS_INFO("Received a %d X %d map at %f m/pix", getSizeInCellsX(), getSizeInCellsY(), getResolution());
-  
+
   if(subscribe_to_updates_)
   {
     ROS_INFO("Subscribing to updates");
@@ -121,18 +121,13 @@ void StaticLayer::reconfigureCB(costmap_2d::GenericPluginConfig &config, uint32_
   }
 }
 
-void StaticLayer::matchSize()
-{
-  Costmap2D* master = layered_costmap_->getCostmap();
-  resizeMap(master->getSizeInCellsX(), master->getSizeInCellsY(), master->getResolution(),
-            master->getOriginX(), master->getOriginY());
-}
-
 unsigned char StaticLayer::interpretValue(unsigned char value)
 {
   //check if the static value is above the unknown or lethal thresholds
   if (track_unknown_space_ && value == unknown_cost_value_)
     return NO_INFORMATION;
+  else if (!track_unknown_space_ && value == unknown_cost_value_)
+    return FREE_SPACE;
   else if (value >= lethal_threshold_)
     return LETHAL_OBSTACLE;
   else if (trinary_costmap_)
@@ -150,12 +145,12 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
 
   // resize costmap if size, resolution or origin do not match
   Costmap2D* master = layered_costmap_->getCostmap();
-  if (master->getSizeInCellsX() != size_x ||
+  if (!layered_costmap_->isRolling() && (master->getSizeInCellsX() != size_x ||
       master->getSizeInCellsY() != size_y ||
       master->getResolution() != new_map->info.resolution ||
       master->getOriginX() != new_map->info.origin.position.x ||
       master->getOriginY() != new_map->info.origin.position.y ||
-      !layered_costmap_->isSizeLocked())
+      !layered_costmap_->isSizeLocked()))
   {
     ROS_INFO("Resizing costmap to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);
     layered_costmap_->resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x,
@@ -164,7 +159,7 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
       resolution_ != new_map->info.resolution ||
       origin_x_ != new_map->info.origin.position.x ||
       origin_y_ != new_map->info.origin.position.y){
-    matchSize();
+    resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x, new_map->info.origin.position.y);
   }
 
   unsigned int index = 0;
@@ -228,19 +223,19 @@ void StaticLayer::updateBounds(double robot_x, double robot_y, double robot_yaw,
 {
   if (!map_received_ || !(has_updated_data_ || has_extra_bounds_))
     return;
-    
+
   useExtraBounds(min_x, min_y, max_x, max_y);
 
-  double mx, my;
-  
-  mapToWorld(x_, y_, mx, my);
-  *min_x = std::min(mx, *min_x);
-  *min_y = std::min(my, *min_y);
-  
-  mapToWorld(x_ + width_, y_ + height_, mx, my);
-  *max_x = std::max(mx, *max_x);
-  *max_y = std::max(my, *max_y);
-  
+  double wx, wy;
+
+  mapToWorld(x_, y_, wx, wy);
+  *min_x = std::min(wx, *min_x);
+  *min_y = std::min(wy, *min_y);
+
+  mapToWorld(x_ + width_, y_ + height_, wx, wy);
+  *max_x = std::max(wx, *max_x);
+  *max_y = std::max(wy, *max_y);
+
   has_updated_data_ = false;
 }
 
@@ -248,10 +243,33 @@ void StaticLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int
 {
   if (!map_received_)
     return;
-  if (!use_maximum_)
-    updateWithTrueOverwrite(master_grid, min_i, min_j, max_i, max_j);
+
+  if (!layered_costmap_->isRolling())
+  {
+    if (!use_maximum_)
+      updateWithTrueOverwrite(master_grid, min_i, min_j, max_i, max_j);
+    else
+      updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+  }
   else
-    updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+  {
+    unsigned int mx, my;
+    double wx, wy;
+    for (unsigned int i = min_i; i < max_i; ++i)
+    {
+      for (unsigned int j = min_j; j < max_j; ++j)
+      {
+        layered_costmap_->getCostmap()->mapToWorld(i, j, wx, wy);
+        if (worldToMap(wx, wy, mx, my))
+        {
+          if(!use_maximum_)
+            master_grid.setCost(i, j, getCost(mx, my));
+          else
+            master_grid.setCost(i, j, std::max(getCost(mx, my), master_grid.getCost(i, j)));
+        }
+      }
+    }
+  }
 }
 
 }  // namespace costmap_2d


### PR DESCRIPTION
This cherry-picks from #246, fixes an additional issue with the layeredcostmap calling matchSize() and making the static map all wrong, and applies some small style fixes for future maintainability of code.

Jade-targeted PR coming in a moment
