### PR TITLE
fix pthread_mutex_lock on shutdown in amcl

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -271,6 +271,9 @@ main(int argc, char** argv)
 
   ros::spin();
 
+  // Without this, our boost locks are not shut down nicely
+  amcl_node_ptr.reset();
+
   // To quote Morgan, Hooray!
   return(0);
 }


### PR DESCRIPTION
Without this fix, we get the following error on shutdown:

```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```

Artifact of #305
