### PR TITLE
Add a first_map_only parameter so we keep reusing the first received static map

### DIFF
--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -67,6 +67,7 @@ public:
   virtual void matchSize();
 
 private:
+  void initialize(const nav_msgs::OccupancyGridConstPtr& new_map);
   /**
    * @brief  Callback to update the costmap's map from the map_server
    * @param new_map The map to put into the costmap. The origin of the new
@@ -87,7 +88,10 @@ private:
   bool track_unknown_space_;
   bool use_maximum_;
   bool trinary_costmap_;
+  bool first_map_only_;      ///< @brief Store the first static map and reuse it on reinitializing
   ros::Subscriber map_sub_, map_update_sub_;
+
+  nav_msgs::OccupancyGrid::Ptr first_map_;
 
   unsigned char lethal_threshold_, unknown_cost_value_;
 


### PR DESCRIPTION
This is follow-up of #150 to use ros-navi stack for multi-master usecase.
