### PR TITLE
proper locking during costmap update

### DIFF
--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -124,7 +124,7 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
 
 void ClearCostmapRecovery::clearMap(boost::shared_ptr<costmap_2d::CostmapLayer> costmap, 
                                         double pose_x, double pose_y){
-  boost::unique_lock< boost::shared_mutex > lock(*(costmap->getLock()));
+  boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(costmap->getMutex()));
  
   double start_point_x = pose_x - reset_distance_ / 2;
   double start_point_y = pose_y - reset_distance_ / 2;

--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -290,7 +290,9 @@ public:
    */
   unsigned int cellDistance(double world_dist);
 
-  boost::shared_mutex* getLock()
+  // Provide a typedef to ease future code maintenance
+  typedef boost::recursive_mutex mutex_t;
+  mutex_t* getMutex()
   {
     return access_;
   }
@@ -415,7 +417,7 @@ private:
     return x > 0 ? 1.0 : -1.0;
   }
 
-  boost::shared_mutex* access_;
+  mutex_t* access_;
 protected:
   unsigned int size_x_;
   unsigned int size_y_;

--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -91,7 +91,6 @@ private:
 
   unsigned char lethal_threshold_, unknown_cost_value_;
 
-  mutable boost::recursive_mutex lock_;
   dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> *dsrv_;
 };
 

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -47,7 +47,7 @@ Costmap2D::Costmap2D(unsigned int cells_size_x, unsigned int cells_size_y, doubl
     size_x_(cells_size_x), size_y_(cells_size_y), resolution_(resolution), origin_x_(origin_x), 
     origin_y_(origin_y), costmap_(NULL), default_value_(default_value)
 {
-  access_ = new boost::shared_mutex();
+  access_ = new mutex_t();
 
   //create the costmap
   initMaps(size_x_, size_y_);
@@ -57,14 +57,14 @@ Costmap2D::Costmap2D(unsigned int cells_size_x, unsigned int cells_size_y, doubl
 void Costmap2D::deleteMaps()
 {
   //clean up data
-  boost::unique_lock < boost::shared_mutex > lock(*access_);
+  boost::unique_lock<mutex_t> lock(*access_);
   delete[] costmap_;
   costmap_ = NULL;
 }
 
 void Costmap2D::initMaps(unsigned int size_x, unsigned int size_y)
 {
-  boost::unique_lock < boost::shared_mutex > lock(*access_);
+  boost::unique_lock<mutex_t> lock(*access_);
   delete[] costmap_;
   costmap_ = new unsigned char[size_x * size_y];
 }
@@ -86,13 +86,13 @@ void Costmap2D::resizeMap(unsigned int size_x, unsigned int size_y, double resol
 
 void Costmap2D::resetMaps()
 {
-  boost::unique_lock < boost::shared_mutex > lock(*access_);
+  boost::unique_lock<mutex_t> lock(*access_);
   memset(costmap_, default_value_, size_x_ * size_y_ * sizeof(unsigned char));
 }
 
 void Costmap2D::resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn)
 {
-  boost::unique_lock < boost::shared_mutex > lock(*(access_));
+  boost::unique_lock<mutex_t> lock(*(access_));
   unsigned int len = xn - x0;
   for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_)
     memset(costmap_ + y, default_value_, len * sizeof(unsigned char));
@@ -162,6 +162,7 @@ Costmap2D& Costmap2D::operator=(const Costmap2D& map)
 Costmap2D::Costmap2D(const Costmap2D& map) :
     costmap_(NULL)
 {
+  access_ = new mutex_t();
   *this = map;
 }
 
@@ -169,7 +170,7 @@ Costmap2D::Costmap2D(const Costmap2D& map) :
 Costmap2D::Costmap2D() :
     size_x_(0), size_y_(0), resolution_(0.0), origin_x_(0.0), origin_y_(0.0), costmap_(NULL)
 {
-  access_ = new boost::shared_mutex();
+  access_ = new mutex_t();
 }
 
 Costmap2D::~Costmap2D()

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -176,6 +176,7 @@ Costmap2D::Costmap2D() :
 Costmap2D::~Costmap2D()
 {
   deleteMaps();
+  delete access_;
 }
 
 unsigned int Costmap2D::cellDistance(double world_dist)

--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -82,7 +82,7 @@ void Costmap2DPublisher::onNewSubscription( const ros::SingleSubscriberPublisher
 // prepare grid_ message for publication.
 void Costmap2DPublisher::prepareGrid()
 {
-  boost::shared_lock < boost::shared_mutex > lock(*(costmap_->getLock()));
+  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
   double resolution = costmap_->getResolution();
 
   grid_.header.frame_id = global_frame_;
@@ -121,7 +121,7 @@ void Costmap2DPublisher::publishCostmap()
   }
   else if (x0_ < xn_)
   {
-    boost::shared_lock < boost::shared_mutex > lock(*(costmap_->getLock()));
+    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_->getMutex()));
     // Publish Just an Update
     map_msgs::OccupancyGridUpdate update;
     update.header.stamp = ros::Time::now();

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -112,10 +112,10 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   if (xn < x0 || yn < y0)
     return;
 
-  costmap_.resetMap(x0, y0, xn, yn);
-
   {
-    boost::unique_lock < boost::shared_mutex > lock(*(costmap_.getLock()));
+    // Clear and update costmap under a single lock
+    boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
+    costmap_.resetMap(x0, y0, xn, yn);
     for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
         ++plugin)
     {

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -505,7 +505,7 @@ namespace move_base {
   }
 
   bool MoveBase::makePlan(const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan){
-    boost::unique_lock< boost::shared_mutex > lock(*(planner_costmap_ros_->getCostmap()->getLock()));
+    boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(planner_costmap_ros_->getCostmap()->getMutex()));
 
     //make sure to set the plan to be empty initially
     plan.clear();
@@ -934,7 +934,7 @@ namespace move_base {
         }
         
         {
-         boost::unique_lock< boost::shared_mutex > lock(*(controller_costmap_ros_->getCostmap()->getLock()));
+         boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(controller_costmap_ros_->getCostmap()->getMutex()));
         
         if(tc_->computeVelocityCommands(cmd_vel)){
           ROS_DEBUG_NAMED( "move_base", "Got a valid command from the local planner: %.3lf, %.3lf, %.3lf",


### PR DESCRIPTION
This addresses possible empty costmap issue mentioned in https://github.com/ros-planning/navigation/issues/187#issuecomment-45051376

In order to properly hold costmap when calling resetMap, we need a recursive mutex. Since only costmap publisher was using a shared_lock, switching from shared_mutex to recursive should have no (runtime) downsides.

I've also changed getLock to getMutex -- since it actually returns a mutex, not a lock. In addition I have typedef'd the mutex type so that if we later change this again, it is less difficult to update everything properly.
