### PR TITLE
support rolling static map in any frame

### DIFF
--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -80,6 +80,7 @@ private:
   unsigned char interpretValue(unsigned char value);
 
   std::string global_frame_; ///< @brief The global frame for the costmap
+  std::string map_frame_;  /// @brief frame that map is located in
   bool subscribe_to_updates_;
   bool map_received_;
   bool has_updated_data_;


### PR DESCRIPTION
This expands on #324 and allows the rolling costmap global frame to be different from the map frame.
