### PR TITLE
Add a first_map_only parameter so we keep reusing the first received static map

### DIFF
--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -87,6 +87,7 @@ private:
   unsigned int x_,y_,width_,height_;
   bool track_unknown_space_;
   bool use_maximum_;
+  bool first_map_only_;      ///< @brief Store the first static map and reuse it on reinitializing
   bool trinary_costmap_;
   ros::Subscriber map_sub_, map_update_sub_;
 

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -66,6 +66,7 @@ void StaticLayer::onInitialize()
 
   std::string map_topic;
   nh.param("map_topic", map_topic, std::string("map"));
+  nh.param("first_map_only", first_map_only_, false);
   nh.param("subscribe_to_updates", subscribe_to_updates_, false);
 
   nh.param("track_unknown_space", track_unknown_space_, true);
@@ -200,6 +201,12 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
   height_ = size_y_;
   map_received_ = true;
   has_updated_data_ = true;
+
+  // shutdown the map subscrber if firt_map_only_ flag is on
+  if(first_map_only_) {
+    ROS_INFO("Shutting down the map subscriber. first_map_only flag is on");
+    map_sub_.shutdown();
+  }
 }
 
 void StaticLayer::incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr& update)
@@ -235,8 +242,13 @@ void StaticLayer::deactivate()
 
 void StaticLayer::reset()
 {
-  deactivate();
-  activate();
+  if(first_map_only_) {
+    has_updated_data_ = true;
+  }
+  else{
+   deactivate();
+   activate();
+  }
 }
 
 void StaticLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,


### PR DESCRIPTION
It is to follow up #150 and #329

@corot's note from old commit.

We need this for a rather exotic case: when using https://github.com/robotics-in-concert/rocon_multimaster/tree/hydro-devel/rocon_gateway, the first time we subscribe we get the map, but not in subsequent subscriptions due to clearing costmaps.
An easier solution is just to call shutdown in the map subscriber, but we still have a big delay until receiving the map, so this flag is much better option.
I didn't verify that it doesn't interfere with map updates (because is the first time I see this feature). Appart from this, we have the change running happily in our robots.
