### PR TITLE
Add missing angles dependecy

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -3,6 +3,7 @@ project(global_planner)
 
 find_package(catkin REQUIRED
   COMPONENTS
+    angles
     costmap_2d
     dynamic_reconfigure
     geometry_msgs

--- a/global_planner/package.xml
+++ b/global_planner/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>angles</build_depend>
   <build_depend>costmap_2d</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>geometry_msgs</build_depend>


### PR DESCRIPTION
https://github.com/ros-planning/navigation/commit/98894a70117de2d6fbe50c33d151faa808d9a752 uses angles' headers but there are no dependencies set in the CMakeLists.txt or package.xml.
