### PR TITLE
Costmap_2d linting

### DIFF
--- a/costmap_2d/include/costmap_2d/array_parser.h
+++ b/costmap_2d/include/costmap_2d/array_parser.h
@@ -28,8 +28,8 @@
  *
  * author: Dave Hershberger
  */
-#ifndef ARRAY_PARSER_H
-#define ARRAY_PARSER_H
+#ifndef COSTMAP_2D_ARRAY_PARSER_H
+#define COSTMAP_2D_ARRAY_PARSER_H
 
 #include <vector>
 #include <string>
@@ -48,4 +48,4 @@ std::vector<std::vector<float> > parseVVF(const std::string& input, std::string&
 
 }  // end namespace costmap_2d
 
-#endif  // ARRAY_PARSER_H
+#endif  // COSTMAP_2D_ARRAY_PARSER_H

--- a/costmap_2d/include/costmap_2d/array_parser.h
+++ b/costmap_2d/include/costmap_2d/array_parser.h
@@ -44,8 +44,8 @@ namespace costmap_2d
  *
  * On error, error_return is set and the return value could be
  * anything, like part of a successful parse. */
-std::vector<std::vector<float> > parseVVF( const std::string& input, std::string& error_return );
+std::vector<std::vector<float> > parseVVF(const std::string& input, std::string& error_return);
 
-} // end namespace costmap_2d
+}  // end namespace costmap_2d
 
-#endif // ARRAY_PARSER_H
+#endif  // ARRAY_PARSER_H

--- a/costmap_2d/include/costmap_2d/cost_values.h
+++ b/costmap_2d/include/costmap_2d/cost_values.h
@@ -44,4 +44,4 @@ static const unsigned char LETHAL_OBSTACLE = 254;
 static const unsigned char INSCRIBED_INFLATED_OBSTACLE = 253;
 static const unsigned char FREE_SPACE = 0;
 }
-#endif
+#endif  // COSTMAP_COST_VALUES_H_

--- a/costmap_2d/include/costmap_2d/cost_values.h
+++ b/costmap_2d/include/costmap_2d/cost_values.h
@@ -34,8 +34,8 @@
  *
  * Author: Eitan Marder-Eppstein
  *********************************************************************/
-#ifndef COSTMAP_COST_VALUES_H_
-#define COSTMAP_COST_VALUES_H_
+#ifndef COSTMAP_2D_COST_VALUES_H_
+#define COSTMAP_2D_COST_VALUES_H_
 /** Provides a mapping for often used cost values */
 namespace costmap_2d
 {
@@ -44,4 +44,4 @@ static const unsigned char LETHAL_OBSTACLE = 254;
 static const unsigned char INSCRIBED_INFLATED_OBSTACLE = 253;
 static const unsigned char FREE_SPACE = 0;
 }
-#endif  // COSTMAP_COST_VALUES_H_
+#endif  // COSTMAP_2D_COST_VALUES_H_

--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -35,8 +35,8 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_COSTMAP_2D_H_
-#define COSTMAP_COSTMAP_2D_H_
+#ifndef COSTMAP_2D_COSTMAP_2D_H_
+#define COSTMAP_2D_COSTMAP_2D_H_
 
 #include <vector>
 #include <queue>
@@ -466,4 +466,4 @@ protected:
 };
 }  // namespace costmap_2d
 
-#endif  // COSTMAP_2D_H
+#endif  // COSTMAP_2D_COSTMAP_2D_H

--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -46,7 +46,7 @@
 namespace costmap_2d
 {
 
-//convenient for storing x/y point pairs
+// convenient for storing x/y point pairs
 struct MapLocation
 {
   unsigned int x;
@@ -59,7 +59,7 @@ struct MapLocation
  */
 class Costmap2D
 {
-  friend class CostmapTester; //Need this for gtest to work correctly
+  friend class CostmapTester;  // Need this for gtest to work correctly
 public:
   /**
    * @brief  Constructor for a costmap
@@ -317,11 +317,11 @@ protected:
                        unsigned int dm_lower_left_y, unsigned int dm_size_x, unsigned int region_size_x,
                        unsigned int region_size_y)
     {
-      //we'll first need to compute the starting points for each map
+      // we'll first need to compute the starting points for each map
       data_type* sm_index = source_map + (sm_lower_left_y * sm_size_x + sm_lower_left_x);
       data_type* dm_index = dest_map + (dm_lower_left_y * dm_size_x + dm_lower_left_x);
 
-      //now, we'll copy the source map into the destination map
+      // now, we'll copy the source map into the destination map
       for (unsigned int i = 0; i < region_size_y; ++i)
       {
         memcpy(dm_index, sm_index, region_size_x * sizeof(data_type));
@@ -371,11 +371,11 @@ protected:
 
       unsigned int offset = y0 * size_x_ + x0;
 
-      //we need to chose how much to scale our dominant dimension, based on the maximum length of the line
+      // we need to chose how much to scale our dominant dimension, based on the maximum length of the line
       double dist = hypot(dx, dy);
       double scale = (dist == 0.0) ? 1.0 : std::min(1.0, max_length / dist);
 
-      //if x is dominant
+      // if x is dominant
       if (abs_dx >= abs_dy)
       {
         int error_y = abs_dx / 2;
@@ -383,10 +383,9 @@ protected:
         return;
       }
 
-      //otherwise y is dominant
+      // otherwise y is dominant
       int error_x = abs_dy / 2;
       bresenham2D(at, abs_dy, abs_dx, error_x, offset_dy, offset_dx, offset, (unsigned int)(scale * abs_dy));
-
     }
 
 private:
@@ -451,7 +450,7 @@ protected:
     {
     }
 
-    //just push the relevant cells back onto the list
+    // just push the relevant cells back onto the list
     inline void operator()(unsigned int offset)
     {
       MapLocation loc;
@@ -465,6 +464,6 @@ protected:
     std::vector<MapLocation>& cells_;
   };
 };
-}
+}  // namespace costmap_2d
 
-#endif
+#endif  // COSTMAP_2D_H

--- a/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
@@ -35,8 +35,8 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_COSTMAP_2D_PUBLISHER_H_
-#define COSTMAP_COSTMAP_2D_PUBLISHER_H_
+#ifndef COSTMAP_2D_COSTMAP_2D_PUBLISHER_H_
+#define COSTMAP_2D_COSTMAP_2D_PUBLISHER_H_
 #include <ros/ros.h>
 #include <costmap_2d/costmap_2d.h>
 #include <nav_msgs/OccupancyGrid.h>
@@ -105,4 +105,4 @@ private:
   static char* cost_translation_table_;  ///< Translate from 0-255 values in costmap to -1 to 100 values in message.
 };
 }  // namespace costmap_2d
-#endif  // COSTMAP_2D_PUBLISHER_H
+#endif  // COSTMAP_2D_COSTMAP_2D_PUBLISHER_H

--- a/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
@@ -55,7 +55,8 @@ public:
   /**
    * @brief  Constructor for the Costmap2DPublisher
    */
-  Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* costmap, std::string global_frame, std::string topic_name, bool always_send_full_costmap = false);
+  Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* costmap, std::string global_frame,
+                     std::string topic_name, bool always_send_full_costmap = false);
 
   /**
    * @brief  Destructor
@@ -90,7 +91,7 @@ private:
   void prepareGrid();
 
   /** @brief Publish the latest full costmap to the new subscriber. */
-  void onNewSubscription( const ros::SingleSubscriberPublisher& pub );
+  void onNewSubscription(const ros::SingleSubscriberPublisher& pub);
 
   ros::NodeHandle* node;
   Costmap2D* costmap_;
@@ -101,7 +102,7 @@ private:
   ros::Publisher costmap_pub_;
   ros::Publisher costmap_update_pub_;
   nav_msgs::OccupancyGrid grid_;
-  static char* cost_translation_table_; ///< Translate from 0-255 values in costmap to -1 to 100 values in message.
+  static char* cost_translation_table_;  ///< Translate from 0-255 values in costmap to -1 to 100 values in message.
 };
-}
-#endif
+}  // namespace costmap_2d
+#endif  // COSTMAP_2D_PUBLISHER_H

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -154,7 +154,7 @@ public:
   /** @brief Returns the current padded footprint as a geometry_msgs::Polygon. */
   geometry_msgs::Polygon getRobotFootprintPolygon()
   {
-    return costmap_2d::toPolygon( padded_footprint_ );
+    return costmap_2d::toPolygon( padded_footprint_);
   }
 
   /** @brief Return the current footprint of the robot as a vector of points.
@@ -189,7 +189,8 @@ public:
    * @param  theta The orientation of the robot
    * @param  oriented_footprint Will be filled with the points in the oriented footprint of the robot
    */
-  void getOrientedFootprint(double x, double y, double theta, std::vector<geometry_msgs::Point>& oriented_footprint) const;
+  void getOrientedFootprint(double x, double y, double theta,
+                            std::vector<geometry_msgs::Point>& oriented_footprint) const;
 
   /**
    * @brief  Build the oriented footprint of the robot at the robot's current pose
@@ -207,7 +208,7 @@ public:
    * layered_costmap_->setFootprint().  Also saves the unpadded
    * footprint, which is available from
    * getUnpaddedRobotFootprint(). */
-  void setUnpaddedRobotFootprint( const std::vector<geometry_msgs::Point>& points );
+  void setUnpaddedRobotFootprint(const std::vector<geometry_msgs::Point>& points);
 
   /** @brief Set the footprint of the robot to be the given polygon,
    * padded by footprint_padding.
@@ -219,7 +220,7 @@ public:
    * layered_costmap_->setFootprint().  Also saves the unpadded
    * footprint, which is available from
    * getUnpaddedRobotFootprint(). */
-  void setUnpaddedRobotFootprintPolygon( const geometry_msgs::Polygon& footprint );
+  void setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon& footprint);
 
 protected:
   LayeredCostmap* layered_costmap_;
@@ -227,30 +228,30 @@ protected:
   tf::TransformListener& tf_;  ///< @brief Used for transforming point clouds
   std::string global_frame_;  ///< @brief The global frame for the costmap
   std::string robot_base_frame_;  ///< @brief The frame_id of the robot base
-  double transform_tolerance_; ///< timeout before transform errors
+  double transform_tolerance_;  ///< timeout before transform errors
 
 private:
   /** @brief Set the footprint from the given string.
    *
-   * Format should be bracketed array of arrays of floats, like so: [[1.0, 2.2], [3.3, 4.2], ...] 
+   * Format should be bracketed array of arrays of floats, like so: [[1.0, 2.2], [3.3, 4.2], ...]
    * @return true on success, false on failure. */
-  bool readFootprintFromString( const std::string& footprint_string );
+  bool readFootprintFromString(const std::string& footprint_string);
 
   /** @brief Set the footprint from the new_config object.
    *
    * If the values of footprint and robot_radius are the same in
    * new_config and old_config, nothing is changed. */
-  void readFootprintFromConfig( const costmap_2d::Costmap2DConfig &new_config,
-                                const costmap_2d::Costmap2DConfig &old_config );
+  void readFootprintFromConfig(const costmap_2d::Costmap2DConfig &new_config,
+                               const costmap_2d::Costmap2DConfig &old_config);
 
   /** @brief Set the footprint to a circle of the given radius, in meters. */
-  void setFootprintFromRadius( double radius );
-  
+  void setFootprintFromRadius(double radius);
+
   /** @brief Read the ros-params "footprint" and/or "robot_radius" from
    * the given NodeHandle using searchParam() to go up the tree.
    *
    * Calls setFootprint() when successful. */
-  void readFootprintFromParams( ros::NodeHandle& nh );
+  void readFootprintFromParams(ros::NodeHandle& nh);
 
   /** @brief Set the footprint from the given XmlRpcValue.
    *
@@ -262,13 +263,13 @@ private:
    * @param full_param_name this is the full name of the rosparam from
    * which the footprint_xmlrpc value came.  It is used only for
    * reporting errors. */
-  void readFootprintFromXMLRPC( XmlRpc::XmlRpcValue& footprint_xmlrpc,
-                                const std::string& full_param_name );
+  void readFootprintFromXMLRPC(XmlRpc::XmlRpcValue& footprint_xmlrpc,
+                                const std::string& full_param_name);
 
   /** @brief Write the current unpadded_footprint_ to the "footprint"
    * parameter of the given NodeHandle so that dynamic_reconfigure
    * will see the new value. */
-  void writeFootprintToParam( ros::NodeHandle& nh );
+  void writeFootprintToParam(ros::NodeHandle& nh);
 
   void resetOldParameters(ros::NodeHandle& nh);
   void reconfigureCB(costmap_2d::Costmap2DConfig &config, uint32_t level);
@@ -295,6 +296,6 @@ private:
   costmap_2d::Costmap2DConfig old_config_;
 };
 // class Costmap2DROS
-}// namespace costmap_2d
+}  // namespace costmap_2d
 
-#endif
+#endif  // COSTMAP_2D_ROS_H

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -154,7 +154,7 @@ public:
   /** @brief Returns the current padded footprint as a geometry_msgs::Polygon. */
   geometry_msgs::Polygon getRobotFootprintPolygon()
   {
-    return costmap_2d::toPolygon( padded_footprint_);
+    return costmap_2d::toPolygon(padded_footprint_);
   }
 
   /** @brief Return the current footprint of the robot as a vector of points.

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -35,8 +35,8 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_COSTMAP_2D_ROS_H_
-#define COSTMAP_COSTMAP_2D_ROS_H_
+#ifndef COSTMAP_2D_COSTMAP_2D_ROS_H_
+#define COSTMAP_2D_COSTMAP_2D_ROS_H_
 
 #include <costmap_2d/layered_costmap.h>
 #include <costmap_2d/layer.h>
@@ -298,4 +298,4 @@ private:
 // class Costmap2DROS
 }  // namespace costmap_2d
 
-#endif  // COSTMAP_2D_ROS_H
+#endif  // COSTMAP_2D_COSTMAP_2D_ROS_H

--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -47,8 +47,8 @@ namespace costmap_2d
 class CostmapLayer : public Layer, public Costmap2D
 {
 public:
-  CostmapLayer() : has_extra_bounds_(false), 
-    extra_min_x_( 1e6), extra_min_y_( 1e6),
+  CostmapLayer() : has_extra_bounds_(false),
+    extra_min_x_(1e6), extra_min_y_(1e6),
     extra_max_x_(-1e6), extra_max_y_(-1e6) {}
 
   bool isDiscretized()
@@ -57,11 +57,11 @@ public:
   }
 
   virtual void matchSize();
-  
+
   /**
-   * If an external source changes values in the costmap, 
+   * If an external source changes values in the costmap,
    * it should call this method with the area that it changed
-   * to ensure that the costmap includes this region as well. 
+   * to ensure that the costmap includes this region as well.
    * @param mx0 Minimum x value of the bounding box
    * @param my0 Minimum y value of the bounding box
    * @param mx1 Maximum x value of the bounding box
@@ -70,49 +70,48 @@ public:
   void addExtraBounds(double mx0, double my0, double mx1, double my1);
 
 protected:
-
   /*
-   * Updates the master_grid within the specified 
-   * bounding box using this layer's values. 
+   * Updates the master_grid within the specified
+   * bounding box using this layer's values.
    *
    * TrueOverwrite means every value from this layer
    * is written into the master grid.
    */
   void updateWithTrueOverwrite(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
-  
+
   /*
-   * Updates the master_grid within the specified 
-   * bounding box using this layer's values. 
+   * Updates the master_grid within the specified
+   * bounding box using this layer's values.
    *
    * Overwrite means every valid value from this layer
    * is written into the master grid (does not copy NO_INFORMATION)
    */
-  void updateWithOverwrite    (costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
-  
+  void updateWithOverwrite(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+
   /*
-   * Updates the master_grid within the specified 
-   * bounding box using this layer's values. 
+   * Updates the master_grid within the specified
+   * bounding box using this layer's values.
    *
-   * Sets the new value to the maximum of the master_grid's value 
+   * Sets the new value to the maximum of the master_grid's value
    * and this layer's value. If the master value is NO_INFORMATION,
-   * it is overwritten. If the layer's value is NO_INFORMATION, 
-   * the master value does not change. 
+   * it is overwritten. If the layer's value is NO_INFORMATION,
+   * the master value does not change.
    */
-  void updateWithMax          (costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
-  
+  void updateWithMax(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+
   /*
-   * Updates the master_grid within the specified 
-   * bounding box using this layer's values. 
+   * Updates the master_grid within the specified
+   * bounding box using this layer's values.
    *
-   * Sets the new value to the sum of the master grid's value 
+   * Sets the new value to the sum of the master grid's value
    * and this layer's value. If the master value is NO_INFORMATION,
-   * it is overwritten with the layer's value. If the layer's value 
-   * is NO_INFORMATION, then the master value does not change. 
+   * it is overwritten with the layer's value. If the layer's value
+   * is NO_INFORMATION, then the master value does not change.
    *
    * If the sum value is larger than INSCRIBED_INFLATED_OBSTACLE,
    * the master value is set to (INSCRIBED_INFLATED_OBSTACLE - 1).
    */
-  void updateWithAddition     (costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+  void updateWithAddition(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
   /**
    * Updates the bounding box specified in the parameters to include
@@ -126,14 +125,14 @@ protected:
    * @param max_y bounding box
    */
   void touch(double x, double y, double* min_x, double* min_y, double* max_x, double* max_y);
-  
+
   /*
    * Updates the bounding box specified in the parameters
    * to include the bounding box from the addExtraBounds
    * call. If addExtraBounds was not called, the method will do nothing.
    *
    * Should be called at the beginning of the updateBounds method
-   * 
+   *
    * @param min_x bounding box (input and output)
    * @param min_y bounding box (input and output)
    * @param max_x bounding box (input and output)
@@ -141,11 +140,10 @@ protected:
    */
   void useExtraBounds(double* min_x, double* min_y, double* max_x, double* max_y);
   bool has_extra_bounds_;
-  
+
 private:
   double extra_min_x_, extra_max_x_, extra_min_y_, extra_max_y_;
 };
 
 }  // namespace costmap_2d
-
 #endif  // COSTMAP_2D_COSTMAP_LAYER_H_

--- a/costmap_2d/include/costmap_2d/costmap_math.h
+++ b/costmap_2d/include/costmap_2d/costmap_math.h
@@ -66,4 +66,4 @@ bool intersects(std::vector<geometry_msgs::Point>& polygon, float testx, float t
 
 bool intersects(std::vector<geometry_msgs::Point>& polygon1, std::vector<geometry_msgs::Point>& polygon2);
 
-#endif
+#endif  // COSTMAP_MATH_H_

--- a/costmap_2d/include/costmap_2d/costmap_math.h
+++ b/costmap_2d/include/costmap_2d/costmap_math.h
@@ -35,8 +35,8 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_MATH_H_
-#define COSTMAP_MATH_H_
+#ifndef COSTMAP_2D_COSTMAP_MATH_H_
+#define COSTMAP_2D_COSTMAP_MATH_H_
 
 #include <math.h>
 #include <algorithm>
@@ -66,4 +66,4 @@ bool intersects(std::vector<geometry_msgs::Point>& polygon, float testx, float t
 
 bool intersects(std::vector<geometry_msgs::Point>& polygon1, std::vector<geometry_msgs::Point>& polygon2);
 
-#endif  // COSTMAP_MATH_H_
+#endif  // COSTMAP_2D_COSTMAP_MATH_H_

--- a/costmap_2d/include/costmap_2d/footprint.h
+++ b/costmap_2d/include/costmap_2d/footprint.h
@@ -46,12 +46,13 @@
 namespace costmap_2d
 {
 
-void calculateMinAndMaxDistances(const std::vector<geometry_msgs::Point>& footprint, double& min_dist, double& max_dist);
-geometry_msgs::Point              toPoint      (geometry_msgs::Point32 pt);
-geometry_msgs::Point32            toPoint32    (geometry_msgs::Point   pt);
-geometry_msgs::Polygon            toPolygon    (std::vector<geometry_msgs::Point> pts);
+void calculateMinAndMaxDistances(const std::vector<geometry_msgs::Point>& footprint,
+                                 double& min_dist, double& max_dist);
+geometry_msgs::Point              toPoint(geometry_msgs::Point32 pt);
+geometry_msgs::Point32            toPoint32(geometry_msgs::Point   pt);
+geometry_msgs::Polygon            toPolygon(std::vector<geometry_msgs::Point> pts);
 std::vector<geometry_msgs::Point> toPointVector(geometry_msgs::Polygon polygon);
 
-} // end namespace costmap_2d
+}  // end namespace costmap_2d
 
-#endif
+#endif  // _FOOTPRINT_HELPER_H

--- a/costmap_2d/include/costmap_2d/footprint.h
+++ b/costmap_2d/include/costmap_2d/footprint.h
@@ -35,8 +35,8 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef _FOOTPRINT_HELPER_H
-#define _FOOTPRINT_HELPER_H
+#ifndef COSTMAP_2D_FOOTPRINT_H
+#define COSTMAP_2D_FOOTPRINT_H
 
 #include <ros/ros.h>
 #include <geometry_msgs/Polygon.h>
@@ -55,4 +55,4 @@ std::vector<geometry_msgs::Point> toPointVector(geometry_msgs::Polygon polygon);
 
 }  // end namespace costmap_2d
 
-#endif  // _FOOTPRINT_HELPER_H
+#endif  // COSTMAP_2D_FOOTPRINT_H

--- a/costmap_2d/include/costmap_2d/footprint_layer.h
+++ b/costmap_2d/include/costmap_2d/footprint_layer.h
@@ -62,7 +62,7 @@ public:
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
 private:
-  geometry_msgs::PolygonStamped footprint_; ///< Storage for polygon being published.
+  geometry_msgs::PolygonStamped footprint_;  ///< Storage for polygon being published.
   void publishFootprint();
   void reconfigureCB(costmap_2d::GenericPluginConfig &config, uint32_t level);
   ros::Publisher footprint_pub_;

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -91,13 +91,13 @@ public:
   virtual ~InflationLayer()
   {
     deleteKernels();
-    if(dsrv_)
+    if (dsrv_)
         delete dsrv_;
   }
 
   virtual void onInitialize();
-  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
-                             double* max_y);
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y);
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
   virtual bool isDiscretized()
   {
@@ -119,7 +119,7 @@ public:
       cost = INSCRIBED_INFLATED_OBSTACLE;
     else
     {
-      //make sure cost falls off by Euclidean distance
+      // make sure cost falls off by Euclidean distance
       double euclidean_distance = distance * resolution_;
       double factor = exp(-1.0 * weight_ * (euclidean_distance - inscribed_radius_));
       cost = (unsigned char)((INSCRIBED_INFLATED_OBSTACLE - 1) * factor);
@@ -190,7 +190,7 @@ private:
   dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig> *dsrv_;
   void reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level);
 
-  bool need_reinflation_; ///< Indicates that the entire costmap should be reinflated next time around.
+  bool need_reinflation_;  ///< Indicates that the entire costmap should be reinflated next time around.
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -34,8 +34,8 @@
  *
  * Author: David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_2D_COSTMAP_2D_LAYER_H_
-#define COSTMAP_2D_COSTMAP_2D_LAYER_H_
+#ifndef COSTMAP_2D_LAYER_H_
+#define COSTMAP_2D_LAYER_H_
 
 #include <costmap_2d/costmap_2d.h>
 #include <costmap_2d/layered_costmap.h>
@@ -131,4 +131,4 @@ private:
 
 }  // namespace costmap_2d
 
-#endif  // COSTMAP_2D_COSTMAP_2D_LAYER_H_
+#endif  // COSTMAP_2D_LAYER_H_

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -52,7 +52,7 @@ class Layer
 public:
   Layer();
 
-  void initialize( LayeredCostmap* parent, std::string name, tf::TransformListener *tf );
+  void initialize(LayeredCostmap* parent, std::string name, tf::TransformListener *tf);
 
   /**
    * @brief This is called by the LayeredCostmap to poll this plugin as to how
@@ -81,15 +81,15 @@ public:
 
   virtual ~Layer() {}
 
-  /** 
-   * @brief Check to make sure all the data in the layer is up to date. 
-   *        If the layer is not up to date, then it may be unsafe to 
-   *        plan using the data from this layer, and the planner may 
-   *        need to know. 
+  /**
+   * @brief Check to make sure all the data in the layer is up to date.
+   *        If the layer is not up to date, then it may be unsafe to
+   *        plan using the data from this layer, and the planner may
+   *        need to know.
    *
    *        A layer's current state should be managed by the protected
    *        variable current_.
-   * @return Whether the data in the layer is up to date. 
+   * @return Whether the data in the layer is up to date.
    */
   bool isCurrent() const
   {
@@ -121,7 +121,7 @@ protected:
 
   LayeredCostmap* layered_costmap_;
   bool current_;
-  bool enabled_; ///< Currently this var is managed by subclasses.  TODO: make this managed by this class and/or container class.
+  bool enabled_;  ///< Currently this var is managed by subclasses. TODO: make this managed by this class and/or container class.
   std::string name_;
   tf::TransformListener* tf_;
 

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -101,7 +101,7 @@ public:
 
   bool isTrackingUnknown()
   {
-    return costmap_.getDefaultValue()==costmap_2d::NO_INFORMATION;
+    return costmap_.getDefaultValue() == costmap_2d::NO_INFORMATION;
   }
 
   std::vector<boost::shared_ptr<Layer> >* getPlugins()

--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2008, 2013, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -67,9 +67,10 @@ public:
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
    * @param raytrace_range The range out to which an observation should be able to clear via raytracing
    */
-  Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud, double obstacle_range,
-              double raytrace_range) :
-      origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), obstacle_range_(obstacle_range), raytrace_range_(raytrace_range)
+  Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
+              double obstacle_range, double raytrace_range) :
+      origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
+      obstacle_range_(obstacle_range), raytrace_range_(raytrace_range)
   {
   }
 
@@ -78,8 +79,8 @@ public:
    * @param obs The observation to copy
    */
   Observation(const Observation& obs) :
-      origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))), obstacle_range_(obs.obstacle_range_), raytrace_range_(
-          obs.raytrace_range_)
+      origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))),
+      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_)
   {
   }
 
@@ -98,5 +99,5 @@ public:
   double obstacle_range_, raytrace_range_;
 };
 
-}
-#endif
+} // namespace costmap_2d
+#endif  // COSTMAP_OBSERVATION_H_

--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -29,8 +29,8 @@
  * Authors: Conor McGann
  */
 
-#ifndef COSTMAP_OBSERVATION_H_
-#define COSTMAP_OBSERVATION_H_
+#ifndef COSTMAP_2D_OBSERVATION_H_
+#define COSTMAP_2D_OBSERVATION_H_
 
 #include <geometry_msgs/Point.h>
 #include <pcl/point_types.h>
@@ -99,5 +99,5 @@ public:
   double obstacle_range_, raytrace_range_;
 };
 
-} // namespace costmap_2d
-#endif  // COSTMAP_OBSERVATION_H_
+}  // namespace costmap_2d
+#endif  // COSTMAP_2D_OBSERVATION_H_

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -34,8 +34,8 @@
  *
  * Author: Eitan Marder-Eppstein
  *********************************************************************/
-#ifndef COSTMAP_OBSERVATION_BUFFER_H_
-#define COSTMAP_OBSERVATION_BUFFER_H_
+#ifndef COSTMAP_2D_OBSERVATION_BUFFER_H_
+#define COSTMAP_2D_OBSERVATION_BUFFER_H_
 
 #include <vector>
 #include <list>
@@ -161,4 +161,4 @@ private:
   double tf_tolerance_;
 };
 }  // namespace costmap_2d
-#endif  // COSTMAP_OBSERVATION_BUFFER_H_
+#endif  // COSTMAP_2D_OBSERVATION_BUFFER_H_

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -45,7 +45,7 @@
 #include <tf/transform_listener.h>
 #include <tf/transform_datatypes.h>
 
-//PCL Stuff
+// PCL Stuff
 #include <pcl/point_cloud.h>
 #include <sensor_msgs/PointCloud2.h>
 
@@ -156,9 +156,9 @@ private:
   std::list<Observation> observation_list_;
   std::string topic_name_;
   double min_obstacle_height_, max_obstacle_height_;
-  boost::recursive_mutex lock_; ///< @brief A lock for accessing data in callbacks safely
+  boost::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
   double obstacle_range_, raytrace_range_;
   double tf_tolerance_;
 };
-}
-#endif
+}  // namespace costmap_2d
+#endif  // COSTMAP_OBSERVATION_BUFFER_H_

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -64,13 +64,13 @@ class ObstacleLayer : public CostmapLayer
 public:
   ObstacleLayer()
   {
-    costmap_ = NULL; // this is the unsigned char* member of parent class Costmap2D.
+    costmap_ = NULL;  // this is the unsigned char* member of parent class Costmap2D.
   }
 
   virtual ~ObstacleLayer();
   virtual void onInitialize();
-  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
-                             double* max_y);
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y);
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
   virtual void activate();
@@ -86,12 +86,12 @@ public:
                          const boost::shared_ptr<costmap_2d::ObservationBuffer>& buffer);
 
    /**
-    * @brief  A callback to handle buffering LaserScan messages which need to be filtered to turn Inf values into range_max.
-    * @param message The message returned from a message notifier 
+    * @brief A callback to handle buffering LaserScan messages which need filtering to turn Inf values into range_max.
+    * @param message The message returned from a message notifier
     * @param buffer A pointer to the observation buffer to update
     */
-   void laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr& message, 
-                                  const boost::shared_ptr<ObservationBuffer>& buffer);
+  void laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr& message,
+                                 const boost::shared_ptr<ObservationBuffer>& buffer);
 
   /**
    * @brief  A callback to handle buffering PointCloud messages
@@ -114,7 +114,6 @@ public:
   void clearStaticObservations(bool marking, bool clearing);
 
 protected:
-
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
 
   /**
@@ -148,16 +147,16 @@ protected:
   /** @brief Overridden from superclass Layer to pass new footprint into footprint_layer_. */
   virtual void onFootprintChanged();
 
-  std::string global_frame_; ///< @brief The global frame for the costmap
-  double max_obstacle_height_; ///< @brief Max Obstacle Height
+  std::string global_frame_;  ///< @brief The global frame for the costmap
+  double max_obstacle_height_;  ///< @brief Max Obstacle Height
 
-  laser_geometry::LaserProjection projector_; ///< @brief Used to project laser scans into point clouds
+  laser_geometry::LaserProjection projector_;  ///< @brief Used to project laser scans into point clouds
 
-  std::vector<boost::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_; ///< @brief Used for the observation message filters
-  std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_; ///< @brief Used to make sure that transforms are available for each sensor
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_; ///< @brief Used to store observations from various sensors
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_; ///< @brief Used to store observation buffers used for marking obstacles
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_; ///< @brief Used to store observation buffers used for clearing obstacles
+  std::vector<boost::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_;  ///< @brief Used for the observation message filters
+  std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_;  ///< @brief Used to make sure that transforms are available for each sensor
+  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_;  ///< @brief Used to store observations from various sensors
+  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_;  ///< @brief Used to store observation buffers used for marking obstacles
+  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_;  ///< @brief Used to store observation buffers used for clearing obstacles
 
   // Used only for testing purposes
   std::vector<costmap_2d::Observation> static_clearing_observations_, static_marking_observations_;
@@ -165,8 +164,8 @@ protected:
   bool rolling_window_;
   dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig> *dsrv_;
 
-  FootprintLayer footprint_layer_; ///< @brief clears the footprint in this obstacle layer.
-  
+  FootprintLayer footprint_layer_;  ///< @brief clears the footprint in this obstacle layer.
+
   int combination_method_;
 
 private:

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -142,7 +142,7 @@ protected:
                                  double* max_x, double* max_y);
 
   void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
-			    double* max_x, double* max_y);
+                            double* max_x, double* max_y);
 
   /** @brief Overridden from superclass Layer to pass new footprint into footprint_layer_. */
   virtual void onFootprintChanged();

--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -60,8 +60,8 @@ public:
   virtual void deactivate();
   virtual void reset();
 
-  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
-                             double* max_y);
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y);
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
   virtual void matchSize();
@@ -79,12 +79,12 @@ private:
 
   unsigned char interpretValue(unsigned char value);
 
-  std::string global_frame_; ///< @brief The global frame for the costmap
+  std::string global_frame_;  ///< @brief The global frame for the costmap
   std::string map_frame_;  /// @brief frame that map is located in
   bool subscribe_to_updates_;
   bool map_received_;
   bool has_updated_data_;
-  unsigned int x_,y_,width_,height_;
+  unsigned int x_, y_, width_, height_;
   bool track_unknown_space_;
   bool use_maximum_;
   bool first_map_only_;      ///< @brief Store the first static map and reuse it on reinitializing

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -21,7 +21,7 @@ void setValues(costmap_2d::Costmap2D& costmap, const unsigned char* map)
 
 char printableCost(unsigned char cost)
 {
-  switch ( cost)
+  switch (cost)
   {
   case costmap_2d::NO_INFORMATION: return '?';
   case costmap_2d::LETHAL_OBSTACLE: return 'L';

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -1,5 +1,5 @@
-#ifndef TESTING_HELPER_H
-#define TESTING_HELPER_H
+#ifndef COSTMAP_2D_TESTING_HELPER_H
+#define COSTMAP_2D_TESTING_HELPER_H
 
 #include<costmap_2d/cost_values.h>
 #include<costmap_2d/costmap_2d.h>
@@ -99,4 +99,4 @@ costmap_2d::InflationLayer* addInflationLayer(costmap_2d::LayeredCostmap& layers
 }
 
 
-#endif  // TESTING_HELPER_H
+#endif  // COSTMAP_2D_TESTING_HELPER_H

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -9,19 +9,19 @@
 
 const double MAX_Z(1.0);
 
-void setValues( costmap_2d::Costmap2D& costmap, const unsigned char* map )
+void setValues(costmap_2d::Costmap2D& costmap, const unsigned char* map)
 {
-  int index=0;
-  for(int i=0;i<costmap.getSizeInCellsY();i++){
-    for(int j=0;j<costmap.getSizeInCellsX();j++){
-      costmap.setCost(j,i,map[index]);
+  int index = 0;
+  for (int i = 0; i < costmap.getSizeInCellsY(); i++){
+    for (int j = 0; j < costmap.getSizeInCellsX(); j++){
+      costmap.setCost(j, i, map[index]);
     }
   }
 }
 
-char printableCost( unsigned char cost )
+char printableCost(unsigned char cost)
 {
-  switch( cost )
+  switch ( cost)
   {
   case costmap_2d::NO_INFORMATION: return '?';
   case costmap_2d::LETHAL_OBSTACLE: return 'L';
@@ -31,24 +31,24 @@ char printableCost( unsigned char cost )
   }
 }
 
-void printMap( costmap_2d::Costmap2D& costmap )
+void printMap(costmap_2d::Costmap2D& costmap)
 {
   printf("map:\n");
-  for(int i=0;i<costmap.getSizeInCellsY();i++){
-    for(int j=0;j<costmap.getSizeInCellsX();j++){
-      printf("%4d", int(costmap.getCost(j,i) ));
+  for (int i = 0; i < costmap.getSizeInCellsY(); i++){
+    for (int j = 0; j < costmap.getSizeInCellsX(); j++){
+      printf("%4d", int(costmap.getCost(j, i)));
     }
     printf("\n\n");
   }
 }
 
-unsigned int countValues( costmap_2d::Costmap2D& costmap, unsigned char value, bool equal=true)
+unsigned int countValues(costmap_2d::Costmap2D& costmap, unsigned char value, bool equal = true)
 {
   unsigned int count = 0;
-  for(int i=0;i<costmap.getSizeInCellsY();i++){
-    for(int j=0;j<costmap.getSizeInCellsX();j++){
-      unsigned char c = costmap.getCost(j,i);
-      if((equal && c==value) || (!equal && c!=value))
+  for (int i = 0; i < costmap.getSizeInCellsY(); i++){
+    for (int j = 0; j < costmap.getSizeInCellsX(); j++){
+      unsigned char c = costmap.getCost(j, i);
+      if ((equal && c == value) || (!equal && c != value))
       {
         count+=1;
       }
@@ -60,7 +60,7 @@ unsigned int countValues( costmap_2d::Costmap2D& costmap, unsigned char value, b
 void addStaticLayer(costmap_2d::LayeredCostmap& layers, tf::TransformListener& tf)
 {
   costmap_2d::StaticLayer* slayer = new costmap_2d::StaticLayer();
-  layers.addPlugin( boost::shared_ptr<costmap_2d::Layer>(slayer) );
+  layers.addPlugin(boost::shared_ptr<costmap_2d::Layer>(slayer));
   slayer->initialize(&layers, "static", &tf);
 }
 
@@ -68,11 +68,12 @@ costmap_2d::ObstacleLayer* addObstacleLayer(costmap_2d::LayeredCostmap& layers, 
 {
   costmap_2d::ObstacleLayer* olayer = new costmap_2d::ObstacleLayer();
   olayer->initialize(&layers, "obstacles", &tf);
-  layers.addPlugin( boost::shared_ptr<costmap_2d::Layer>(olayer) );
+  layers.addPlugin(boost::shared_ptr<costmap_2d::Layer>(olayer));
   return olayer;
 }
 
-void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z=0.0, double ox=0.0, double oy=0.0, double oz=MAX_Z){
+void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z = 0.0,
+                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z){
   pcl::PointCloud<pcl::PointXYZ> cloud;
   cloud.points.resize(1);
   cloud.points[0].x = x;
@@ -93,9 +94,9 @@ costmap_2d::InflationLayer* addInflationLayer(costmap_2d::LayeredCostmap& layers
   costmap_2d::InflationLayer* ilayer = new costmap_2d::InflationLayer();
   ilayer->initialize(&layers, "inflation", &tf);
   boost::shared_ptr<costmap_2d::Layer> ipointer(ilayer);
-  layers.addPlugin( ipointer );
+  layers.addPlugin(ipointer);
   return ilayer;
 }
 
 
-#endif
+#endif  // TESTING_HELPER_H

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -65,14 +65,14 @@ public:
   VoxelLayer() :
       voxel_grid_(0, 0, 0)
   {
-    costmap_ = NULL; // this is the unsigned char* member of parent class's parent class Costmap2D.
+    costmap_ = NULL;  // this is the unsigned char* member of parent class's parent class Costmap2D.
   }
 
   virtual ~VoxelLayer();
 
   virtual void onInitialize();
-  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
-                             double* max_y);
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y);
 
   void updateOrigin(double new_origin_x, double new_origin_y);
   bool isDiscretized()
@@ -134,7 +134,7 @@ private:
 
   inline void mapToWorld3D(unsigned int mx, unsigned int my, unsigned int mz, double& wx, double& wy, double& wz)
   {
-    //returns the center point of the cell
+    // returns the center point of the cell
     wx = origin_x_ + (mx + 0.5) * resolution_;
     wy = origin_y_ + (my + 0.5) * resolution_;
     wz = origin_z_ + (mz + 0.5) * z_resolution_;

--- a/costmap_2d/plugins/footprint_layer.cpp
+++ b/costmap_2d/plugins/footprint_layer.cpp
@@ -63,7 +63,7 @@ namespace costmap_2d
 
   FootprintLayer::~FootprintLayer()
   {
-    if(dsrv_)
+    if (dsrv_)
       delete dsrv_;
   }
 
@@ -74,14 +74,14 @@ namespace costmap_2d
 
   void FootprintLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x, double* max_y)
   {
-    if(!enabled_) return;
-    //update transformed polygon
+    if (!enabled_) return;
+    // update transformed polygon
     footprint_.header.stamp = ros::Time::now();
     footprint_.polygon.points.clear();
     double cos_th = cos(robot_yaw);
     double sin_th = sin(robot_yaw);
     const std::vector<geometry_msgs::Point>& footprint_spec = getFootprint();
-    for(unsigned int i = 0; i < footprint_spec.size(); ++i)
+    for (unsigned int i = 0; i < footprint_spec.size(); ++i)
     {
       geometry_msgs::Point32 new_pt;
       new_pt.x = robot_x + (footprint_spec[i].x * cos_th - footprint_spec[i].y * sin_th);
@@ -89,7 +89,7 @@ namespace costmap_2d
       footprint_.polygon.points.push_back(new_pt);
     }
 
-    for(unsigned int i=0; i < footprint_.polygon.points.size(); i++)
+    for (unsigned int i=0; i < footprint_.polygon.points.size(); i++)
     {
       double px = footprint_.polygon.points[i].x, py = footprint_.polygon.points[i].y;
       *min_x = std::min(px, *min_x);
@@ -102,7 +102,7 @@ namespace costmap_2d
 
   void FootprintLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
   {
-    if(!enabled_) return;
+    if (!enabled_) return;
     std::vector<geometry_msgs::Point> footprint_points = costmap_2d::toPointVector(footprint_.polygon);
     master_grid.setConvexPolygonCost(footprint_points, costmap_2d::FREE_SPACE);
   }

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -126,7 +126,7 @@ void InflationLayer::matchSize()
 void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
                                            double* min_y, double* max_x, double* max_y)
 {
-  if ( need_reinflation_ )
+  if (need_reinflation_)
   {
     // For some reason when I make these -<double>::max() it does not
     // work with Costmap2D::worldToMapEnforceBounds(), so I'm using

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -50,8 +50,8 @@ namespace costmap_2d
 {
 
 InflationLayer::InflationLayer()
-  : inflation_radius_( 0 )
-  , weight_( 0 )
+  : inflation_radius_(0)
+  , weight_(0)
   , cell_inflation_radius_(0)
   , cached_cell_inflation_radius_(0)
   , dsrv_(NULL)
@@ -77,7 +77,7 @@ void InflationLayer::onInitialize()
     dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig>::CallbackType cb = boost::bind(
         &InflationLayer::reconfigureCB, this, _1, _2);
 
-    if(dsrv_ != NULL){
+    if (dsrv_ != NULL){
       dsrv_->clearCallback();
       dsrv_->setCallback(cb);
     }
@@ -86,7 +86,6 @@ void InflationLayer::onInitialize()
       dsrv_ = new dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig>(ros::NodeHandle("~/" + name_));
       dsrv_->setCallback(cb);
     }
-
   }
 
   matchSize();
@@ -127,7 +126,7 @@ void InflationLayer::matchSize()
 void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
                                            double* min_y, double* max_x, double* max_y)
 {
-  if( need_reinflation_ )
+  if ( need_reinflation_ )
   {
     // For some reason when I make these -<double>::max() it does not
     // work with Costmap2D::worldToMapEnforceBounds(), so I'm using
@@ -143,12 +142,13 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 void InflationLayer::onFootprintChanged()
 {
   inscribed_radius_ = layered_costmap_->getInscribedRadius();
-  cell_inflation_radius_ = cellDistance( inflation_radius_ );
+  cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();
   need_reinflation_ = true;
 
-  ROS_DEBUG( "InflationLayer::onFootprintChanged(): num footprint points: %lu, inscribed_radius_ = %.3f, inflation_radius_ = %.3f",
-             layered_costmap_->getFootprint().size(), inscribed_radius_, inflation_radius_ );
+  ROS_DEBUG("InflationLayer::onFootprintChanged(): num footprint points: %lu,"
+            " inscribed_radius_ = %.3f, inflation_radius_ = %.3f",
+            layered_costmap_->getFootprint().size(), inscribed_radius_, inflation_radius_);
 }
 
 void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i,
@@ -158,7 +158,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
   if (!enabled_)
     return;
 
-  //make sure the inflation queue is empty at the beginning of the cycle (should always be true)
+  // make sure the inflation queue is empty at the beginning of the cycle (should always be true)
   ROS_ASSERT_MSG(inflation_queue_.empty(), "The inflation queue must be empty at the beginning of inflation");
 
   unsigned char* master_array = master_grid.getCharMap();
@@ -187,10 +187,10 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
   max_i += cell_inflation_radius_;
   max_j += cell_inflation_radius_;
 
-  min_i = std::max( 0, min_i );
-  min_j = std::max( 0, min_j );
-  max_i = std::min( int( size_x  ), max_i );
-  max_j = std::min( int( size_y  ), max_j );
+  min_i = std::max(0, min_i);
+  min_j = std::max(0, min_j);
+  max_i = std::min(int(size_x), max_i);
+  max_j = std::min(int(size_y), max_j);
 
   for (int j = min_j; j < max_j; j++)
   {
@@ -207,7 +207,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
 
   while (!inflation_queue_.empty())
   {
-    //get the highest priority cell and pop it off the priority queue
+    // get the highest priority cell and pop it off the priority queue
     const CellData& current_cell = inflation_queue_.top();
 
     unsigned int index = current_cell.index_;
@@ -216,10 +216,10 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     unsigned int sx = current_cell.src_x_;
     unsigned int sy = current_cell.src_y_;
 
-    //pop once we have our cell info
+    // pop once we have our cell info
     inflation_queue_.pop();
 
-    //attempt to put the neighbors of the current cell onto the queue
+    // attempt to put the neighbors of the current cell onto the queue
     if (mx > 0)
       enqueue(master_array, index - 1, mx - 1, my, sx, sy);
     if (my > 0)
@@ -229,7 +229,6 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     if (my < size_y - 1)
       enqueue(master_array, index + size_x, mx, my + 1, sx, sy);
   }
-
 }
 
 /**
@@ -244,18 +243,17 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
 inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my,
                                             unsigned int src_x, unsigned int src_y)
 {
-
-  //set the cost of the cell being inserted
+  // set the cost of the cell being inserted
   if (!seen_[index])
   {
-    //we compute our distance table one cell further than the inflation radius dictates so we can make the check below
+    // we compute our distance table one cell further than the inflation radius dictates so we can make the check below
     double distance = distanceLookup(mx, my, src_x, src_y);
 
-    //we only want to put the cell in the queue if it is within the inflation radius of the obstacle point
+    // we only want to put the cell in the queue if it is within the inflation radius of the obstacle point
     if (distance > cell_inflation_radius_)
       return;
 
-    //assign the cost associated with the distance from an obstacle to the cell
+    // assign the cost associated with the distance from an obstacle to the cell
     unsigned char cost = costLookup(mx, my, src_x, src_y);
     unsigned char old_cost = grid[index];
 
@@ -263,7 +261,7 @@ inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, uns
       grid[index] = cost;
     else
       grid[index] = std::max(old_cost, cost);
-    //push the cell data onto the queue and mark
+    // push the cell data onto the queue and mark
     seen_[index] = true;
     CellData data(distance, index, mx, my, src_x, src_y);
     inflation_queue_.push(data);
@@ -272,11 +270,11 @@ inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, uns
 
 void InflationLayer::computeCaches()
 {
-  if(cell_inflation_radius_ == 0)
+  if (cell_inflation_radius_ == 0)
     return;
 
-  //based on the inflation radius... compute distance and cost caches
-  if(cell_inflation_radius_ != cached_cell_inflation_radius_)
+  // based on the inflation radius... compute distance and cost caches
+  if (cell_inflation_radius_ != cached_cell_inflation_radius_)
   {
     deleteKernels();
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -58,7 +58,7 @@ void ObstacleLayer::onInitialize()
 
   bool track_unknown_space;
   nh.param("track_unknown_space", track_unknown_space, layered_costmap_->isTrackingUnknown());
-  if(track_unknown_space)
+  if (track_unknown_space)
     default_value_ = NO_INFORMATION;
   else
     default_value_ = FREE_SPACE;
@@ -71,7 +71,7 @@ void ObstacleLayer::onInitialize()
   nh.param("transform_tolerance", transform_tolerance, 0.2);
 
   std::string topics_string;
-  //get the topics that we'll subscribe to from the parameter server
+  // get the topics that we'll subscribe to from the parameter server
   nh.param("observation_sources", topics_string, std::string(""));
   ROS_INFO("    Subscribed to Topics: %s", topics_string.c_str());
 
@@ -79,7 +79,7 @@ void ObstacleLayer::onInitialize()
   ros::NodeHandle prefix_nh;
   const std::string tf_prefix = tf::getPrefixParam(prefix_nh);
 
-  //now we need to split the topics based on whitespace which we can use a stringstream for
+  // now we need to split the topics based on whitespace which we can use a stringstream for
   std::stringstream ss(topics_string);
 
   std::string source;
@@ -87,7 +87,7 @@ void ObstacleLayer::onInitialize()
   {
     ros::NodeHandle source_node(nh, source);
 
-    //get the parameters for the specific topic
+    // get the parameters for the specific topic
     double observation_keep_time, expected_update_rate, min_obstacle_height, max_obstacle_height;
     std::string topic, sensor_frame, data_type;
     bool inf_is_valid, clearing, marking;
@@ -116,14 +116,14 @@ void ObstacleLayer::onInitialize()
 
     std::string raytrace_range_param_name, obstacle_range_param_name;
 
-    //get the obstacle range for the sensor
+    // get the obstacle range for the sensor
     double obstacle_range = 2.5;
     if (source_node.searchParam("obstacle_range", obstacle_range_param_name))
     {
       source_node.getParam(obstacle_range_param_name, obstacle_range);
     }
 
-    //get the raytrace range for the sensor
+    // get the raytrace range for the sensor
     double raytrace_range = 3.0;
     if (source_node.searchParam("raytrace_range", raytrace_range_param_name))
     {
@@ -133,26 +133,27 @@ void ObstacleLayer::onInitialize()
     ROS_DEBUG("Creating an observation buffer for source %s, topic %s, frame %s", source.c_str(), topic.c_str(),
               sensor_frame.c_str());
 
-    //create an observation buffer
+    // create an observation buffer
     observation_buffers_.push_back(
         boost::shared_ptr < ObservationBuffer
             > (new ObservationBuffer(topic, observation_keep_time, expected_update_rate, min_obstacle_height,
                                      max_obstacle_height, obstacle_range, raytrace_range, *tf_, global_frame_,
                                      sensor_frame, transform_tolerance)));
 
-    //check if we'll add this buffer to our marking observation buffers
+    // check if we'll add this buffer to our marking observation buffers
     if (marking)
       marking_buffers_.push_back(observation_buffers_.back());
 
-    //check if we'll also add this buffer to our clearing observation buffers
+    // check if we'll also add this buffer to our clearing observation buffers
     if (clearing)
       clearing_buffers_.push_back(observation_buffers_.back());
 
     ROS_DEBUG(
-        "Created an observation buffer for source %s, topic %s, global frame: %s, expected update rate: %.2f, observation persistence: %.2f",
+        "Created an observation buffer for source %s, topic %s, global frame: %s, "
+        "expected update rate: %.2f, observation persistence: %.2f",
         source.c_str(), topic.c_str(), global_frame_.c_str(), expected_update_rate, observation_keep_time);
 
-    //create a callback for the topic
+    // create a callback for the topic
     if (data_type == "LaserScan")
     {
       boost::shared_ptr < message_filters::Subscriber<sensor_msgs::LaserScan>
@@ -182,7 +183,7 @@ void ObstacleLayer::onInitialize()
       boost::shared_ptr < message_filters::Subscriber<sensor_msgs::PointCloud>
           > sub(new message_filters::Subscriber<sensor_msgs::PointCloud>(g_nh, topic, 50));
 
-      if( inf_is_valid )
+      if ( inf_is_valid )
       {
        ROS_WARN("obstacle_layer: inf_is_valid option is not applicable to PointCloud observations.");
       }
@@ -200,7 +201,7 @@ void ObstacleLayer::onInitialize()
       boost::shared_ptr < message_filters::Subscriber<sensor_msgs::PointCloud2>
           > sub(new message_filters::Subscriber<sensor_msgs::PointCloud2>(g_nh, topic, 50));
 
-      if( inf_is_valid )
+      if ( inf_is_valid )
       {
        ROS_WARN("obstacle_layer: inf_is_valid option is not applicable to PointCloud observations.");
       }
@@ -221,12 +222,11 @@ void ObstacleLayer::onInitialize()
       target_frames.push_back(sensor_frame);
       observation_notifiers_.back()->setTargetFrames(target_frames);
     }
-
   }
 
   dsrv_ = NULL;
   setupDynamicReconfigure(nh);
-  footprint_layer_.initialize( layered_costmap_, name_ + "_footprint", tf_);
+  footprint_layer_.initialize(layered_costmap_, name_ + "_footprint", tf_);
 }
 
 void ObstacleLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
@@ -239,7 +239,7 @@ void ObstacleLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
 
 ObstacleLayer::~ObstacleLayer()
 {
-    if(dsrv_)
+    if (dsrv_)
         delete dsrv_;
 }
 void ObstacleLayer::reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint32_t level)
@@ -252,11 +252,11 @@ void ObstacleLayer::reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint
 void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& message,
                                       const boost::shared_ptr<ObservationBuffer>& buffer)
 {
-  //project the laser into a point cloud
+  // project the laser into a point cloud
   sensor_msgs::PointCloud2 cloud;
   cloud.header = message->header;
 
-  //project the scan into a point cloud
+  // project the scan into a point cloud
   try
   {
     projector_.transformLaserScanToPointCloud(message->header.frame_id, *message, cloud, *tf_);
@@ -268,42 +268,44 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& mess
     projector_.projectLaser(*message, cloud);
   }
 
-  //buffer the point cloud
+  // buffer the point cloud
   buffer->lock();
   buffer->bufferCloud(cloud);
   buffer->unlock();
 }
 
-void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr& raw_message, 
-                                              const boost::shared_ptr<ObservationBuffer>& buffer){
+void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr& raw_message,
+                                              const boost::shared_ptr<ObservationBuffer>& buffer)
+{
   // Filter positive infinities ("Inf"s) to max_range.
-  float epsilon = 0.0001; // a tenth of a millimeter
+  float epsilon = 0.0001;  // a tenth of a millimeter
   sensor_msgs::LaserScan message = *raw_message;
-  for( size_t i = 0; i < message.ranges.size(); i++ )
+  for ( size_t i = 0; i < message.ranges.size(); i++ )
   {
     float range = message.ranges[ i ];
-    if( !std::isfinite( range ) && range > 0 )
+    if ( !std::isfinite( range ) && range > 0 )
     {
       message.ranges[ i ] = message.range_max - epsilon;
     }
   }
 
-  //project the laser into a point cloud
+  // project the laser into a point cloud
   sensor_msgs::PointCloud2 cloud;
   cloud.header = message.header;
 
-  //project the scan into a point cloud
+  // project the scan into a point cloud
   try
   {
     projector_.transformLaserScanToPointCloud(message.header.frame_id, message, cloud, *tf_);
   }
   catch (tf::TransformException &ex)
   {
-    ROS_WARN ("High fidelity enabled, but TF returned a transform exception to frame %s: %s", global_frame_.c_str (), ex.what ());
+    ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s",
+             global_frame_.c_str(), ex.what());
     projector_.projectLaser(message, cloud);
   }
 
-  //buffer the point cloud
+  // buffer the point cloud
   buffer->lock();
   buffer->bufferCloud(cloud);
   buffer->unlock();
@@ -320,7 +322,7 @@ void ObstacleLayer::pointCloudCallback(const sensor_msgs::PointCloudConstPtr& me
     return;
   }
 
-  //buffer the point cloud
+  // buffer the point cloud
   buffer->lock();
   buffer->bufferCloud(cloud2);
   buffer->unlock();
@@ -329,7 +331,7 @@ void ObstacleLayer::pointCloudCallback(const sensor_msgs::PointCloudConstPtr& me
 void ObstacleLayer::pointCloud2Callback(const sensor_msgs::PointCloud2ConstPtr& message,
                                                 const boost::shared_ptr<ObservationBuffer>& buffer)
 {
-  //buffer the point cloud
+  // buffer the point cloud
   buffer->lock();
   buffer->bufferCloud(*message);
   buffer->unlock();
@@ -347,22 +349,22 @@ void ObstacleLayer::updateBounds(double robot_x, double robot_y, double robot_ya
   bool current = true;
   std::vector<Observation> observations, clearing_observations;
 
-  //get the marking observations
+  // get the marking observations
   current = current && getMarkingObservations(observations);
 
-  //get the clearing observations
+  // get the clearing observations
   current = current && getClearingObservations(clearing_observations);
 
-  //update the global current status
+  // update the global current status
   current_ = current;
 
-  //raytrace freespace
+  // raytrace freespace
   for (unsigned int i = 0; i < clearing_observations.size(); ++i)
   {
     raytraceFreespace(clearing_observations[i], min_x, min_y, max_x, max_y);
   }
 
-  //place the new obstacles into a priority queue... each with a priority of zero to begin with
+  // place the new obstacles into a priority queue... each with a priority of zero to begin with
   for (std::vector<Observation>::const_iterator it = observations.begin(); it != observations.end(); ++it)
   {
     const Observation& obs = *it;
@@ -375,25 +377,25 @@ void ObstacleLayer::updateBounds(double robot_x, double robot_y, double robot_ya
     {
       double px = cloud.points[i].x, py = cloud.points[i].y, pz = cloud.points[i].z;
 
-      //if the obstacle is too high or too far away from the robot we won't add it
+      // if the obstacle is too high or too far away from the robot we won't add it
       if (pz > max_obstacle_height_)
       {
         ROS_DEBUG("The point is too high");
         continue;
       }
 
-      //compute the squared distance from the hitpoint to the pointcloud's origin
+      // compute the squared distance from the hitpoint to the pointcloud's origin
       double sq_dist = (px - obs.origin_.x) * (px - obs.origin_.x) + (py - obs.origin_.y) * (py - obs.origin_.y)
           + (pz - obs.origin_.z) * (pz - obs.origin_.z);
 
-      //if the point is far enough away... we won't consider it
+      // if the point is far enough away... we won't consider it
       if (sq_dist >= sq_obstacle_range)
       {
         ROS_DEBUG("The point is too far away");
         continue;
       }
 
-      //now we need to compute the map coordinates for the observation
+      // now we need to compute the map coordinates for the observation
       unsigned int mx, my;
       if (!worldToMap(px, py, mx, my))
       {
@@ -419,37 +421,39 @@ void ObstacleLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, i
   // before we merge this obstacle layer into the master_grid.
   footprint_layer_.updateCosts(*this, min_i, min_j, max_i, max_j);
 
-  switch(combination_method_){
-    case 0: // Overwrite
+  switch (combination_method_)
+  {
+    case 0:  // Overwrite
       updateWithOverwrite(master_grid, min_i, min_j, max_i, max_j);
       break;
-    case 1: // Maximum
+    case 1:  // Maximum
       updateWithMax(master_grid, min_i, min_j, max_i, max_j);
       break;
-    default: // Nothing
+    default:  // Nothing
       break;
   }
 }
 
 void ObstacleLayer::addStaticObservation(costmap_2d::Observation& obs, bool marking, bool clearing)
 {
-  if(marking)
+  if (marking)
     static_marking_observations_.push_back(obs);
-  if(clearing)
+  if (clearing)
     static_clearing_observations_.push_back(obs);
 }
 
-void ObstacleLayer::clearStaticObservations(bool marking, bool clearing){
-  if(marking)
+void ObstacleLayer::clearStaticObservations(bool marking, bool clearing)
+{
+  if (marking)
     static_marking_observations_.clear();
-  if(clearing)
+  if (clearing)
     static_clearing_observations_.clear();
 }
 
 bool ObstacleLayer::getMarkingObservations(std::vector<Observation>& marking_observations) const
 {
   bool current = true;
-  //get the marking observations
+  // get the marking observations
   for (unsigned int i = 0; i < marking_buffers_.size(); ++i)
   {
     marking_buffers_[i]->lock();
@@ -457,7 +461,7 @@ bool ObstacleLayer::getMarkingObservations(std::vector<Observation>& marking_obs
     current = marking_buffers_[i]->isCurrent() && current;
     marking_buffers_[i]->unlock();
   }
-  marking_observations.insert(marking_observations.end(), 
+  marking_observations.insert(marking_observations.end(),
                               static_marking_observations_.begin(), static_marking_observations_.end());
   return current;
 }
@@ -465,7 +469,7 @@ bool ObstacleLayer::getMarkingObservations(std::vector<Observation>& marking_obs
 bool ObstacleLayer::getClearingObservations(std::vector<Observation>& clearing_observations) const
 {
   bool current = true;
-  //get the clearing observations
+  // get the clearing observations
   for (unsigned int i = 0; i < clearing_buffers_.size(); ++i)
   {
     clearing_buffers_[i]->lock();
@@ -473,7 +477,7 @@ bool ObstacleLayer::getClearingObservations(std::vector<Observation>& clearing_o
     current = clearing_buffers_[i]->isCurrent() && current;
     clearing_buffers_[i]->unlock();
   }
-  clearing_observations.insert(clearing_observations.end(), 
+  clearing_observations.insert(clearing_observations.end(),
                               static_clearing_observations_.begin(), static_clearing_observations_.end());
   return current;
 }
@@ -485,7 +489,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   double oy = clearing_observation.origin_.y;
   pcl::PointCloud < pcl::PointXYZ > cloud = *(clearing_observation.cloud_);
 
-  //get the map coordinates of the origin of the sensor
+  // get the map coordinates of the origin of the sensor
   unsigned int x0, y0;
   if (!worldToMap(ox, oy, x0, y0))
   {
@@ -495,7 +499,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     return;
   }
 
-  //we can pre-compute the enpoints of the map outside of the inner loop... we'll need these later
+  // we can pre-compute the enpoints of the map outside of the inner loop... we'll need these later
   double origin_x = origin_x_, origin_y = origin_y_;
   double map_end_x = origin_x + size_x_ * resolution_;
   double map_end_y = origin_y + size_y_ * resolution_;
@@ -503,18 +507,18 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
 
   touch(ox, oy, min_x, min_y, max_x, max_y);
 
-  //for each point in the cloud, we want to trace a line from the origin and clear obstacles along it
+  // for each point in the cloud, we want to trace a line from the origin and clear obstacles along it
   for (unsigned int i = 0; i < cloud.points.size(); ++i)
   {
     double wx = cloud.points[i].x;
     double wy = cloud.points[i].y;
 
-    //now we also need to make sure that the enpoint we're raytracing
-    //to isn't off the costmap and scale if necessary
+    // now we also need to make sure that the enpoint we're raytracing
+    // to isn't off the costmap and scale if necessary
     double a = wx - ox;
     double b = wy - oy;
 
-    //the minimum value to raytrace from is the origin
+    // the minimum value to raytrace from is the origin
     if (wx < origin_x)
     {
       double t = (origin_x - ox) / a;
@@ -528,7 +532,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
       wy = origin_y;
     }
 
-    //the maximum value to raytrace to is the end of the map
+    // the maximum value to raytrace to is the end of the map
     if (wx > map_end_x)
     {
       double t = (map_end_x - ox) / a;
@@ -542,16 +546,16 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
       wy = map_end_y - .001;
     }
 
-    //now that the vector is scaled correctly... we'll get the map coordinates of its endpoint
+    // now that the vector is scaled correctly... we'll get the map coordinates of its endpoint
     unsigned int x1, y1;
 
-    //check for legality just in case
+    // check for legality just in case
     if (!worldToMap(wx, wy, x1, y1))
       continue;
 
     unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
     MarkCell marker(costmap_, FREE_SPACE);
-    //and finally... we can execute our trace to clear obstacles along that line
+    // and finally... we can execute our trace to clear obstacles along that line
     raytraceLine(marker, x0, y0, x1, y1, cell_raytrace_range);
 
     updateRaytraceBounds(ox, oy, wx, wy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
@@ -560,7 +564,7 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
 
 void ObstacleLayer::activate()
 {
-  //if we're stopped we need to re-subscribe to topics
+  // if we're stopped we need to re-subscribe to topics
   for (unsigned int i = 0; i < observation_subscribers_.size(); ++i)
   {
     if (observation_subscribers_[i] != NULL)
@@ -582,8 +586,8 @@ void ObstacleLayer::deactivate()
   }
 }
 
-void ObstacleLayer::updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
-					 double* max_x, double* max_y)
+void ObstacleLayer::updateRaytraceBounds(double ox, double oy, double wx, double wy, double range,
+                                         double* min_x, double* min_y, double* max_x, double* max_y)
 {
   double dx = wx-ox, dy = wy-oy;
   double full_distance = hypot(dx, dy);

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -183,7 +183,7 @@ void ObstacleLayer::onInitialize()
       boost::shared_ptr < message_filters::Subscriber<sensor_msgs::PointCloud>
           > sub(new message_filters::Subscriber<sensor_msgs::PointCloud>(g_nh, topic, 50));
 
-      if ( inf_is_valid )
+      if (inf_is_valid)
       {
        ROS_WARN("obstacle_layer: inf_is_valid option is not applicable to PointCloud observations.");
       }
@@ -201,7 +201,7 @@ void ObstacleLayer::onInitialize()
       boost::shared_ptr < message_filters::Subscriber<sensor_msgs::PointCloud2>
           > sub(new message_filters::Subscriber<sensor_msgs::PointCloud2>(g_nh, topic, 50));
 
-      if ( inf_is_valid )
+      if (inf_is_valid)
       {
        ROS_WARN("obstacle_layer: inf_is_valid option is not applicable to PointCloud observations.");
       }
@@ -280,10 +280,10 @@ void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstP
   // Filter positive infinities ("Inf"s) to max_range.
   float epsilon = 0.0001;  // a tenth of a millimeter
   sensor_msgs::LaserScan message = *raw_message;
-  for ( size_t i = 0; i < message.ranges.size(); i++ )
+  for (size_t i = 0; i < message.ranges.size(); i++)
   {
     float range = message.ranges[ i ];
-    if ( !std::isfinite( range ) && range > 0 )
+    if (!std::isfinite(range) && range > 0)
     {
       message.ranges[ i ] = message.range_max - epsilon;
     }

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -53,7 +53,7 @@ StaticLayer::StaticLayer() : dsrv_(NULL) {}
 
 StaticLayer::~StaticLayer()
 {
-  if(dsrv_)
+  if (dsrv_)
     delete dsrv_;
 }
 
@@ -79,7 +79,7 @@ void StaticLayer::onInitialize()
 
   lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 100), 0);
   unknown_cost_value_ = temp_unknown_cost_value;
-  //we'll subscribe to the latched topic that the map server uses
+  // we'll subscribe to the latched topic that the map server uses
   ROS_INFO("Requesting the map...");
   map_sub_ = g_nh.subscribe(map_topic, 1, &StaticLayer::incomingMap, this);
   map_received_ = false;
@@ -94,13 +94,13 @@ void StaticLayer::onInitialize()
 
   ROS_INFO("Received a %d X %d map at %f m/pix", getSizeInCellsX(), getSizeInCellsY(), getResolution());
 
-  if(subscribe_to_updates_)
+  if (subscribe_to_updates_)
   {
     ROS_INFO("Subscribing to updates");
     map_update_sub_ = g_nh.subscribe(map_topic + "_updates", 10, &StaticLayer::incomingUpdate, this);
   }
 
-  if(dsrv_)
+  if (dsrv_)
   {
     delete dsrv_;
   }
@@ -137,7 +137,7 @@ void StaticLayer::matchSize()
 
 unsigned char StaticLayer::interpretValue(unsigned char value)
 {
-  //check if the static value is above the unknown or lethal thresholds
+  // check if the static value is above the unknown or lethal thresholds
   if (track_unknown_space_ && value == unknown_cost_value_)
     return NO_INFORMATION;
   else if (!track_unknown_space_ && value == unknown_cost_value_)
@@ -178,12 +178,13 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
   {
     // only update the size of the costmap stored locally in this layer
     ROS_INFO("Resizing static layer to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);
-    resizeMap(size_x, size_y, new_map->info.resolution, new_map->info.origin.position.x, new_map->info.origin.position.y);
+    resizeMap(size_x, size_y, new_map->info.resolution,
+              new_map->info.origin.position.x, new_map->info.origin.position.y);
   }
 
   unsigned int index = 0;
 
-  //initialize the costmap with static data
+  // initialize the costmap with static data
   for (unsigned int i = 0; i < size_y; ++i)
   {
     for (unsigned int j = 0; j < size_x; ++j)
@@ -203,7 +204,8 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
   has_updated_data_ = true;
 
   // shutdown the map subscrber if firt_map_only_ flag is on
-  if(first_map_only_) {
+  if (first_map_only_)
+  {
     ROS_INFO("Shutting down the map subscriber. first_map_only flag is on");
     map_sub_.shutdown();
   }
@@ -218,7 +220,7 @@ void StaticLayer::incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr& up
     for (unsigned int x = 0; x < update->width ; x++)
     {
       unsigned int index = index_base + x + update->x;
-      costmap_[index] = interpretValue( update->data[di++] );
+      costmap_[index] = interpretValue(update->data[di++]);
     }
   }
   x_ = update->x;
@@ -242,12 +244,14 @@ void StaticLayer::deactivate()
 
 void StaticLayer::reset()
 {
-  if(first_map_only_) {
+  if (first_map_only_)
+  {
     has_updated_data_ = true;
   }
-  else{
-   deactivate();
-   activate();
+  else
+  {
+    deactivate();
+    activate();
   }
 }
 
@@ -298,7 +302,7 @@ void StaticLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int
     }
     catch (tf::TransformException ex)
     {
-      ROS_ERROR("%s",ex.what());
+      ROS_ERROR("%s", ex.what());
       return;
     }
     // Copy map data given proper transformations

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -61,7 +61,7 @@ void VoxelLayer::onInitialize()
   if (publish_voxel_)
     voxel_pub_ = private_nh.advertise < costmap_2d::VoxelGrid > ("voxel_grid", 1);
 
-  clearing_endpoints_pub_ = private_nh.advertise<sensor_msgs::PointCloud>( "clearing_endpoints", 1 );
+  clearing_endpoints_pub_ = private_nh.advertise<sensor_msgs::PointCloud>("clearing_endpoints", 1);
 }
 
 void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
@@ -74,7 +74,7 @@ void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
 
 VoxelLayer::~VoxelLayer()
 {
-  if(voxel_dsrv_)
+  if (voxel_dsrv_)
     delete voxel_dsrv_;
 }
 
@@ -124,22 +124,22 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
   bool current = true;
   std::vector<Observation> observations, clearing_observations;
 
-  //get the marking observations
+  // get the marking observations
   current = current && getMarkingObservations(observations);
 
-  //get the clearing observations
+  // get the clearing observations
   current = current && getClearingObservations(clearing_observations);
 
-  //update the global current status
+  // update the global current status
   current_ = current;
 
-  //raytrace freespace
+  // raytrace freespace
   for (unsigned int i = 0; i < clearing_observations.size(); ++i)
   {
     raytraceFreespace(clearing_observations[i], min_x, min_y, max_x, max_y);
   }
 
-  //place the new obstacles into a priority queue... each with a priority of zero to begin with
+  // place the new obstacles into a priority queue... each with a priority of zero to begin with
   for (std::vector<Observation>::const_iterator it = observations.begin(); it != observations.end(); ++it)
   {
     const Observation& obs = *it;
@@ -150,20 +150,20 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
     for (unsigned int i = 0; i < cloud.points.size(); ++i)
     {
-      //if the obstacle is too high or too far away from the robot we won't add it
+      // if the obstacle is too high or too far away from the robot we won't add it
       if (cloud.points[i].z > max_obstacle_height_)
         continue;
 
-      //compute the squared distance from the hitpoint to the pointcloud's origin
+      // compute the squared distance from the hitpoint to the pointcloud's origin
       double sq_dist = (cloud.points[i].x - obs.origin_.x) * (cloud.points[i].x - obs.origin_.x)
           + (cloud.points[i].y - obs.origin_.y) * (cloud.points[i].y - obs.origin_.y)
           + (cloud.points[i].z - obs.origin_.z) * (cloud.points[i].z - obs.origin_.z);
 
-      //if the point is far enough away... we won't consider it
+      // if the point is far enough away... we won't consider it
       if (sq_dist >= sq_obstacle_range)
         continue;
 
-      //now we need to compute the map coordinates for the observation
+      // now we need to compute the map coordinates for the observation
       unsigned int mx, my, mz;
       if (cloud.points[i].z < origin_z_)
       {
@@ -175,7 +175,7 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
         continue;
       }
 
-      //mark the cell in the voxel grid and check if we should also mark it in the costmap
+      // mark the cell in the voxel grid and check if we should also mark it in the costmap
       if (voxel_grid_.markVoxelInMap(mx, my, mz, mark_threshold_))
       {
         unsigned int index = getIndex(mx, my);
@@ -213,39 +213,39 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
 void VoxelLayer::clearNonLethal(double wx, double wy, double w_size_x, double w_size_y, bool clear_no_info)
 {
-  //get the cell coordinates of the center point of the window
+  // get the cell coordinates of the center point of the window
   unsigned int mx, my;
   if (!worldToMap(wx, wy, mx, my))
     return;
 
-  //compute the bounds of the window
+  // compute the bounds of the window
   double start_x = wx - w_size_x / 2;
   double start_y = wy - w_size_y / 2;
   double end_x = start_x + w_size_x;
   double end_y = start_y + w_size_y;
 
-  //scale the window based on the bounds of the costmap
+  // scale the window based on the bounds of the costmap
   start_x = std::max(origin_x_, start_x);
   start_y = std::max(origin_y_, start_y);
 
   end_x = std::min(origin_x_ + getSizeInMetersX(), end_x);
   end_y = std::min(origin_y_ + getSizeInMetersY(), end_y);
 
-  //get the map coordinates of the bounds of the window
+  // get the map coordinates of the bounds of the window
   unsigned int map_sx, map_sy, map_ex, map_ey;
 
-  //check for legality just in case
+  // check for legality just in case
   if (!worldToMap(start_x, start_y, map_sx, map_sy) || !worldToMap(end_x, end_y, map_ex, map_ey))
     return;
 
-  //we know that we want to clear all non-lethal obstacles in this window to get it ready for inflation
+  // we know that we want to clear all non-lethal obstacles in this window to get it ready for inflation
   unsigned int index = getIndex(map_sx, map_sy);
   unsigned char* current = &costmap_[index];
   for (unsigned int j = map_sy; j <= map_ey; ++j)
   {
     for (unsigned int i = map_sx; i <= map_ex; ++i)
     {
-      //if the cell is a lethal obstacle... we'll keep it and queue it, otherwise... we'll clear it
+      // if the cell is a lethal obstacle... we'll keep it and queue it, otherwise... we'll clear it
       if (*current != LETHAL_OBSTACLE)
       {
         if (clear_no_info || *current != NO_INFORMATION)
@@ -283,13 +283,13 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
   }
 
   bool publish_clearing_points = (clearing_endpoints_pub_.getNumSubscribers() > 0);
-  if( publish_clearing_points )
+  if ( publish_clearing_points )
   {
     clearing_endpoints_.points.clear();
-    clearing_endpoints_.points.reserve( clearing_observation.cloud_->points.size() );
+    clearing_endpoints_.points.reserve(clearing_observation.cloud_->points.size());
   }
 
-  //we can pre-compute the enpoints of the map outside of the inner loop... we'll need these later
+  // we can pre-compute the enpoints of the map outside of the inner loop... we'll need these later
   double map_end_x = origin_x_ + getSizeInMetersX();
   double map_end_y = origin_y_ + getSizeInMetersY();
 
@@ -311,20 +311,20 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     double c = wpz - oz;
     double t = 1.0;
 
-    //we can only raytrace to a maximum z height
+    // we can only raytrace to a maximum z height
     if (wpz > max_obstacle_height_)
     {
-      //we know we want the vector's z value to be max_z
+      // we know we want the vector's z value to be max_z
       t = std::max(0.0, std::min(t, (max_obstacle_height_ - 0.01 - oz) / c));
     }
-    //and we can only raytrace down to the floor
+    // and we can only raytrace down to the floor
     else if (wpz < origin_z_)
     {
-      //we know we want the vector's z value to be 0.0
+      // we know we want the vector's z value to be 0.0
       t = std::min(t, (origin_z_ - oz) / c);
     }
 
-    //the minimum value to raytrace from is the origin
+    // the minimum value to raytrace from is the origin
     if (wpx < origin_x_)
     {
       t = std::min(t, (origin_x_ - ox) / a);
@@ -334,7 +334,7 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
       t = std::min(t, (origin_y_ - oy) / b);
     }
 
-    //the maximum value to raytrace to is the end of the map
+    // the maximum value to raytrace to is the end of the map
     if (wpx > map_end_x)
     {
       t = std::min(t, (map_end_x - ox) / a);
@@ -353,52 +353,52 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     {
       unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
 
-      //voxel_grid_.markVoxelLine(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z);
+      // voxel_grid_.markVoxelLine(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z);
       voxel_grid_.clearVoxelLineInMap(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z, costmap_,
                                       unknown_threshold_, mark_threshold_, FREE_SPACE, NO_INFORMATION,
                                       cell_raytrace_range);
 
       updateRaytraceBounds(ox, oy, wpx, wpy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
 
-      if( publish_clearing_points )
+      if ( publish_clearing_points )
       {
         geometry_msgs::Point32 point;
         point.x = wpx;
         point.y = wpy;
         point.z = wpz;
-        clearing_endpoints_.points.push_back( point );
+        clearing_endpoints_.points.push_back(point);
       }
     }
   }
 
-  if( publish_clearing_points )
+  if ( publish_clearing_points )
   {
     clearing_endpoints_.header.frame_id = global_frame_;
     clearing_endpoints_.header.stamp = pcl_conversions::fromPCL(clearing_observation.cloud_->header).stamp;
     clearing_endpoints_.header.seq = clearing_observation.cloud_->header.seq;
 
-    clearing_endpoints_pub_.publish( clearing_endpoints_ );
+    clearing_endpoints_pub_.publish(clearing_endpoints_);
   }
 }
 
 void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
 {
-  //project the new origin into the grid
+  // project the new origin into the grid
   int cell_ox, cell_oy;
   cell_ox = int((new_origin_x - origin_x_) / resolution_);
   cell_oy = int((new_origin_y - origin_y_) / resolution_);
 
-  //compute the associated world coordinates for the origin cell
-  //beacuase we want to keep things grid-aligned
+  // compute the associated world coordinates for the origin cell
+  // beacuase we want to keep things grid-aligned
   double new_grid_ox, new_grid_oy;
   new_grid_ox = origin_x_ + cell_ox * resolution_;
   new_grid_oy = origin_y_ + cell_oy * resolution_;
 
-  //To save casting from unsigned int to int a bunch of times
+  // To save casting from unsigned int to int a bunch of times
   int size_x = size_x_;
   int size_y = size_y_;
 
-  //we need to compute the overlap of the new and existing windows
+  // we need to compute the overlap of the new and existing windows
   int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
   lower_left_x = std::min(std::max(cell_ox, 0), size_x);
   lower_left_y = std::min(std::max(cell_oy, 0), size_y);
@@ -408,32 +408,32 @@ void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
   unsigned int cell_size_x = upper_right_x - lower_left_x;
   unsigned int cell_size_y = upper_right_y - lower_left_y;
 
-  //we need a map to store the obstacles in the window temporarily
+  // we need a map to store the obstacles in the window temporarily
   unsigned char* local_map = new unsigned char[cell_size_x * cell_size_y];
   unsigned int* local_voxel_map = new unsigned int[cell_size_x * cell_size_y];
   unsigned int* voxel_map = voxel_grid_.getData();
 
-  //copy the local window in the costmap to the local map
+  // copy the local window in the costmap to the local map
   copyMapRegion(costmap_, lower_left_x, lower_left_y, size_x_, local_map, 0, 0, cell_size_x, cell_size_x, cell_size_y);
   copyMapRegion(voxel_map, lower_left_x, lower_left_y, size_x_, local_voxel_map, 0, 0, cell_size_x, cell_size_x,
                 cell_size_y);
 
-  //we'll reset our maps to unknown space if appropriate
+  // we'll reset our maps to unknown space if appropriate
   resetMaps();
 
-  //update the origin with the appropriate world coordinates
+  // update the origin with the appropriate world coordinates
   origin_x_ = new_grid_ox;
   origin_y_ = new_grid_oy;
 
-  //compute the starting cell location for copying data back in
+  // compute the starting cell location for copying data back in
   int start_x = lower_left_x - cell_ox;
   int start_y = lower_left_y - cell_oy;
 
-  //now we want to copy the overlapping information back into the map, but in its new location
+  // now we want to copy the overlapping information back into the map, but in its new location
   copyMapRegion(local_map, 0, 0, cell_size_x, costmap_, start_x, start_y, size_x_, cell_size_x, cell_size_y);
   copyMapRegion(local_voxel_map, 0, 0, cell_size_x, voxel_map, start_x, start_y, size_x_, cell_size_x, cell_size_y);
 
-  //make sure to clean up
+  // make sure to clean up
   delete[] local_map;
   delete[] local_voxel_map;
 }

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -283,7 +283,7 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
   }
 
   bool publish_clearing_points = (clearing_endpoints_pub_.getNumSubscribers() > 0);
-  if ( publish_clearing_points )
+  if (publish_clearing_points)
   {
     clearing_endpoints_.points.clear();
     clearing_endpoints_.points.reserve(clearing_observation.cloud_->points.size());
@@ -360,7 +360,7 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
 
       updateRaytraceBounds(ox, oy, wpx, wpy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
 
-      if ( publish_clearing_points )
+      if (publish_clearing_points)
       {
         geometry_msgs::Point32 point;
         point.x = wpx;
@@ -371,7 +371,7 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     }
   }
 
-  if ( publish_clearing_points )
+  if (publish_clearing_points)
   {
     clearing_endpoints_.header.frame_id = global_frame_;
     clearing_endpoints_.header.stamp = pcl_conversions::fromPCL(clearing_observation.cloud_->header).stamp;

--- a/costmap_2d/src/array_parser.cpp
+++ b/costmap_2d/src/array_parser.cpp
@@ -29,7 +29,7 @@
  * author: Dave Hershberger
  */
 
-#include <cstdio> // for EOF
+#include <cstdio>  // for EOF
 #include <string>
 #include <sstream>
 #include <vector>
@@ -41,22 +41,22 @@ namespace costmap_2d
  * @param input
  * @param error_return
  * Syntax is [[1.0, 2.0], [3.3, 4.4, 5.5], ...] */
-std::vector<std::vector<float> > parseVVF( const std::string& input, std::string& error_return )
+std::vector<std::vector<float> > parseVVF(const std::string& input, std::string& error_return)
 {
   std::vector<std::vector<float> > result;
 
-  std::stringstream input_ss( input );
+  std::stringstream input_ss(input);
   int depth = 0;
   std::vector<float> current_vector;
-  while( !!input_ss && !input_ss.eof() )
+  while (!!input_ss && !input_ss.eof())
   {
-    switch( input_ss.peek() )
+    switch (input_ss.peek())
     {
     case EOF:
       break;
     case '[':
       depth++;
-      if( depth > 2 )
+      if (depth > 2)
       {
         error_return = "Array depth greater than 2";
         return result;
@@ -66,15 +66,15 @@ std::vector<std::vector<float> > parseVVF( const std::string& input, std::string
       break;
     case ']':
       depth--;
-      if( depth < 0 )
+      if (depth < 0)
       {
         error_return = "More close ] than open [";
         return result;
       }
       input_ss.get();
-      if( depth == 1 )
+      if (depth == 1)
       {
-        result.push_back( current_vector );
+        result.push_back(current_vector);
       }
       break;
     case ',':
@@ -82,25 +82,25 @@ std::vector<std::vector<float> > parseVVF( const std::string& input, std::string
     case '\t':
       input_ss.get();
       break;
-    default: // All other characters should be part of the numbers.
-      if( depth != 2 )
+    default:  // All other characters should be part of the numbers.
+      if (depth != 2)
       {
         std::stringstream err_ss;
-        err_ss << "Numbers at depth other than 2. Char was '" << char( input_ss.peek() ) << "'.";
+        err_ss << "Numbers at depth other than 2. Char was '" << char(input_ss.peek()) << "'.";
         error_return = err_ss.str();
         return result;
       }
       float value;
       input_ss >> value;
-      if( !!input_ss )
+      if (!!input_ss)
       {
-        current_vector.push_back( value );
+        current_vector.push_back(value);
       }
       break;
     }
   }
 
-  if( depth != 0 )
+  if (depth != 0)
   {
     error_return = "Unterminated vector string.";
   }
@@ -112,4 +112,4 @@ std::vector<std::vector<float> > parseVVF( const std::string& input, std::string
   return result;
 }
 
-} // end namespace costmap_2d
+}  // end namespace costmap_2d

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -44,19 +44,19 @@ namespace costmap_2d
 {
 Costmap2D::Costmap2D(unsigned int cells_size_x, unsigned int cells_size_y, double resolution,
                      double origin_x, double origin_y, unsigned char default_value) :
-    size_x_(cells_size_x), size_y_(cells_size_y), resolution_(resolution), origin_x_(origin_x), 
+    size_x_(cells_size_x), size_y_(cells_size_y), resolution_(resolution), origin_x_(origin_x),
     origin_y_(origin_y), costmap_(NULL), default_value_(default_value)
 {
   access_ = new mutex_t();
 
-  //create the costmap
+  // create the costmap
   initMaps(size_x_, size_y_);
   resetMaps();
 }
 
 void Costmap2D::deleteMaps()
 {
-  //clean up data
+  // clean up data
   boost::unique_lock<mutex_t> lock(*access_);
   delete[] costmap_;
   costmap_ = NULL;
@@ -101,17 +101,17 @@ void Costmap2D::resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsi
 bool Costmap2D::copyCostmapWindow(const Costmap2D& map, double win_origin_x, double win_origin_y, double win_size_x,
                                   double win_size_y)
 {
-  //check for self windowing
+  // check for self windowing
   if (this == &map)
   {
     // ROS_ERROR("Cannot convert this costmap into a window of itself");
     return false;
   }
 
-  //clean up old data
+  // clean up old data
   deleteMaps();
 
-  //compute the bounds of our new map
+  // compute the bounds of our new map
   unsigned int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
   if (!map.worldToMap(win_origin_x, win_origin_y, lower_left_x, lower_left_y)
       || !map.worldToMap(win_origin_x + win_size_x, win_origin_y + win_size_y, upper_right_x, upper_right_y))
@@ -126,22 +126,21 @@ bool Costmap2D::copyCostmapWindow(const Costmap2D& map, double win_origin_x, dou
   origin_x_ = win_origin_x;
   origin_y_ = win_origin_y;
 
-  //initialize our various maps and reset markers for inflation
+  // initialize our various maps and reset markers for inflation
   initMaps(size_x_, size_y_);
 
-  //copy the window of the static map and the costmap that we're taking
+  // copy the window of the static map and the costmap that we're taking
   copyMapRegion(map.costmap_, lower_left_x, lower_left_y, map.size_x_, costmap_, 0, 0, size_x_, size_x_, size_y_);
   return true;
 }
 
 Costmap2D& Costmap2D::operator=(const Costmap2D& map)
 {
-
-  //check for self assignement
+  // check for self assignement
   if (this == &map)
     return *this;
 
-  //clean up old data
+  // clean up old data
   deleteMaps();
 
   size_x_ = map.size_x_;
@@ -150,10 +149,10 @@ Costmap2D& Costmap2D::operator=(const Costmap2D& map)
   origin_x_ = map.origin_x_;
   origin_y_ = map.origin_y_;
 
-  //initialize our various maps
+  // initialize our various maps
   initMaps(size_x_, size_y_);
 
-  //copy the cost map
+  // copy the cost map
   memcpy(costmap_, map.costmap_, size_x_ * size_y_ * sizeof(unsigned char));
 
   return *this;
@@ -166,7 +165,7 @@ Costmap2D::Costmap2D(const Costmap2D& map) :
   *this = map;
 }
 
-//just initialize everything to NULL by default
+// just initialize everything to NULL by default
 Costmap2D::Costmap2D() :
     size_x_(0), size_y_(0), resolution_(0.0), origin_x_(0.0), origin_y_(0.0), costmap_(NULL)
 {
@@ -231,11 +230,11 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   // Here we avoid doing any math to wx,wy before comparing them to
   // the bounds, so their values can go out to the max and min values
   // of double floating point.
-  if( wx < origin_x_ )
+  if ( wx < origin_x_)
   {
     mx = 0;
   }
-  else if( wx > resolution_ * size_x_ + origin_x_ )
+  else if ( wx > resolution_ * size_x_ + origin_x_)
   {
     mx = size_x_ - 1;
   }
@@ -244,11 +243,11 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
     mx = (int)((wx - origin_x_) / resolution_);
   }
 
-  if( wy < origin_y_ )
+  if ( wy < origin_y_)
   {
     my = 0;
   }
-  else if( wy > resolution_ * size_y_ + origin_y_ )
+  else if ( wy > resolution_ * size_y_ + origin_y_)
   {
     my = size_y_ - 1;
   }
@@ -260,22 +259,22 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
 
 void Costmap2D::updateOrigin(double new_origin_x, double new_origin_y)
 {
-  //project the new origin into the grid
+  // project the new origin into the grid
   int cell_ox, cell_oy;
   cell_ox = int((new_origin_x - origin_x_) / resolution_);
   cell_oy = int((new_origin_y - origin_y_) / resolution_);
 
-  //compute the associated world coordinates for the origin cell
-  //because we want to keep things grid-aligned
+  // compute the associated world coordinates for the origin cell
+  // because we want to keep things grid-aligned
   double new_grid_ox, new_grid_oy;
   new_grid_ox = origin_x_ + cell_ox * resolution_;
   new_grid_oy = origin_y_ + cell_oy * resolution_;
 
-  //To save casting from unsigned int to int a bunch of times
+  // To save casting from unsigned int to int a bunch of times
   int size_x = size_x_;
   int size_y = size_y_;
 
-  //we need to compute the overlap of the new and existing windows
+  // we need to compute the overlap of the new and existing windows
   int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
   lower_left_x = min(max(cell_ox, 0), size_x);
   lower_left_y = min(max(cell_oy, 0), size_y);
@@ -285,33 +284,33 @@ void Costmap2D::updateOrigin(double new_origin_x, double new_origin_y)
   unsigned int cell_size_x = upper_right_x - lower_left_x;
   unsigned int cell_size_y = upper_right_y - lower_left_y;
 
-  //we need a map to store the obstacles in the window temporarily
+  // we need a map to store the obstacles in the window temporarily
   unsigned char* local_map = new unsigned char[cell_size_x * cell_size_y];
 
-  //copy the local window in the costmap to the local map
+  // copy the local window in the costmap to the local map
   copyMapRegion(costmap_, lower_left_x, lower_left_y, size_x_, local_map, 0, 0, cell_size_x, cell_size_x, cell_size_y);
 
-  //now we'll set the costmap to be completely unknown if we track unknown space
+  // now we'll set the costmap to be completely unknown if we track unknown space
   resetMaps();
 
-  //update the origin with the appropriate world coordinates
+  // update the origin with the appropriate world coordinates
   origin_x_ = new_grid_ox;
   origin_y_ = new_grid_oy;
 
-  //compute the starting cell location for copying data back in
+  // compute the starting cell location for copying data back in
   int start_x = lower_left_x - cell_ox;
   int start_y = lower_left_y - cell_oy;
 
-  //now we want to copy the overlapping information back into the map, but in its new location
+  // now we want to copy the overlapping information back into the map, but in its new location
   copyMapRegion(local_map, 0, 0, cell_size_x, costmap_, start_x, start_y, size_x_, cell_size_x, cell_size_y);
 
-  //make sure to clean up
+  // make sure to clean up
   delete[] local_map;
 }
 
 bool Costmap2D::setConvexPolygonCost(const std::vector<geometry_msgs::Point>& polygon, unsigned char cost_value)
 {
-  //we assume the polygon is given in the global_frame... we need to transform it to map coordinates
+  // we assume the polygon is given in the global_frame... we need to transform it to map coordinates
   std::vector<MapLocation> map_polygon;
   for (unsigned int i = 0; i < polygon.size(); ++i)
   {
@@ -326,10 +325,10 @@ bool Costmap2D::setConvexPolygonCost(const std::vector<geometry_msgs::Point>& po
 
   std::vector<MapLocation> polygon_cells;
 
-  //get the cells that fill the polygon
+  // get the cells that fill the polygon
   convexFillCells(map_polygon, polygon_cells);
 
-  //set the cost of those cells
+  // set the cost of those cells
   for (unsigned int i = 0; i < polygon_cells.size(); ++i)
   {
     unsigned int index = getIndex(polygon_cells[i].x, polygon_cells[i].y);
@@ -348,21 +347,21 @@ void Costmap2D::polygonOutlineCells(const std::vector<MapLocation>& polygon, std
   if (!polygon.empty())
   {
     unsigned int last_index = polygon.size() - 1;
-    //we also need to close the polygon by going from the last point to the first
+    // we also need to close the polygon by going from the last point to the first
     raytraceLine(cell_gatherer, polygon[last_index].x, polygon[last_index].y, polygon[0].x, polygon[0].y);
   }
 }
 
 void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells)
 {
-  //we need a minimum polygon of a triangle
+  // we need a minimum polygon of a triangle
   if (polygon.size() < 3)
     return;
 
-  //first get the cells that make up the outline of the polygon
+  // first get the cells that make up the outline of the polygon
   polygonOutlineCells(polygon, polygon_cells);
 
-  //quick bubble sort to sort points by x
+  // quick bubble sort to sort points by x
   MapLocation swap;
   unsigned int i = 0;
   while (i < polygon_cells.size() - 1)
@@ -386,7 +385,7 @@ void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::ve
   unsigned int min_x = polygon_cells[0].x;
   unsigned int max_x = polygon_cells[polygon_cells.size() - 1].x;
 
-  //walk through each column and mark cells inside the polygon
+  // walk through each column and mark cells inside the polygon
   for (unsigned int x = min_x; x <= max_x; ++x)
   {
     if (i >= polygon_cells.size() - 1)
@@ -414,13 +413,12 @@ void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::ve
     }
 
     MapLocation pt;
-    //loop though cells in the column
+    // loop though cells in the column
     for (unsigned int y = min_pt.y; y < max_pt.y; ++y)
     {
       pt.x = x;
       pt.y = y;
       polygon_cells.push_back(pt);
-
     }
   }
 }
@@ -483,4 +481,4 @@ bool Costmap2D::saveMap(std::string file_name)
   return true;
 }
 
-}
+}  // namespace costmap_2d

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -230,11 +230,11 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   // Here we avoid doing any math to wx,wy before comparing them to
   // the bounds, so their values can go out to the max and min values
   // of double floating point.
-  if ( wx < origin_x_)
+  if (wx < origin_x_)
   {
     mx = 0;
   }
-  else if ( wx > resolution_ * size_x_ + origin_x_)
+  else if (wx > resolution_ * size_x_ + origin_x_)
   {
     mx = size_x_ - 1;
   }
@@ -243,11 +243,11 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
     mx = (int)((wx - origin_x_) / resolution_);
   }
 
-  if ( wy < origin_y_)
+  if (wy < origin_y_)
   {
     my = 0;
   }
-  else if ( wy > resolution_ * size_y_ + origin_y_)
+  else if (wy > resolution_ * size_y_ + origin_y_)
   {
     my = size_y_ - 1;
   }

--- a/costmap_2d/src/costmap_2d_cloud.cpp
+++ b/costmap_2d/src/costmap_2d_cloud.cpp
@@ -33,8 +33,9 @@
 static inline void mapToWorld3D(const unsigned int mx, const unsigned int my, const unsigned int mz,
                                       const double origin_x, const double origin_y, const double origin_z,
                                       const double x_resolution, const double y_resolution, const double z_resolution,
-                                      double& wx, double& wy, double& wz){
-  //returns the center point of the cell
+                                      double& wx, double& wy, double& wz)
+{
+  // returns the center point of the cell
   wx = origin_x + (mx + 0.5) * x_resolution;
   wy = origin_y + (my + 0.5) * y_resolution;
   wz = origin_z + (mz + 0.5) * z_resolution;
@@ -116,7 +117,6 @@ void voxelCallback(const ros::Publisher& pub_marked, const ros::Publisher& pub_u
 
           ++num_marked;
         }
-
       }
     }
   }
@@ -144,7 +144,7 @@ void voxelCallback(const ros::Publisher& pub_marked, const ros::Publisher& pub_u
       uint32_t r = g_colors_r[c.status] * 255.0;
       uint32_t g = g_colors_g[c.status] * 255.0;
       uint32_t b = g_colors_b[c.status] * 255.0;
-      //uint32_t a = g_colors_a[c.status] * 255.0;
+      // uint32_t a = g_colors_a[c.status] * 255.0;
 
       uint32_t col = (r << 16) | (g << 8) | b;
       cval = *reinterpret_cast<float*>(&col);
@@ -176,7 +176,7 @@ void voxelCallback(const ros::Publisher& pub_marked, const ros::Publisher& pub_u
       uint32_t r = g_colors_r[c.status] * 255.0;
       uint32_t g = g_colors_g[c.status] * 255.0;
       uint32_t b = g_colors_b[c.status] * 255.0;
-      //uint32_t a = g_colors_a[c.status] * 255.0;
+      // uint32_t a = g_colors_a[c.status] * 255.0;
 
       uint32_t col = (r << 16) | (g << 8) | b;
       cval = *reinterpret_cast<float*>(&col);

--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -44,27 +44,30 @@ namespace costmap_2d
 
 char* Costmap2DPublisher::cost_translation_table_ = NULL;
 
-Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* costmap, std::string global_frame, std::string topic_name, bool always_send_full_costmap) :
-    node(ros_node), costmap_(costmap), global_frame_(global_frame), active_(false), always_send_full_costmap_(always_send_full_costmap)
+Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* costmap, std::string global_frame,
+                                       std::string topic_name, bool always_send_full_costmap) :
+    node(ros_node), costmap_(costmap), global_frame_(global_frame), active_(false),
+    always_send_full_costmap_(always_send_full_costmap)
 {
-  costmap_pub_ = ros_node->advertise<nav_msgs::OccupancyGrid>( topic_name, 1, boost::bind( &Costmap2DPublisher::onNewSubscription, this, _1 ));
-  costmap_update_pub_ = ros_node->advertise<map_msgs::OccupancyGridUpdate>( topic_name + "_updates", 1 );
+  costmap_pub_ = ros_node->advertise<nav_msgs::OccupancyGrid>(topic_name, 1,
+                                                    boost::bind(&Costmap2DPublisher::onNewSubscription, this, _1));
+  costmap_update_pub_ = ros_node->advertise<map_msgs::OccupancyGridUpdate>(topic_name + "_updates", 1);
 
-  if( cost_translation_table_ == NULL )
+  if (cost_translation_table_ == NULL)
   {
     cost_translation_table_ = new char[256];
 
     // special values:
-    cost_translation_table_[0] = 0; // NO obstacle
-    cost_translation_table_[253] = 99; // INSCRIBED obstacle
-    cost_translation_table_[254] = 100; // LETHAL obstacle
-    cost_translation_table_[255] = -1; // UNKNOWN
+    cost_translation_table_[0] = 0;  // NO obstacle
+    cost_translation_table_[253] = 99;  // INSCRIBED obstacle
+    cost_translation_table_[254] = 100;  // LETHAL obstacle
+    cost_translation_table_[255] = -1;  // UNKNOWN
 
     // regular cost values scale the range 1 to 252 (inclusive) to fit
     // into 1 to 98 (inclusive).
-    for( int i = 1; i < 253; i++ )
+    for (int i = 1; i < 253; i++)
     {
-      cost_translation_table_[ i ] = char( 1 + (97 * ( i - 1 )) / 251 );
+      cost_translation_table_[ i ] = char(1 + (97 * (i - 1)) / 251);
     }
   }
 
@@ -77,10 +80,10 @@ Costmap2DPublisher::~Costmap2DPublisher()
 {
 }
 
-void Costmap2DPublisher::onNewSubscription( const ros::SingleSubscriberPublisher& pub )
+void Costmap2DPublisher::onNewSubscription(const ros::SingleSubscriberPublisher& pub)
 {
   prepareGrid();
-  pub.publish( grid_ );
+  pub.publish(grid_);
 }
 
 // prepare grid_ message for publication.
@@ -116,11 +119,13 @@ void Costmap2DPublisher::publishCostmap()
 {
   double resolution = costmap_->getResolution();
 
-  if (always_send_full_costmap_ || grid_.info.resolution != resolution || grid_.info.width != costmap_->getSizeInCellsX())
+  if (always_send_full_costmap_ || grid_.info.resolution != resolution ||
+      grid_.info.width != costmap_->getSizeInCellsX())
   {
     prepareGrid();
-    if (costmap_pub_.getNumSubscribers() > 0) {
-      costmap_pub_.publish( grid_ );
+    if (costmap_pub_.getNumSubscribers() > 0)
+    {
+      costmap_pub_.publish(grid_);
     }
   }
   else if (x0_ < xn_)
@@ -145,7 +150,8 @@ void Costmap2DPublisher::publishCostmap()
         update.data[i++] = cost_translation_table_[ cost ];
       }
     }
-    if (costmap_update_pub_.getNumSubscribers() > 0) {
+    if (costmap_update_pub_.getNumSubscribers() > 0)
+    {
       costmap_update_pub_.publish(update);
     }
   }
@@ -155,4 +161,4 @@ void Costmap2DPublisher::publishCostmap()
   y0_ = costmap_->getSizeInCellsY();
 }
 
-} // end namespace costmap_2d
+}  // end namespace costmap_2d

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -49,7 +49,7 @@ using namespace std;
 namespace costmap_2d
 {
 
-void move_parameter(ros::NodeHandle& old_h, ros::NodeHandle& new_h, std::string name, bool should_delete=true)
+void move_parameter(ros::NodeHandle& old_h, ros::NodeHandle& new_h, std::string name, bool should_delete = true)
 {
   if (!old_h.hasParam(name))
     return;
@@ -57,14 +57,13 @@ void move_parameter(ros::NodeHandle& old_h, ros::NodeHandle& new_h, std::string 
   XmlRpc::XmlRpcValue value;
   old_h.getParam(name, value);
   new_h.setParam(name, value);
-  if(should_delete) old_h.deleteParam(name);
+  if (should_delete) old_h.deleteParam(name);
 }
 
 Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
-    layered_costmap_(NULL), name_(name), tf_(tf), stop_updates_(false), initialized_(true), stopped_(false), robot_stopped_(
-        false), map_update_thread_(NULL), last_publish_(0), plugin_loader_("costmap_2d",
-                                                                           "costmap_2d::Layer"), publisher_(
-        NULL)
+    layered_costmap_(NULL), name_(name), tf_(tf), stop_updates_(false), initialized_(true), stopped_(false),
+    robot_stopped_(false), map_update_thread_(NULL), last_publish_(0),
+    plugin_loader_("costmap_2d", "costmap_2d::Layer"), publisher_(NULL)
 {
   ros::NodeHandle private_nh("~/" + name);
   ros::NodeHandle g_nh;
@@ -128,7 +127,7 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
 
   // subscribe to the footprint topic
   std::string topic_param, topic;
-  if(!private_nh.searchParam("footprint_topic", topic_param))
+  if (!private_nh.searchParam("footprint_topic", topic_param))
   {
     topic_param = "footprint_topic";
   }
@@ -138,7 +137,7 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
 
   try
   {
-    readFootprintFromParams( private_nh );
+    readFootprintFromParams(private_nh);
   }
   catch(...)
   {
@@ -147,7 +146,8 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
     throw;
   }
 
-  publisher_ = new Costmap2DPublisher(&private_nh, layered_costmap_->getCostmap(), global_frame_, "costmap", always_send_full_costmap);
+  publisher_ = new Costmap2DPublisher(&private_nh, layered_costmap_->getCostmap(), global_frame_, "costmap",
+                                      always_send_full_costmap);
 
   // create a thread to handle updating the map
   stop_updates_ = false;
@@ -164,9 +164,9 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
   dsrv_->setCallback(cb);
 }
 
-void Costmap2DROS::setUnpaddedRobotFootprintPolygon( const geometry_msgs::Polygon& footprint )
+void Costmap2DROS::setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon& footprint)
 {
-  setUnpaddedRobotFootprint( toPointVector( footprint ));
+  setUnpaddedRobotFootprint(toPointVector(footprint));
 }
 
 Costmap2DROS::~Costmap2DROS()
@@ -212,7 +212,6 @@ void Costmap2DROS::resetOldParameters(ros::NodeHandle& nh)
   ros::NodeHandle obstacles(nh, "obstacle_layer");
   if (nh.getParam("map_type", s) && s == "voxel")
   {
-
     map["name"] = XmlRpc::XmlRpcValue("obstacle_layer");
     map["type"] = XmlRpc::XmlRpcValue("costmap_2d::VoxelLayer");
     super_map.setStruct(&map);
@@ -256,7 +255,6 @@ void Costmap2DROS::resetOldParameters(ros::NodeHandle& nh)
 
   super_array.setArray(&plugins);
   nh.setParam("plugins", super_array);
-
 }
 
 void Costmap2DROS::reconfigureCB(costmap_2d::Costmap2DConfig &config, uint32_t level)
@@ -290,149 +288,149 @@ void Costmap2DROS::reconfigureCB(costmap_2d::Costmap2DConfig &config, uint32_t l
 
   // If the padding has changed, call setUnpaddedRobotFootprint() to
   // re-apply the padding.
-  if( footprint_padding_ != config.footprint_padding )
+  if (footprint_padding_ != config.footprint_padding)
   {
     footprint_padding_ = config.footprint_padding;
-    setUnpaddedRobotFootprint( unpadded_footprint_ );
+    setUnpaddedRobotFootprint(unpadded_footprint_);
   }
 
-  readFootprintFromConfig( config, old_config_ );
+  readFootprintFromConfig(config, old_config_);
 
   old_config_ = config;
 
   map_update_thread_ = new boost::thread(boost::bind(&Costmap2DROS::mapUpdateLoop, this, map_update_frequency));
 }
 
-void Costmap2DROS::readFootprintFromConfig( const costmap_2d::Costmap2DConfig &new_config,
-                                            const costmap_2d::Costmap2DConfig &old_config )
+void Costmap2DROS::readFootprintFromConfig(const costmap_2d::Costmap2DConfig &new_config,
+                                           const costmap_2d::Costmap2DConfig &old_config)
 {
   // Only change the footprint if footprint or robot_radius has
   // changed.  Otherwise we might overwrite a footprint sent on a
   // topic by a dynamic_reconfigure call which was setting some other
   // variable.
-  if( new_config.footprint == old_config.footprint &&
-      new_config.robot_radius == old_config.robot_radius )
+  if (new_config.footprint == old_config.footprint &&
+      new_config.robot_radius == old_config.robot_radius)
   {
     return;
   }
 
-  if( new_config.footprint != "" && new_config.footprint != "[]" )
+  if (new_config.footprint != "" && new_config.footprint != "[]")
   {
-    readFootprintFromString( new_config.footprint );
+    readFootprintFromString(new_config.footprint);
   }
   else
   {
     // robot_radius may be 0, but that must be intended at this point.
-    setFootprintFromRadius( new_config.robot_radius );
+    setFootprintFromRadius(new_config.robot_radius);
   }
 }
 
-bool Costmap2DROS::readFootprintFromString( const std::string& footprint_string )
+bool Costmap2DROS::readFootprintFromString(const std::string& footprint_string)
 {
   std::string error;
-  std::vector<std::vector<float> > vvf = parseVVF( footprint_string, error );
-  if( error != "" )
+  std::vector<std::vector<float> > vvf = parseVVF(footprint_string, error);
+  if (error != "")
   {
-    ROS_ERROR( "Error parsing footprint parameter: '%s'", error.c_str() );
-    ROS_ERROR( "  Footprint string was '%s'.", footprint_string.c_str() );
+    ROS_ERROR("Error parsing footprint parameter: '%s'", error.c_str());
+    ROS_ERROR("  Footprint string was '%s'.", footprint_string.c_str());
     return false;
   }
 
   // convert vvf into points.
-  if( vvf.size() < 3 )
+  if (vvf.size() < 3)
   {
-    ROS_ERROR( "You must specify at least three points for the robot footprint, reverting to previous footprint." );
+    ROS_ERROR("You must specify at least three points for the robot footprint, reverting to previous footprint.");
     return false;
   }
   std::vector<geometry_msgs::Point> points;
-  points.reserve( vvf.size() );
-  for( unsigned int i = 0; i < vvf.size(); i++ )
+  points.reserve(vvf.size());
+  for (unsigned int i = 0; i < vvf.size(); i++)
   {
-    if( vvf[ i ].size() == 2 )
+    if (vvf[ i ].size() == 2)
     {
       geometry_msgs::Point point;
       point.x = vvf[ i ][ 0 ];
       point.y = vvf[ i ][ 1 ];
       point.z = 0;
-      points.push_back( point );
+      points.push_back(point);
     }
     else
     {
-      ROS_ERROR( "Points in the footprint specification must be pairs of numbers.  Found a point with %d numbers.",
-                 int( vvf[ i ].size() ));
+      ROS_ERROR("Points in the footprint specification must be pairs of numbers.  Found a point with %d numbers.",
+                int(vvf[ i ].size()));
       return false;
     }
   }
 
-  setUnpaddedRobotFootprint( points );
+  setUnpaddedRobotFootprint(points);
   return true;
 }
 
-void Costmap2DROS::setFootprintFromRadius( double radius )
+void Costmap2DROS::setFootprintFromRadius(double radius)
 {
   std::vector<geometry_msgs::Point> points;
 
   // Loop over 16 angles around a circle making a point each time
   int N = 16;
   geometry_msgs::Point pt;
-  for( int i = 0; i < N; ++i )
+  for (int i = 0; i < N; ++i)
   {
     double angle = i * 2 * M_PI / N;
-    pt.x = cos( angle ) * radius;
-    pt.y = sin( angle ) * radius;
+    pt.x = cos(angle) * radius;
+    pt.y = sin(angle) * radius;
 
-    points.push_back( pt );
+    points.push_back(pt);
   }
 
-  setUnpaddedRobotFootprint( points );
+  setUnpaddedRobotFootprint(points);
 }
 
-void Costmap2DROS::readFootprintFromParams( ros::NodeHandle& nh )
+void Costmap2DROS::readFootprintFromParams(ros::NodeHandle& nh)
 {
   std::string full_param_name;
   std::string full_radius_param_name;
 
-  if( nh.searchParam( "footprint", full_param_name ))
+  if (nh.searchParam("footprint", full_param_name))
   {
     XmlRpc::XmlRpcValue footprint_xmlrpc;
-    nh.getParam( full_param_name, footprint_xmlrpc );
-    if( footprint_xmlrpc.getType() == XmlRpc::XmlRpcValue::TypeString &&
-        footprint_xmlrpc != "" && footprint_xmlrpc != "[]" )
+    nh.getParam(full_param_name, footprint_xmlrpc);
+    if (footprint_xmlrpc.getType() == XmlRpc::XmlRpcValue::TypeString &&
+        footprint_xmlrpc != "" && footprint_xmlrpc != "[]")
     {
-      if( readFootprintFromString( std::string( footprint_xmlrpc )))
+      if (readFootprintFromString(std::string(footprint_xmlrpc)))
       {
-        writeFootprintToParam( nh );
+        writeFootprintToParam(nh);
         return;
       }
     }
-    else if( footprint_xmlrpc.getType() == XmlRpc::XmlRpcValue::TypeArray )
+    else if (footprint_xmlrpc.getType() == XmlRpc::XmlRpcValue::TypeArray)
     {
-      readFootprintFromXMLRPC( footprint_xmlrpc, full_param_name );
-      writeFootprintToParam( nh );
+      readFootprintFromXMLRPC(footprint_xmlrpc, full_param_name);
+      writeFootprintToParam(nh);
       return;
     }
   }
-  
-  if( nh.searchParam( "robot_radius", full_radius_param_name ))
+
+  if (nh.searchParam("robot_radius", full_radius_param_name))
   {
     double robot_radius;
-    nh.param( full_radius_param_name, robot_radius, 1.234 );
-    setFootprintFromRadius( robot_radius );
-    nh.setParam( "robot_radius", robot_radius );
+    nh.param(full_radius_param_name, robot_radius, 1.234);
+    setFootprintFromRadius(robot_radius);
+    nh.setParam("robot_radius", robot_radius);
   }
   // Else neither param was found anywhere this knows about, so
   // defaults will come from dynamic_reconfigure stuff, set in
   // cfg/Costmap2D.cfg and read in this file in reconfigureCB().
 }
 
-void Costmap2DROS::writeFootprintToParam( ros::NodeHandle& nh )
+void Costmap2DROS::writeFootprintToParam(ros::NodeHandle& nh)
 {
   ostringstream oss;
   bool first = true;
-  for( unsigned int i = 0; i < unpadded_footprint_.size(); i++ )
+  for (unsigned int i = 0; i < unpadded_footprint_.size(); i++)
   {
     geometry_msgs::Point& p = unpadded_footprint_[ i ];
-    if( first )
+    if (first)
     {
       oss << "[[" << p.x << "," << p.y << "]";
       first = false;
@@ -443,83 +441,87 @@ void Costmap2DROS::writeFootprintToParam( ros::NodeHandle& nh )
     }
   }
   oss << "]";
-  nh.setParam( "footprint", oss.str().c_str() );
+  nh.setParam("footprint", oss.str().c_str());
 }
 
-double getNumberFromXMLRPC( XmlRpc::XmlRpcValue& value, const std::string& full_param_name )
+double getNumberFromXMLRPC(XmlRpc::XmlRpcValue& value, const std::string& full_param_name)
 {
   // Make sure that the value we're looking at is either a double or an int.
-  if( value.getType() != XmlRpc::XmlRpcValue::TypeInt &&
-      value.getType() != XmlRpc::XmlRpcValue::TypeDouble )
+  if (value.getType() != XmlRpc::XmlRpcValue::TypeInt &&
+      value.getType() != XmlRpc::XmlRpcValue::TypeDouble)
   {
     std::string& value_string = value;
-    ROS_FATAL( "Values in the footprint specification (param %s) must be numbers. Found value %s.",
-               full_param_name.c_str(), value_string.c_str() );
+    ROS_FATAL("Values in the footprint specification (param %s) must be numbers. Found value %s.",
+              full_param_name.c_str(), value_string.c_str());
     throw std::runtime_error("Values in the footprint specification must be numbers");
   }
   return value.getType() == XmlRpc::XmlRpcValue::TypeInt ? (int)(value) : (double)(value);
 }
 
-void Costmap2DROS::readFootprintFromXMLRPC( XmlRpc::XmlRpcValue& footprint_xmlrpc,
-                                            const std::string& full_param_name )
+void Costmap2DROS::readFootprintFromXMLRPC(XmlRpc::XmlRpcValue& footprint_xmlrpc,
+                                           const std::string& full_param_name)
 {
   // Make sure we have an array of at least 3 elements.
-  if( footprint_xmlrpc.getType() != XmlRpc::XmlRpcValue::TypeArray ||
-      footprint_xmlrpc.size() < 3 )
+  if (footprint_xmlrpc.getType() != XmlRpc::XmlRpcValue::TypeArray ||
+      footprint_xmlrpc.size() < 3)
   {
-    ROS_FATAL( "The footprint must be specified as list of lists on the parameter server, %s was specified as %s",
-               full_param_name.c_str(), std::string( footprint_xmlrpc ).c_str() );
-    throw std::runtime_error( "The footprint must be specified as list of lists on the parameter server with at least 3 points eg: [[x1, y1], [x2, y2], ..., [xn, yn]]");
+    ROS_FATAL("The footprint must be specified as list of lists on the parameter server, %s was specified as %s",
+              full_param_name.c_str(), std::string(footprint_xmlrpc).c_str());
+    throw std::runtime_error("The footprint must be specified as list of lists on the parameter server with at least "
+                             "3 points eg: [[x1, y1], [x2, y2], ..., [xn, yn]]");
   }
 
-  std::vector<geometry_msgs::Point> footprint;  
+  std::vector<geometry_msgs::Point> footprint;
   geometry_msgs::Point pt;
 
-  for( int i = 0; i < footprint_xmlrpc.size(); ++i )
+  for (int i = 0; i < footprint_xmlrpc.size(); ++i)
   {
     // Make sure each element of the list is an array of size 2. (x and y coordinates)
     XmlRpc::XmlRpcValue point = footprint_xmlrpc[ i ];
-    if( point.getType() != XmlRpc::XmlRpcValue::TypeArray ||
-        point.size() != 2 )
+    if (point.getType() != XmlRpc::XmlRpcValue::TypeArray ||
+        point.size() != 2)
     {
-      ROS_FATAL( "The footprint (parameter %s) must be specified as list of lists on the parameter server eg: [[x1, y1], [x2, y2], ..., [xn, yn]], but this spec is not of that form.",
-                 full_param_name.c_str() );
-      throw std::runtime_error( "The footprint must be specified as list of lists on the parameter server eg: [[x1, y1], [x2, y2], ..., [xn, yn]], but this spec is not of that form" );
+      ROS_FATAL("The footprint (parameter %s) must be specified as list of lists on the parameter server eg: "
+                "[[x1, y1], [x2, y2], ..., [xn, yn]], but this spec is not of that form.",
+                full_param_name.c_str());
+      throw std::runtime_error("The footprint must be specified as list of lists on the parameter server eg: "
+                               "[[x1, y1], [x2, y2], ..., [xn, yn]], but this spec is not of that form");
     }
 
-    pt.x = getNumberFromXMLRPC( point[ 0 ], full_param_name );
-    pt.y = getNumberFromXMLRPC( point[ 1 ], full_param_name );
+    pt.x = getNumberFromXMLRPC(point[ 0 ], full_param_name);
+    pt.y = getNumberFromXMLRPC(point[ 1 ], full_param_name);
 
-    footprint.push_back( pt );
+    footprint.push_back(pt);
   }
 
-  setUnpaddedRobotFootprint( footprint );
+  setUnpaddedRobotFootprint(footprint);
 }
 
-double sign(double x){
+double sign(double x)
+{
   return x < 0.0 ? -1.0 : (x > 0.0 ? 1.0 : 0.0);
 }
 
-void Costmap2DROS::setUnpaddedRobotFootprint( const std::vector<geometry_msgs::Point>& points )
+void Costmap2DROS::setUnpaddedRobotFootprint(const std::vector<geometry_msgs::Point>& points)
 {
   unpadded_footprint_ = points;
   padded_footprint_ = points;
 
   // apply footprint_padding_ to padded_footprint_ (changing it in place).
-  for( unsigned int i = 0; i < padded_footprint_.size(); i++ )
+  for (unsigned int i = 0; i < padded_footprint_.size(); i++)
   {
     geometry_msgs::Point& pt = padded_footprint_[ i ];
-    pt.x += sign( pt.x ) * footprint_padding_;
-    pt.y += sign( pt.y ) * footprint_padding_;
+    pt.x += sign(pt.x) * footprint_padding_;
+    pt.y += sign(pt.y) * footprint_padding_;
   }
 
-  layered_costmap_->setFootprint( padded_footprint_ );
+  layered_costmap_->setFootprint(padded_footprint_);
 }
 
 void Costmap2DROS::movementCB(const ros::TimerEvent &event)
 {
-  //don't allow configuration to happen while this check occurs
-  //boost::recursive_mutex::scoped_lock mcl(configuration_mutex_);
+  // don't allow configuration to happen while this check occurs
+  // boost::recursive_mutex::scoped_lock mcl(configuration_mutex_);
 
   tf::Stamped < tf::Pose > new_pose;
 
@@ -528,7 +530,7 @@ void Costmap2DROS::movementCB(const ros::TimerEvent &event)
     ROS_WARN_THROTTLE(1.0, "Could not get robot pose, cancelling reconfiguration");
     robot_stopped_ = false;
   }
-  //make sure that the robot is not moving
+  // make sure that the robot is not moving
   else if (fabs((old_pose_.getOrigin() - new_pose.getOrigin()).length()) < 1e-3
       && fabs(old_pose_.getRotation().angle(new_pose.getRotation())) < 1e-3)
   {
@@ -563,7 +565,7 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
     end_t = end.tv_sec + double(end.tv_usec) / 1e6;
     t_diff = end_t - start_t;
     ROS_DEBUG("Map update time: %.9f", t_diff);
-    if (publish_cycle.toSec() > 0 and layered_costmap_->isInitialized())
+    if (publish_cycle.toSec() > 0 && layered_costmap_->isInitialized())
     {
       unsigned int x0, y0, xn, yn;
       layered_costmap_->getBounds(&x0, &xn, &y0, &yn);
@@ -588,7 +590,7 @@ void Costmap2DROS::updateMap()
 {
   if (!stop_updates_)
   {
-    //get global pose
+    // get global pose
     tf::Stamped < tf::Pose > pose;
     if (getRobotPose (pose))
     {
@@ -665,15 +667,14 @@ void Costmap2DROS::resetLayers()
 
 bool Costmap2DROS::getRobotPose(tf::Stamped<tf::Pose>& global_pose) const
 {
-
   global_pose.setIdentity();
   tf::Stamped < tf::Pose > robot_pose;
   robot_pose.setIdentity();
   robot_pose.frame_id_ = robot_base_frame_;
   robot_pose.stamp_ = ros::Time();
-  ros::Time current_time = ros::Time::now(); // save time for checking tf delay later
+  ros::Time current_time = ros::Time::now();  // save time for checking tf delay later
 
-  //get the global pose of the robot
+  // get the global pose of the robot
   try
   {
     tf_.transformPose(global_frame_, robot_pose, global_pose);
@@ -705,20 +706,23 @@ bool Costmap2DROS::getRobotPose(tf::Stamped<tf::Pose>& global_pose) const
   return true;
 }
 
-void Costmap2DROS::getOrientedFootprint(std::vector<geometry_msgs::Point>& oriented_footprint) const {
+void Costmap2DROS::getOrientedFootprint(std::vector<geometry_msgs::Point>& oriented_footprint) const
+{
   tf::Stamped<tf::Pose> global_pose;
-  if(!getRobotPose(global_pose))
+  if (!getRobotPose(global_pose))
     return;
 
   double yaw = tf::getYaw(global_pose.getRotation());
   getOrientedFootprint(global_pose.getOrigin().x(), global_pose.getOrigin().y(), yaw, oriented_footprint);
 }
 
-void Costmap2DROS::getOrientedFootprint(double x, double y, double theta, std::vector<geometry_msgs::Point>& oriented_footprint) const {
-  //build the oriented footprint at the robot's current location
+void Costmap2DROS::getOrientedFootprint(double x, double y, double theta,
+                                        std::vector<geometry_msgs::Point>& oriented_footprint) const
+{
+  // build the oriented footprint at the robot's current location
   double cos_th = cos(theta);
   double sin_th = sin(theta);
-  for(unsigned int i = 0; i < padded_footprint_.size(); ++i){
+  for (unsigned int i = 0; i < padded_footprint_.size(); ++i){
     geometry_msgs::Point new_pt;
     new_pt.x = x + (padded_footprint_[i].x * cos_th - padded_footprint_[i].y * sin_th);
     new_pt.y = y + (padded_footprint_[i].x * sin_th + padded_footprint_[i].y * cos_th);
@@ -726,4 +730,4 @@ void Costmap2DROS::getOrientedFootprint(double x, double y, double theta, std::v
   }
 }
 
-} // namespace layered_costmap
+}  // namespace costmap_2d

--- a/costmap_2d/src/costmap_layer.cpp
+++ b/costmap_2d/src/costmap_layer.cpp
@@ -31,7 +31,7 @@ void CostmapLayer::useExtraBounds(double* min_x, double* min_y, double* max_x, d
 {
     if (!has_extra_bounds_)
         return;
-        
+
     *min_x = std::min(extra_min_x_, *min_x);
     *min_y = std::min(extra_min_y_, *min_y);
     *max_x = std::max(extra_max_x_, *max_x);
@@ -69,7 +69,8 @@ void CostmapLayer::updateWithMax(costmap_2d::Costmap2D& master_grid, int min_i, 
   }
 }
 
-void CostmapLayer::updateWithTrueOverwrite(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
+void CostmapLayer::updateWithTrueOverwrite(costmap_2d::Costmap2D& master_grid, int min_i, int min_j,
+                                           int max_i, int max_j)
 {
   if (!enabled_)
     return;
@@ -126,7 +127,7 @@ void CostmapLayer::updateWithAddition(costmap_2d::Costmap2D& master_grid, int mi
       unsigned char old_cost = master_array[it];
       if (old_cost == NO_INFORMATION)
         master_array[it] = costmap_[it];
-      else 
+      else
       {
         int sum = old_cost + costmap_[it];
         if (sum >= costmap_2d::INSCRIBED_INFLATED_OBSTACLE)
@@ -137,7 +138,5 @@ void CostmapLayer::updateWithAddition(costmap_2d::Costmap2D& master_grid, int mi
       it++;
     }
   }
-
-
 }
-}
+}  // namespace costmap_2d

--- a/costmap_2d/src/footprint.cpp
+++ b/costmap_2d/src/footprint.cpp
@@ -49,7 +49,7 @@ void calculateMinAndMaxDistances(const std::vector<geometry_msgs::Point>& footpr
 
   for (unsigned int i = 0; i < footprint.size() - 1; ++i)
   {
-    //check the distance from the robot center point to the first vertex
+    // check the distance from the robot center point to the first vertex
     double vertex_dist = distance(0.0, 0.0, footprint[i].x, footprint[i].y);
     double edge_dist = distanceToLine(0.0, 0.0, footprint[i].x, footprint[i].y,
                                       footprint[i + 1].x, footprint[i + 1].y);
@@ -57,7 +57,7 @@ void calculateMinAndMaxDistances(const std::vector<geometry_msgs::Point>& footpr
     max_dist = std::max(max_dist, std::max(vertex_dist, edge_dist));
   }
 
-  //we also need to do the last vertex and the first vertex
+  // we also need to do the last vertex and the first vertex
   double vertex_dist = distance(0.0, 0.0, footprint.back().x, footprint.back().y);
   double edge_dist = distanceToLine(0.0, 0.0, footprint.back().x, footprint.back().y,
                                       footprint.front().x, footprint.front().y);
@@ -86,8 +86,8 @@ geometry_msgs::Point toPoint(geometry_msgs::Point32 pt)
 geometry_msgs::Polygon toPolygon(std::vector<geometry_msgs::Point> pts)
 {
   geometry_msgs::Polygon polygon;
-  for(int i=0;i<pts.size();i++){
-    polygon.points.push_back( toPoint32(pts[i]) );
+  for (int i = 0; i < pts.size(); i++){
+    polygon.points.push_back(toPoint32(pts[i]));
   }
   return polygon;
 }
@@ -95,11 +95,11 @@ geometry_msgs::Polygon toPolygon(std::vector<geometry_msgs::Point> pts)
 std::vector<geometry_msgs::Point> toPointVector(geometry_msgs::Polygon polygon)
 {
   std::vector<geometry_msgs::Point> pts;
-  for(int i=0;i<polygon.points.size();i++)
+  for (int i = 0; i < polygon.points.size(); i++)
   {
-    pts.push_back( toPoint(polygon.points[i] ) );
+    pts.push_back(toPoint(polygon.points[i]));
   }
   return pts;
 }
 
-} // end namespace costmap_2d
+}  // end namespace costmap_2d

--- a/costmap_2d/src/layer.cpp
+++ b/costmap_2d/src/layer.cpp
@@ -33,14 +33,14 @@ namespace costmap_2d
 {
 
 Layer::Layer()
-  : layered_costmap_( NULL )
-  , current_( false )
-  , enabled_( false )
+  : layered_costmap_(NULL)
+  , current_(false)
+  , enabled_(false)
   , name_()
   , tf_(NULL)
 {}
 
-void Layer::initialize( LayeredCostmap* parent, std::string name, tf::TransformListener *tf )
+void Layer::initialize(LayeredCostmap* parent, std::string name, tf::TransformListener *tf)
 {
   layered_costmap_ = parent;
   name_ = name;
@@ -53,4 +53,4 @@ const std::vector<geometry_msgs::Point>& Layer::getFootprint() const
   return layered_costmap_->getFootprint();
 }
 
-} // end namespace costmap_2d
+}  // end namespace costmap_2d

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -145,7 +145,7 @@ bool LayeredCostmap::isCurrent()
 void LayeredCostmap::setFootprint(const std::vector<geometry_msgs::Point>& footprint_spec)
 {
   footprint_ = footprint_spec;
-  costmap_2d::calculateMinAndMaxDistances( footprint_spec, inscribed_radius_, circumscribed_radius_ );
+  costmap_2d::calculateMinAndMaxDistances(footprint_spec, inscribed_radius_, circumscribed_radius_);
 
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
       ++plugin)


### PR DESCRIPTION
Done using the roslint command: 

`rosrun roslint cpplint --verbose=2 --filter=-runtime/references,-build/include_what_you_use,-readability/casting,-build/namespaces,-legal src/*cpp include/costmap_2d/*h plugins/*cpp`

This gets most of the lint reports. The main thing it doesn't like are the header directives that include the package name as well as the file name. 
