### PR TITLE
More tolerant initial pose transform lookup [fake-localisation : indigo]

### DIFF
--- a/fake_localization/fake_localization.cpp
+++ b/fake_localization/fake_localization.cpp
@@ -184,7 +184,6 @@ class FakeOdomNode
         ROS_ERROR("Failed to transform to %s from %s: %s\n", odom_frame_id_.c_str(), base_frame_id_.c_str(), e.what());
         return;
       }
-
       m_tfServer->sendTransform(tf::StampedTransform(odom_to_map.inverse(),
                                                      message->header.stamp + ros::Duration(transform_tolerance_),
                                                      global_frame_id_, message->header.frame_id));
@@ -221,7 +220,8 @@ class FakeOdomNode
       // set offset so that current pose is set to "initialpose"    
       tf::StampedTransform baseInMap;
       try{
-        m_tfListener->lookupTransform(base_frame_id_, global_frame_id_, msg->header.stamp, baseInMap);
+	// just get the latest
+        m_tfListener->lookupTransform(base_frame_id_, global_frame_id_, ros::Time(0), baseInMap);
       } catch(tf::TransformException){
         ROS_WARN("Failed to lookup transform!");
         return;


### PR DESCRIPTION
If using the initial pose timestamp it will quite often be later than
the latest base -> map transform information (depends on how base -> odom
is being broadcasted). This happens with gazebo and in some robot setups.
In this situation, you get a future timestamp lookup error, e.g.

```
Failed to lookup dude transform!(Lookup would require extrapolation into
the future.  Requested time 8896.400000000 but the latest data is at time
8896.390000000, when looking up transform from frame [map] to frame
[base_footprint])
```

Note this is still not as complete as the amcl_node implementation, which
does a lookup to determine how much the robot has moved as well. However
it at least actually gets us somewhere.
