### PR TITLE
Republish costmap if origin changes

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_publisher.h
@@ -97,6 +97,7 @@ private:
   Costmap2D* costmap_;
   std::string global_frame_;
   unsigned int x0_, xn_, y0_, yn_;
+  double saved_origin_x_, saved_origin_y_;
   bool active_;
   bool always_send_full_costmap_;
   ros::Publisher costmap_pub_;

--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -105,6 +105,8 @@ void Costmap2DPublisher::prepareGrid()
   grid_.info.origin.position.y = wy - resolution / 2;
   grid_.info.origin.position.z = 0.0;
   grid_.info.origin.orientation.w = 1.0;
+  saved_origin_x_ = costmap_->getOriginX();
+  saved_origin_y_ = costmap_->getOriginY();
 
   grid_.data.resize(grid_.info.width * grid_.info.height);
 
@@ -117,10 +119,12 @@ void Costmap2DPublisher::prepareGrid()
 
 void Costmap2DPublisher::publishCostmap()
 {
-  double resolution = costmap_->getResolution();
+  float resolution = costmap_->getResolution();
 
   if (always_send_full_costmap_ || grid_.info.resolution != resolution ||
-      grid_.info.width != costmap_->getSizeInCellsX())
+      grid_.info.width != costmap_->getSizeInCellsX() ||
+      saved_origin_x_ != costmap_->getOriginX() ||
+      saved_origin_y_ != costmap_->getOriginY())
   {
     prepareGrid();
     if (costmap_pub_.getNumSubscribers() > 0)


### PR DESCRIPTION
Addresses bug #333. 

Also fixes a small floating point error. Comparing the double resolution to the float32 msg.info.resolution failed in some cases because of the lack of precision (0.0250000004 vs. 0.0250000000). Rather than change all the resolution types, changing the resolution to a float before comparison fixes the problem. 
