### PR TITLE
No more ghosts in the inflation layer

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -186,6 +186,7 @@ private:
 
   unsigned char** cached_costs_;
   double** cached_distances_;
+  double last_min_x_, last_min_y_, last_max_x_, last_max_y_;
 
   dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig> *dsrv_;
   void reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level);

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -35,6 +35,7 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
+#include <algorithm>
 #include <costmap_2d/inflation_layer.h>
 #include <costmap_2d/costmap_math.h>
 #include <costmap_2d/footprint.h>
@@ -58,6 +59,10 @@ InflationLayer::InflationLayer()
   , seen_(NULL)
   , cached_costs_(NULL)
   , cached_distances_(NULL)
+  , last_min_x_(-std::numeric_limits<float>::max())
+  , last_min_y_(-std::numeric_limits<float>::max())
+  , last_max_x_(std::numeric_limits<float>::max())
+  , last_max_y_(std::numeric_limits<float>::max())
 {
   access_ = new boost::shared_mutex();
 }
@@ -128,6 +133,10 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 {
   if (need_reinflation_)
   {
+    last_min_x_ = *min_x;
+    last_min_y_ = *min_y;
+    last_max_x_ = *max_x;
+    last_max_y_ = *max_y;
     // For some reason when I make these -<double>::max() it does not
     // work with Costmap2D::worldToMapEnforceBounds(), so I'm using
     // -<float>::max() instead.
@@ -136,6 +145,25 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
     *max_x = std::numeric_limits<float>::max();
     *max_y = std::numeric_limits<float>::max();
     need_reinflation_ = false;
+  }
+  else
+  {
+    double tmp_min_x = last_min_x_;
+    double tmp_min_y = last_min_y_;
+    double tmp_max_x = last_max_x_;
+    double tmp_max_y = last_max_y_;
+    last_min_x_ = *min_x;
+    last_min_y_ = *min_y;
+    last_max_x_ = *max_x;
+    last_max_y_ = *max_y;
+    // We need to include in the inflation cells outside the bounding
+    // box by the amount of the cell_inflation_radius_.  Cells
+    // up to that distance outside the box can still influence the costs
+    // stored in cells inside the box.
+    *min_x = std::min(tmp_min_x, *min_x) - inflation_radius_;
+    *min_y = std::min(tmp_min_y, *min_y) - inflation_radius_;
+    *max_x = std::max(tmp_max_x, *max_x) + inflation_radius_;
+    *max_y = std::max(tmp_max_y, *max_y) + inflation_radius_;
   }
 }
 
@@ -177,15 +205,6 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     seen_ = new bool[seen_size_];
   }
   memset(seen_, false, size_x * size_y * sizeof(bool));
-
-  // We need to include in the inflation cells outside the bounding
-  // box min_i...max_j, by the amount cell_inflation_radius_.  Cells
-  // up to that distance outside the box can still influence the costs
-  // stored in cells inside the box.
-  min_i -= cell_inflation_radius_;
-  min_j -= cell_inflation_radius_;
-  max_i += cell_inflation_radius_;
-  max_j += cell_inflation_radius_;
 
   min_i = std::max(0, min_i);
   min_j = std::max(0, min_j);


### PR DESCRIPTION
Previous bounds would fit the sensor measurements, and the inflation layer would clear
out to these, but leave 'ghosts' behind. These ghosts are from two sources - 1) the
inflation radius and 2) whole obstacles left behind as the robot has moved from the last point.

The modifications here remember the last bounds and set the new bounds so that a box at least
large enough to incorporate the old bounds plus the inflation radius is generated.

More detail in #388 for jade.
