### PR TITLE
Can the canTransform spam.

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -89,10 +89,13 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
     ros::spinOnce();
     if (last_error + ros::Duration(5.0) < ros::Time::now())
     {
-      ROS_WARN("Waiting on transform from %s to %s to become available before running costmap, tf error: %s",
+      ROS_WARN("Timed out waiting for transform from %s to %s to become available before running costmap, tf error: %s",
                robot_base_frame_.c_str(), global_frame_.c_str(), tf_error.c_str());
       last_error = ros::Time::now();
     }
+    // The error string will accumulate and errors will typically be the same, so the last
+    // will do for the warning above. Reset the string here to avoid accumulation.
+    tf_error.clear();
   }
 
   // check if we want a rolling window version of the costmap


### PR DESCRIPTION
Typically this throws a very large accumulated error message (once
every 100ms for 5.0s) which gets in the way of easily seeing what
went wrong when things do go wrong. e.g. before:

```
[ WARN] [1440127742.620334720]: Waiting on transform from base_footprint to map to
become available before running costmap, tf error: . canTransform returned after 0.107727
timeout was 0.1.. canTransform returned after 0.100816 timeout was 0.1.. canTransform 
returned after 0.100771 timeout was 0.1.. canTransform returned after 0.101238 timeout 
was 0.1.. canTransform returned after 0.100725 timeout was 0.1.. canTransform returned 
after 0.101388 timeout was 0.1.. canTransform returned after 0.10067 timeout was 0.1.. 
canTransform returned after 0.100841 timeout was 0.1.. canTransform returned after 
0.100671 timeout was 0.1.. canTransform returned after 0.100756 timeout was 0.1.. 
canTransform returned after 0.100722 timeout was 0.1.. canTransform returned after 0.100731 timeout was 0.1..
```
