### PR TITLE
recompute cluster stat when force_publication

### DIFF
--- a/amcl/include/amcl/pf/pf.h
+++ b/amcl/include/amcl/pf/pf.h
@@ -167,6 +167,10 @@ void pf_get_cep_stats(pf_t *pf, pf_vector_t *mean, double *var);
 int pf_get_cluster_stats(pf_t *pf, int cluster, double *weight,
                          pf_vector_t *mean, pf_matrix_t *cov);
 
+// Re-compute the cluster statistics for a sample set
+void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set);
+
+
 // Display the sample set
 void pf_draw_samples(pf_t *pf, struct _rtk_fig_t *fig, int max_samples);
 

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -39,8 +39,6 @@
 // with samples in them.
 static int pf_resample_limit(pf_t *pf, int k);
 
-// Re-compute the cluster statistics for a sample set
-static void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set);
 
 
 // Create a new filter

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1136,6 +1136,11 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
 
   if(resampled || force_publication)
   {
+    if (!resampled)
+    {
+	    // re-compute the cluster statistics
+	    pf_cluster_stats(pf_, pf_->sets);
+    }
     // Read out the current hypotheses
     double max_weight = 0.0;
     int max_weight_hyp = -1;


### PR DESCRIPTION
When force_publication is True, and no resample has been done the statistic
about the current clusters of particles are not recomputed. So amcl published
an outdated information.

This commit introduces a call to `pf_cluster_stats` when required (i.e no
resample but force_publication).
