### PR TITLE
[proposed for Kinetic Kame] navfn: change API

### DIFF
--- a/navfn/include/navfn/navfn_ros.h
+++ b/navfn/include/navfn/navfn_ros.h
@@ -70,11 +70,27 @@ namespace navfn {
       NavfnROS(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
 
       /**
+       * @brief  Constructor for the NavFnROS object
+       * @param  name The name of this planner
+       * @param  costmap A pointer to the costmap to use
+       * @param  global_frame The global frame of the costmap
+       */
+      NavfnROS(std::string name, costmap_2d::Costmap2D* costmap, std::string global_frame);
+
+      /**
        * @brief  Initialization function for the NavFnROS object
        * @param  name The name of this planner
        * @param  costmap A pointer to the ROS wrapper of the costmap to use for planning
        */
       void initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
+
+      /**
+       * @brief  Initialization function for the NavFnROS object
+       * @param  name The name of this planner
+       * @param  costmap A pointer to the costmap to use for planning
+       * @param  global_frame The global frame of the costmap
+       */
+      void initialize(std::string name, costmap_2d::Costmap2D* costmap, std::string global_frame);
 
       /**
        * @brief Given a goal pose in the world, compute a plan
@@ -148,7 +164,7 @@ namespace navfn {
       /**
        * @brief Store a copy of the current costmap in \a costmap.  Called by makePlan.
        */
-      costmap_2d::Costmap2DROS* costmap_ros_;
+      costmap_2d::Costmap2D* costmap_;
       boost::shared_ptr<NavFn> planner_;
       ros::Publisher plan_pub_;
       pcl_ros::Publisher<PotarrPoint> potarr_pub_;
@@ -168,6 +184,7 @@ namespace navfn {
       std::string tf_prefix_;
       boost::mutex mutex_;
       ros::ServiceServer make_plan_srv_;
+      std::string global_frame_;
   };
 };
 


### PR DESCRIPTION
Currently it is not possible to make use of navfn::NavfnROS without costmap_2d::Costmap2DROS. This means that you are forced to publish costmap every time you want to run planner on costmap.

This PR adds another constructor for navfn::NavfnROS to allow running navfn::NavfnROS on arbitrary costmap2d. This makes navfnROS usable in local scenarios, where you don't want to publish costmap, it doesn't make sense to publish costmap, or costmap is published without costmap_2d::Costmap2DROS.

navfn::NavfnROS:
    \* remove direct dependency on costmap_2d::Costmap2DROS
    \* add constructor for barebone costmap_2d::Costmap2D (user must provide also global_frame)
    \* NavfnROS::initialize() follows constructor semantics

nav_core::BaseGlobalPlanner interface unchanged
