### PR TITLE
Fixes an issue with having multiple static layers

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -79,25 +79,31 @@ void StaticLayer::onInitialize()
 
   lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 100), 0);
   unknown_cost_value_ = temp_unknown_cost_value;
-  // we'll subscribe to the latched topic that the map server uses
-  ROS_INFO("Requesting the map...");
-  map_sub_ = g_nh.subscribe(map_topic, 1, &StaticLayer::incomingMap, this);
-  map_received_ = false;
-  has_updated_data_ = false;
 
-  ros::Rate r(10);
-  while (!map_received_ && g_nh.ok())
+  // Only resubscribe if topic has changed
+  if (map_sub_.getTopic() != ros::names::resolve(map_topic))
   {
-    ros::spinOnce();
-    r.sleep();
-  }
+    // we'll subscribe to the latched topic that the map server uses
+    ROS_INFO("Requesting the map...");
+    map_sub_ = g_nh.subscribe(map_topic, 1, &StaticLayer::incomingMap, this);
+    map_received_ = false;
+    has_updated_data_ = false;
 
-  ROS_INFO("Received a %d X %d map at %f m/pix", getSizeInCellsX(), getSizeInCellsY(), getResolution());
+    ros::Rate r(10);
+    while (!map_received_ && g_nh.ok())
+    {
+      ros::spinOnce();
+      r.sleep();
+    }
 
-  if (subscribe_to_updates_)
-  {
-    ROS_INFO("Subscribing to updates");
-    map_update_sub_ = g_nh.subscribe(map_topic + "_updates", 10, &StaticLayer::incomingUpdate, this);
+    ROS_INFO("Received a %d X %d map at %f m/pix", getSizeInCellsX(), getSizeInCellsY(), getResolution());
+
+    if (subscribe_to_updates_)
+    {
+      ROS_INFO("Subscribing to updates");
+      map_update_sub_ = g_nh.subscribe(map_topic + "_updates", 10, &StaticLayer::incomingUpdate, this);
+
+    }
   }
 
   if (dsrv_)
@@ -250,8 +256,7 @@ void StaticLayer::reset()
   }
   else
   {
-    deactivate();
-    activate();
+    onInitialize();
   }
 }
 


### PR DESCRIPTION
If you have a static layer in both the local and global costmaps that
use the same map topic, there is a race condition that can cause the
static layer to get stuck after printing `Requesting map....`. This race
condition seems to be due to the call to shutdown in deactivate and how
the NodeHandle handles multiple subscribers under the hood.

This issue appears to happen about 1 in 1000 times in the setup I was
testing. This fix has never failed in over 1000000 tests. Instead of
calling activate and deactivate, the publisher is only recreated if the
topic has changed. Otherwise, it reuses the old setup.

@DLu can you take a look at this?
