### PR TITLE
fix related to issue #408 - With Rolling Window on, costmap_2d not pr…

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -263,8 +263,11 @@ void StaticLayer::reset()
 void StaticLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
                                double* max_x, double* max_y)
 {
-  if (!map_received_ || !(has_updated_data_ || has_extra_bounds_))
-    return;
+
+  if( !layered_costmap_->isRolling() ){
+    if (!map_received_ || !(has_updated_data_ || has_extra_bounds_))
+      return;
+  }
 
   useExtraBounds(min_x, min_y, max_x, max_y);
 


### PR DESCRIPTION
…operly updating bounds and costs in the static layer
