### PR TITLE
Add optional PNG saving for map_server

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -7,14 +7,24 @@ find_package(catkin REQUIRED
             tf
             nav_msgs
         )
+find_package(PNG REQUIRED)
+find_path(png++_INCLUDE_DIR
+  NAMES png++/png.hpp)
+
 
 find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(PkgConfig)
 pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
 if(NEW_YAMLCPP_FOUND)
-add_definitions(-DHAVE_NEW_YAMLCPP)
+  add_definitions(-DHAVE_NEW_YAMLCPP)
 endif(NEW_YAMLCPP_FOUND)
+
+pkg_check_modules (LIBPNG libpng REQUIRED)
+if(NOT png++_INCLUDE_DIR)
+  message(STATUS "libpng++ not found. PNG saving will be unavailable for map_server.")
+  add_definitions(-DNO_LIBPNGPP)
+endif()
 
 catkin_package(
     INCLUDE_DIRS
@@ -26,10 +36,23 @@ catkin_package(
         tf
         nav_msgs
 )
+include_directories (${LIBPNG_INCLUDE_DIRS})
+link_directories (${LIBPNG_LIBRARY_DIRS})
 
-include_directories( include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
-add_library(image_loader src/image_loader.cpp)
-target_link_libraries(image_loader SDL SDL_image ${Boost_LIBRARIES})
+include_directories( 
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${PNG_INCLUDE_DIR}
+)
+
+add_library(map_server_image_loader src/image_loader.cpp)
+target_link_libraries(map_server_image_loader
+  SDL
+  SDL_image
+  ${Boost_LIBRARIES}
+  ${LIBPNG_LIBRARIES}
+)
 
 add_executable(map_server src/main.cpp)
 target_link_libraries(map_server
@@ -38,11 +61,28 @@ target_link_libraries(map_server
     ${catkin_LIBRARIES}
 )
 
-add_executable(map_server-map_saver src/map_saver.cpp)
-set_target_properties(map_server-map_saver PROPERTIES OUTPUT_NAME map_saver)
+add_library(map_server_map_generator
+  src/map_generator.cpp
+  ${LIBPNG_LINK_FLAGS}
+)
+target_link_libraries(map_server_map_generator
+  ${catkin_LIBRARIES}
+  ${LIBPNG_LIBRARIES}
+)
+
+add_executable(map_server-map_saver
+  src/map_saver.cpp
+)
+set_target_properties(map_server-map_saver
+  PROPERTIES
+    OUTPUT_NAME
+      map_saver
+)
 target_link_libraries(map_server-map_saver
+    map_server_map_generator
     ${catkin_LIBRARIES}
-    )
+    ${LIBPNG_LIBRARIES}
+)
 
 # copy test data to same place as tests are run
 function(copy_test_data)
@@ -60,12 +100,22 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp test/test_constants.cpp)
   target_link_libraries(${PROJECT_NAME}_utest image_loader SDL SDL_image)
 
-  add_executable(rtest test/rtest.cpp test/test_constants.cpp)
-  target_link_libraries( rtest
+  add_executable(map_server_rtest
+    src/map_generator.cpp
+    src/image_loader.cpp
+    test/rtest.cpp
+    test/test_constants.cpp
+  )
+  target_link_libraries(map_server_rtest
       gtest
       ${catkin_LIBRARIES}
+      ${LIBPNG_LIBRARIES}
+      map_server_image_loader
+      map_server_map_generator
+      SDL
+      SDL_image
   )
-  add_dependencies(rtest nav_msgs_gencpp)
+  add_dependencies(map_server_rtest nav_msgs_gencpp)
 
   # This has to be done after we've already built targets, or catkin variables get borked
   find_package(rostest)

--- a/map_server/include/map_server/map_generator.h
+++ b/map_server/include/map_server/map_generator.h
@@ -27,51 +27,36 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#ifndef MAP_SERVER_MAP_GENERATOR_H
+#define MAP_SERVER_MAP_GENERATOR_H
 
-#include "map_server/map_generator.h"
-#include "ros/ros.h"
-#include "ros/console.h"
+#include <cstdio>
+#include <map>
 #include <string>
+#include "ros/ros.h"
+#include "nav_msgs/GetMap.h"
 
-#define USAGE "Usage: \n" \
-              "  map_saver -h\n"\
-              "  map_saver [-f <mapname>] [ROS remapping args]"
-
-int main(int argc, char** argv) 
+/**
+ * @brief Map generation node.
+ * @param mapname The filename to save the map to
+ */
+class MapGenerator 
 {
-  ros::init(argc, argv, "map_saver");
-  std::string mapname = "map";
+  public:
+    MapGenerator(const std::string& mapname);
 
-  for(int i=1; i<argc; i++)
-  {
-    if(!strcmp(argv[i], "-h"))
-    {
-      puts(USAGE);
-      return 0;
-    }
-    else if(!strcmp(argv[i], "-f"))
-    {
-      if(++i < argc)
-        mapname = argv[i];
-      else
-      {
-        puts(USAGE);
-        return 1;
-      }
-    }
-    else
-    {
-      puts(USAGE);
-      return 1;
-    }
-  }
-  
-  MapGenerator mg(mapname);
+    void savePNG(const std::string& mapdatafile,
+                 const nav_msgs::OccupancyGridConstPtr& map);
 
-  while(!mg.saved_map_ && ros::ok())
-    ros::spinOnce();
+    void savePGM(const std::string& mapdatafile,
+                 const nav_msgs::OccupancyGridConstPtr& map);
 
-  return 0;
-}
+    void mapCallback(const nav_msgs::OccupancyGridConstPtr& map);
 
+    std::string mapname_;
+    ros::Subscriber map_sub_;
+    bool saved_map_;
+    std::map<std::string, std::string> types_;
+};
 
+#endif

--- a/map_server/package.xml
+++ b/map_server/package.xml
@@ -30,4 +30,7 @@
     <run_depend>yaml-cpp</run_depend>
 
     <test_depend>rospy</test_depend>
+    <test_depend>libpng12-dev</test_depend>
+    <test_depend>libpng++-dev</test_depend>
+
 </package>

--- a/map_server/src/map_generator.cpp
+++ b/map_server/src/map_generator.cpp
@@ -1,0 +1,159 @@
+/*
+ * map_saver
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <ORGANIZATION> nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "map_server/map_generator.h"
+#include <cstdio>
+#include "ros/console.h"
+#include "tf/LinearMath/Matrix3x3.h"
+#include "geometry_msgs/Quaternion.h"
+
+#ifndef NO_LIBPNGPP
+// Use png++ for saving PNG files
+#include <png++/png.hpp>
+#endif
+
+/**
+ * @brief Map generation node.
+ */
+MapGenerator::MapGenerator(const std::string& mapname) : mapname_(mapname), saved_map_(false)
+{
+  // Map for filetype validity checking and filename extensions
+  types_["png"] = ".png";
+  types_["pgm"] = ".pgm";
+
+  ros::NodeHandle n;
+  ROS_INFO("Waiting for the map");
+  map_sub_ = n.subscribe("map", 1, &MapGenerator::mapCallback, this);
+}
+
+void MapGenerator::savePNG(const std::string& mapdatafile,
+                           const nav_msgs::OccupancyGridConstPtr& map)
+{
+
+#ifdef NO_LIBPNGPP
+  ROS_INFO("PNG is unsupported without the PNG++ library.");
+  std::string mapdatafile_pgm = mapname_ + ".pgm";
+  ROS_INFO("Writing map occupancy data to %s instead", mapdatafile_pgm.c_str());
+  savePGM(mapdatafile, map);
+#else
+  png::image< png::rgb_pixel > image(map->info.width, map->info.height);
+  for (unsigned int y = 0; y < map->info.height; y++) {
+    for (unsigned int x = 0; x < map->info.width; x++) {
+      unsigned int i = x + (map->info.height - y - 1) * map->info.width;
+      if (map->data[i] == 0) { //occ [0,0.1)
+        image[y][x] = png::rgb_pixel(254, 254, 254);
+      } else if (map->data[i] == +100) { //occ (0.65,1]
+        image[y][x] = png::rgb_pixel(0, 0, 0);
+      } else { //occ [0.1,0.65]
+        image[y][x] = png::rgb_pixel(205, 205, 205);
+      }
+    }
+  }
+
+  image.write(mapdatafile.c_str());
+#endif
+}
+
+
+void MapGenerator::savePGM(const std::string& mapdatafile,
+                           const nav_msgs::OccupancyGridConstPtr& map)
+{
+  FILE* out = fopen(mapdatafile.c_str(), "w");
+  if (!out)
+  {
+    ROS_ERROR("Couldn't save map file to %s", mapdatafile.c_str());
+    return;
+  }
+
+  fprintf(out, "P5\n# CREATOR: Map_generator.cpp %.3f m/pix\n%d %d\n255\n",
+          map->info.resolution, map->info.width, map->info.height);
+  for (unsigned int y = 0; y < map->info.height; y++) {
+    for (unsigned int x = 0; x < map->info.width; x++) {
+      unsigned int i = x + (map->info.height - y - 1) * map->info.width;
+      if (map->data[i] == 0) { //occ [0,0.1)
+        fputc(254, out);
+      } else if (map->data[i] == +100) { //occ (0.65,1]
+        fputc(000, out);
+      } else { //occ [0.1,0.65]
+        fputc(205, out);
+      }
+    }
+  }
+
+  fclose(out);      
+}
+
+void MapGenerator::mapCallback(const nav_msgs::OccupancyGridConstPtr& map)
+{
+  ROS_INFO("Received a %d X %d map @ %.3f m/pix",
+           map->info.width,
+           map->info.height,
+           map->info.resolution);
+
+  // Retrieve type to save map as
+  std::string map_type;
+  ros::param::param<std::string>("/map_saver/save_file_type", map_type, "pgm");
+  // Transform string to lowercase
+  std::transform(map_type.begin(), map_type.end(), map_type.begin(), ::tolower);
+  std::string map_ext;
+
+  if (types_.find(map_type) != types_.end()) {
+    map_ext = types_[map_type];
+  } else {
+    ROS_INFO("Could not find a supported filetype matching given parameter '%s'",
+             map_type.c_str());
+    map_ext = ".pgm";
+  }
+
+  std::string mapdatafile = mapname_ + map_ext;
+  ROS_INFO("Writing map occupancy data to %s", mapdatafile.c_str());
+
+  if (map_ext == ".png") {
+    savePNG(mapdatafile, map);
+  } else {
+    savePGM(mapdatafile, map);
+  }
+
+  std::string mapmetadatafile = mapname_ + ".yaml";
+  ROS_INFO("Writing map occupancy data to %s", mapmetadatafile.c_str());
+  FILE* yaml = fopen(mapmetadatafile.c_str(), "w");
+
+  geometry_msgs::Quaternion orientation = map->info.origin.orientation;
+  tf::Matrix3x3 mat(tf::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w));
+  double yaw, pitch, roll;
+  mat.getEulerYPR(yaw, pitch, roll);
+
+  fprintf(yaml, "image: %s\nresolution: %f\norigin: [%f, %f, %f]\nnegate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n\n",
+          mapdatafile.c_str(), map->info.resolution, map->info.origin.position.x, map->info.origin.position.y, yaw);
+
+  fclose(yaml);
+
+  ROS_INFO("Done\n");
+  saved_map_ = true;
+}


### PR DESCRIPTION
Changes:
- Adds optional PNG saving feature enabled by use of rosparam
- Adds rosparam **/map_saver/save_file_type** to determine file type for map_saver
- Add external library dependencies for PNG processing:
  - libpng - C library for processing PNG files
  - png++ - C++ wrapper for libpng
- Reorganized map_saver into map_saver.cpp and map_generator.cpp/.h for ease of testing
- Adds unit test for saving PGM and PNG map files

Things of note that probably need changing:
- The define guards work, but they might not be the right way to do things
- The PNG dependencies are test_depends for a couple of reasons:
  - They aren't necessary for building/running if the functionality isn't desired
  - The tests don't have define guards
- The CMakeLists.txt works, but the formatting might be off
  - libpng is a required package at the moment, which might interfere with the above test_depend assumptions
- Should I switch the rosparam to a namespaced one? I kept it hard coded since it would've required a node handle and none of the other map_server stuff seems to namespace their parameters
- Documentation? Not much code was changed but if more comments are needed I can add them in

I'll also have to update the ROS wiki with the rosparam/functionality changes if they get in.
