### PR TITLE
Adding map server raw mode implemented by DLu

### DIFF
--- a/map_server/include/map_server/image_loader.h
+++ b/map_server/include/map_server/image_loader.h
@@ -36,11 +36,11 @@
 #include "nav_msgs/GetMap.h"
 
 /** Map mode
- *  Default: TRINARY - 
+ *  Default: TRINARY -
  *      value >= occ_th - Occupied (100)
  *      value <= free_th - Free (0)
  *      otherwise - Unknown
- *  SCALE - 
+ *  SCALE -
  *      alpha < 1.0 - Unknown
  *      value >= occ_th - Occupied (100)
  *      value <= free_th - Free (0)

--- a/map_server/include/map_server/image_loader.h
+++ b/map_server/include/map_server/image_loader.h
@@ -35,6 +35,22 @@
 
 #include "nav_msgs/GetMap.h"
 
+/** Map mode
+ *  Default: TRINARY - 
+ *      value >= occ_th - Occupied (100)
+ *      value <= free_th - Free (0)
+ *      otherwise - Unknown
+ *  SCALE - 
+ *      alpha < 1.0 - Unknown
+ *      value >= occ_th - Occupied (100)
+ *      value <= free_th - Free (0)
+ *      otherwise - f( (free_th, occ_th) ) = (0, 100)
+ *          (linearly map in between values to (0,100)
+ *  RAW -
+ *      value = value
+ */
+enum MapMode {TRINARY, SCALE, RAW};
+
 namespace map_server
 {
 
@@ -49,13 +65,13 @@ namespace map_server
  * @param occ_th Threshold above which pixels are occupied
  * @param free_th Threshold below which pixels are free
  * @param origin Triple specifying 2-D pose of lower-left corner of image
- * @param trinary If true, only outputs Occupied/Free/Unknown
+ * @param mode Map mode
  * @throws std::runtime_error If the image file can't be loaded
  * */
 void loadMapFromFile(nav_msgs::GetMap::Response* resp,
                      const char* fname, double res, bool negate,
                      double occ_th, double free_th, double* origin,
-                     bool trinary=true);
+                     MapMode mode=TRINARY);
 }
 
 #endif

--- a/map_server/src/image_loader.cpp
+++ b/map_server/src/image_loader.cpp
@@ -124,13 +124,13 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
 
       if(negate)
         color_avg = 255 - color_avg;
-        
+
       if(mode==RAW){
           value = color_avg;
           resp->map.data[MAP_IDX(resp->map.info.width,i,resp->map.info.height - j - 1)] = value;
           continue;
       }
-        
+
 
       // If negate is true, we consider blacker pixels free, and whiter
       // pixels free.  Otherwise, it's vice versa.

--- a/map_server/src/image_loader.cpp
+++ b/map_server/src/image_loader.cpp
@@ -99,7 +99,9 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
   rowstride = img->pitch;
   n_channels = img->format->BytesPerPixel;
 
-  if (n_channels <= 3)
+  // NOTE: Trinary mode still overrides here to preserve existing behavior.
+  // Alpha will be averaged in with color channels when using trinary mode.
+  if (mode==TRINARY || !img->format->Amask)
     avg_channels = n_channels;
   else
     avg_channels = n_channels - 1;

--- a/map_server/src/image_loader.cpp
+++ b/map_server/src/image_loader.cpp
@@ -55,7 +55,7 @@ void
 loadMapFromFile(nav_msgs::GetMap::Response* resp,
                 const char* fname, double res, bool negate,
                 double occ_th, double free_th, double* origin,
-                bool trinary)
+                MapMode mode)
 {
   SDL_Surface* img;
 
@@ -99,7 +99,7 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
   rowstride = img->pitch;
   n_channels = img->format->BytesPerPixel;
 
-  if (trinary || n_channels == 1)
+  if (n_channels <= 3)
     avg_channels = n_channels;
   else
     avg_channels = n_channels - 1;
@@ -122,12 +122,19 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
       else
           alpha = *(p+n_channels-1);
 
+      if(negate)
+        color_avg = 255 - color_avg;
+        
+      if(mode==RAW){
+          value = color_avg;
+          resp->map.data[MAP_IDX(resp->map.info.width,i,resp->map.info.height - j - 1)] = value;
+          continue;
+      }
+        
+
       // If negate is true, we consider blacker pixels free, and whiter
       // pixels free.  Otherwise, it's vice versa.
-      if(negate)
-        occ = color_avg / 255.0;
-      else
-        occ = (255 - color_avg) / 255.0;
+      occ = (255 - color_avg) / 255.0;
       
       // Apply thresholds to RGB means to determine occupancy values for
       // map.  Note that we invert the graphics-ordering of the pixels to
@@ -136,7 +143,7 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
         value = +100;
       else if(occ < free_th)
         value = 0;
-      else if(trinary || alpha < 1.0)
+      else if(mode==TRINARY || alpha < 1.0)
         value = -1;
       else {
         double ratio = (occ - free_th) / (occ_th - free_th);

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -112,9 +112,9 @@ class MapServer
           exit(-1);
         }
         try { 
-          std::string modeS = "";   
-          doc["mode"] >> modeS; 
-          
+          std::string modeS = "";
+          doc["mode"] >> modeS;
+
           if(modeS=="trinary")
             mode = TRINARY;
           else if(modeS=="scale")

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -66,7 +66,7 @@ class MapServer
       double origin[3];
       int negate;
       double occ_th, free_th;
-      bool trinary = true;
+      MapMode mode = TRINARY;
       std::string frame_id;
       ros::NodeHandle private_nh("~");
       private_nh.param("frame_id", frame_id, std::string("map"));
@@ -112,10 +112,22 @@ class MapServer
           exit(-1);
         }
         try { 
-          doc["trinary"] >> trinary; 
+          std::string modeS = "";   
+          doc["mode"] >> modeS; 
+          
+          if(modeS=="trinary")
+            mode = TRINARY;
+          else if(modeS=="scale")
+            mode = SCALE;
+          else if(modeS=="raw")
+            mode = RAW;
+          else{
+            ROS_ERROR("Invalid mode tag \"%s\".", modeS.c_str());
+            exit(-1);
+          }
         } catch (YAML::Exception) { 
-          ROS_DEBUG("The map does not contain a trinary tag or it is invalid... assuming true");
-          trinary = true;
+          ROS_DEBUG("The map does not contain a mode tag or it is invalid... assuming Trinary");
+          mode = TRINARY;
         }
         try { 
           doc["origin"][0] >> origin[0]; 
@@ -153,7 +165,7 @@ class MapServer
       }
 
       ROS_INFO("Loading map from image \"%s\"", mapfname.c_str());
-      map_server::loadMapFromFile(&map_resp_,mapfname.c_str(),res,negate,occ_th,free_th, origin, trinary);
+      map_server::loadMapFromFile(&map_resp_,mapfname.c_str(),res,negate,occ_th,free_th, origin, mode);
       map_resp_.map.info.map_load_time = ros::Time::now();
       map_resp_.map.header.frame_id = frame_id;
       map_resp_.map.header.stamp = ros::Time::now();


### PR DESCRIPTION
Originally implemented by DLu (and I've added some minor cleanup), this adds a mode to the map server that simply passes pixel values straight through, allowing more flexibility for how maps are used.
