### PR TITLE
Virtual computeCost function and protected members for inflation layer

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -111,7 +111,7 @@ public:
   /** @brief  Given a distance, compute a cost.
    * @param  distance The distance from an obstacle in cells
    * @return A cost value for the distance */
-  inline unsigned char computeCost(double distance) const
+  virtual inline unsigned char computeCost(double distance) const
   {
     unsigned char cost = 0;
     if (distance == 0)
@@ -138,6 +138,11 @@ public:
 protected:
   virtual void onFootprintChanged();
   boost::recursive_mutex* inflation_access_;
+  
+  double resolution_;
+  double inflation_radius_;
+  double inscribed_radius_;
+  double weight_;
 
 private:
   /**
@@ -182,12 +187,9 @@ private:
   inline void enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my, unsigned int src_x,
                       unsigned int src_y);
 
-  double inflation_radius_, inscribed_radius_, weight_;
   unsigned int cell_inflation_radius_;
   unsigned int cached_cell_inflation_radius_;
   std::priority_queue<CellData> inflation_queue_;
-
-  double resolution_;
 
   bool* seen_;
   int seen_size_;


### PR DESCRIPTION
Currently child classes of the inflation layer do not have access to the resolution, inflation / inscribed radius and the weight (they are private.
So if you want to use a different cost function for the inflation you currently can't simply inherent and change the cost function.

So this changes the members needed for cost calculation to protected and makes the computeCost function virtual so it is possible to override it.
