### PR TITLE
[proposed for Kinetic Kame] navfn: change API

### DIFF
--- a/navfn/include/navfn/navfn_ros.h
+++ b/navfn/include/navfn/navfn_ros.h
@@ -70,11 +70,27 @@ namespace navfn {
       NavfnROS(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
 
       /**
+       * @brief  Constructor for the NavFnROS object
+       * @param  name The name of this planner
+       * @param  costmap A pointer to the costmap to use
+       * @param  global_frame The global frame of the costmap
+       */
+      NavfnROS(std::string name, costmap_2d::Costmap2D* costmap, std::string global_frame);
+
+      /**
        * @brief  Initialization function for the NavFnROS object
        * @param  name The name of this planner
        * @param  costmap A pointer to the ROS wrapper of the costmap to use for planning
        */
       void initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
+
+      /**
+       * @brief  Initialization function for the NavFnROS object
+       * @param  name The name of this planner
+       * @param  costmap A pointer to the costmap to use for planning
+       * @param  global_frame The global frame of the costmap
+       */
+      void initialize(std::string name, costmap_2d::Costmap2D* costmap, std::string global_frame);
 
       /**
        * @brief Given a goal pose in the world, compute a plan
@@ -148,7 +164,7 @@ namespace navfn {
       /**
        * @brief Store a copy of the current costmap in \a costmap.  Called by makePlan.
        */
-      costmap_2d::Costmap2DROS* costmap_ros_;
+      costmap_2d::Costmap2D* costmap_;
       boost::shared_ptr<NavFn> planner_;
       ros::Publisher plan_pub_;
       pcl_ros::Publisher<PotarrPoint> potarr_pub_;
@@ -168,6 +184,7 @@ namespace navfn {
       std::string tf_prefix_;
       boost::mutex mutex_;
       ros::ServiceServer make_plan_srv_;
+      std::string global_frame_;
   };
 };
 


### PR DESCRIPTION
this unbounds `NavfnROS` from `Costmap2DROS` allowing its use with just `Costmap2D` without all the `Costmap2DROS` machinery.

Reproposal of #406.
