### PR TITLE
Fix bug with resetting static layer

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -105,6 +105,10 @@ void StaticLayer::onInitialize()
 
     }
   }
+  else
+  {
+    has_updated_data_ = true;
+  }
 
   if (dsrv_)
   {


### PR DESCRIPTION
If we don't have a new topic, consider our old data as if it were new.

Cherrypicked https://github.com/ros-planning/navigation/pull/446 for kinetic
