### PR TITLE
Reordered initializer list to match order of declarations.

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -48,8 +48,8 @@ class CostmapLayer : public Layer, public Costmap2D
 {
 public:
   CostmapLayer() : has_extra_bounds_(false),
-    extra_min_x_(1e6), extra_min_y_(1e6),
-    extra_max_x_(-1e6), extra_max_y_(-1e6) {}
+    extra_min_x_(1e6), extra_max_x_(-1e6),
+    extra_min_y_(1e6), extra_max_y_(-1e6) {}
 
   bool isDiscretized()
   {


### PR DESCRIPTION
This avoids compiler warning with some compilers.

Cherrypicked https://github.com/ros-planning/navigation/pull/445 for jade
