### PR TITLE
Pass in action types as references for costmap algorithms.

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -357,7 +357,7 @@ protected:
    * @param  max_length The maximum desired length of the segment... allows you to not go all the way to the endpoint
    */
   template<class ActionType>
-    inline void raytraceLine(ActionType at, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+    inline void raytraceLine(ActionType &at, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
                              unsigned int max_length = UINT_MAX)
     {
       int dx = x1 - x0;
@@ -393,7 +393,7 @@ private:
    * @brief  A 2D implementation of Bresenham's raytracing algorithm... applies an action at each step
    */
   template<class ActionType>
-    inline void bresenham2D(ActionType at, unsigned int abs_da, unsigned int abs_db, int error_b, int offset_a,
+    inline void bresenham2D(ActionType &at, unsigned int abs_da, unsigned int abs_db, int error_b, int offset_a,
                             int offset_b, unsigned int offset, unsigned int max_length)
     {
       unsigned int end = std::min(max_length, abs_da);


### PR DESCRIPTION
This allows custom action types to record some data as they work
and be passed back out again for introspection of that data to make
higher level decisions. e.g. affect combination methods for the layer
depending on which cells got marked on that cycle.

Initial pull request for indigo (redirected here to kinetic to avoid ABI changes) in #396
