### PR TITLE
[amcl_laser] Revert the measurement computation to what is in Probabilistic Robotics textbook.

### DIFF
--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -197,10 +197,11 @@ double AMCLLaser::BeamModel(AMCLLaserData *data, pf_sample_set_t* set)
 
       assert(pz <= 1.0);
       assert(pz >= 0.0);
-      //      p *= pz;
+      // Instead of using the ad-hoc weight in a few lines later, this is what the textbook defines.
+      p *= pz;
       // here we have an ad-hoc weighting scheme for combining beam probs
       // works well, though...
-      p += pz*pz*pz;
+      // p += pz*pz*pz;
     }
 
     sample->weight *= p;


### PR DESCRIPTION
Originally raised [in this QandA](http://answers.ros.org/question/30711/amcl-observation-model/).

I'm also wondering how this ad-hoc weight was developed. I understand that this ad-hoc value has been functioning for the purpose, but ideally should better be to be documented with a mathematical rationale considering it's based on a textbook.

I don't expect this to be merged as it is, or even understand if rejected; if the rationale for the current ad-hoc modification is provided, I think that would be fine. And we might want to keep using a long-standing logic rather than modifying it, unless new logic is tested thoroughly or gone through a heavy review process. 
