### PR TITLE
[Fix] Illegal vector visit when no path planned

### DIFF
--- a/global_planner/src/orientation_filter.cpp
+++ b/global_planner/src/orientation_filter.cpp
@@ -54,6 +54,7 @@ void OrientationFilter::processPath(const geometry_msgs::PoseStamped& start,
                                     std::vector<geometry_msgs::PoseStamped>& path)
 {
     int n = path.size();
+    if (n == 0) return;
     switch(omode_) {
         case FORWARD:
             for(int i=0;i<n-1;i++){

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -529,6 +529,7 @@ namespace move_base {
     //if the planner fails or returns a zero length plan, planning failed
     if(!planner_->makePlan(start, goal, plan) || plan.empty()){
       ROS_DEBUG_NAMED("move_base","Failed to find a  plan to point (%.2f, %.2f)", goal.pose.position.x, goal.pose.position.y);
+      publishZeroVelocity();
       return false;
     }
 


### PR DESCRIPTION
When global interpolation is enabled, `OrientationFilter::processPath` will perform illegal vector visit.
This pull request fixes this bug.
When empty path is planned, our robot cannot successfully stop so I added a `publishZeroVelocity` for safety.
