### PR TITLE
Fix costmap artifacts

### DIFF
--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -150,10 +150,10 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
     last_min_y_ = *min_y;
     last_max_x_ = *max_x;
     last_max_y_ = *max_y;
-    *min_x = std::min(tmp_min_x, *min_x);
-    *min_y = std::min(tmp_min_y, *min_y);
-    *max_x = std::max(tmp_max_x, *max_x);
-    *max_y = std::max(tmp_max_y, *max_y);
+    *min_x = std::min(tmp_min_x, *min_x) + inflation_radius_;
+    *min_y = std::min(tmp_min_y, *min_y) + inflation_radius_;
+    *max_x = std::max(tmp_max_x, *max_x) + inflation_radius_;
+    *max_y = std::max(tmp_max_y, *max_y) + inflation_radius_;
   }
 }
 

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -126,10 +126,10 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
   std::vector<Observation> observations, clearing_observations;
 
   // get the marking observations
-  current = current && getMarkingObservations(observations);
+  current = getMarkingObservations(observations) && current;
 
   // get the clearing observations
-  current = current && getClearingObservations(clearing_observations);
+  current = getClearingObservations(clearing_observations) && current;
 
   // update the global current status
   current_ = current;


### PR DESCRIPTION
It looks like part of 1e01019 is necessary in addition to https://github.com/ros-planning/navigation/commit/16e5d80dac9430731dfa707362e26c1d36307b9c, otherwise some of the inflated area won't be cleared properly. This produces artifacts like:

![screenshot - 06012016 - 09 52 50 am](https://cloud.githubusercontent.com/assets/95345/15763322/ef66ab20-28d7-11e6-8d9f-5497de0fb600.png)

The second commit addresses issues with the voxel layer when not current that also causes similar artifacts like:

![screenshot - 06022016 - 08 13 39 am](https://cloud.githubusercontent.com/assets/95345/15763358/24632560-28d8-11e6-9f06-10b2c1e84458.png)
