### PR TITLE
Fixed bug with inflation layer that caused underinflation

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -179,8 +179,8 @@ private:
     return layered_costmap_->getCostmap()->cellDistance(world_dist);
   }
 
-  inline void enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my, unsigned int src_x,
-                      unsigned int src_y);
+  inline void enqueue(unsigned int index, unsigned int mx, unsigned int my,
+                      unsigned int src_x, unsigned int src_y);
 
   double inflation_radius_, inscribed_radius_, weight_;
   unsigned int cell_inflation_radius_;


### PR DESCRIPTION
When marking before adding to the priority queue, it was possible to
underestimate the cost of a cell. This is both dangerous and can lead to
unintended side-effects with navigation.
#478 for kinetic
