### PR TITLE
#485 inflation fix

### DIFF
--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -150,8 +150,8 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
     last_min_y_ = *min_y;
     last_max_x_ = *max_x;
     last_max_y_ = *max_y;
-    *min_x = std::min(tmp_min_x, *min_x) + inflation_radius_;
-    *min_y = std::min(tmp_min_y, *min_y) + inflation_radius_;
+    *min_x = std::min(tmp_min_x, *min_x) - inflation_radius_;
+    *min_y = std::min(tmp_min_y, *min_y) - inflation_radius_;
     *max_x = std::max(tmp_max_x, *max_x) + inflation_radius_;
     *max_y = std::max(tmp_max_y, *max_y) + inflation_radius_;
   }

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -99,7 +99,19 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
        ++plugin)
   {
+    double prev_minx = minx_;
+    double prev_miny = miny_;
+    double prev_maxx = maxx_;
+    double prev_maxy = maxy_;
     (*plugin)->updateBounds(robot_x, robot_y, robot_yaw, &minx_, &miny_, &maxx_, &maxy_);
+    if (minx_ > prev_minx || miny_ > prev_miny || maxx_ < prev_maxx || maxy_ < prev_maxy)
+    {
+      ROS_WARN_THROTTLE(1.0, "Illegal bounds change, was [tl: (%f, %f), br: (%f, %f)], but "
+                        "is now [tl: (%f, %f), br: (%f, %f)]. The offending layer is %s",
+                        prev_minx, prev_miny, prev_maxx , prev_maxy,
+                        minx_, miny_, maxx_ , maxy_,
+                        (*plugin)->getName().c_str());
+    }
   }
 
   int x0, xn, y0, yn;


### PR DESCRIPTION
Fixes a sign error in the inflation layer and adds a warning if there is ever another similar bug in any plugin.

Closes https://github.com/ros-planning/navigation/issues/485
