### PR TITLE
Fix #494: prevent zero-velocity commands during recovery behaviors

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -529,7 +529,6 @@ namespace move_base {
     //if the planner fails or returns a zero length plan, planning failed
     if(!planner_->makePlan(start, goal, plan) || plan.empty()){
       ROS_DEBUG_NAMED("move_base","Failed to find a  plan to point (%.2f, %.2f)", goal.pose.position.x, goal.pose.position.y);
-      publishZeroVelocity();
       return false;
     }
 


### PR DESCRIPTION
Partially reverts 0a686c90c6f188a2731f6f88c2c08610f0ec907e
