### PR TITLE
Issue #496 implementation

### DIFF
--- a/move_base/cfg/MoveBase.cfg
+++ b/move_base/cfg/MoveBase.cfg
@@ -2,7 +2,7 @@
 
 PACKAGE = 'move_base'
 
-from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, str_t, double_t, bool_t
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, str_t, double_t, bool_t, int_t
 
 gen = ParameterGenerator()
 
@@ -15,6 +15,7 @@ gen.add("planner_frequency", double_t, 0, "The rate in Hz at which to run the pl
 gen.add("controller_frequency", double_t, 0, "The rate in Hz at which to run the control loop and send velocity commands to the base.", 20, 0, 100)
 gen.add("planner_patience", double_t, 0, "How long the planner will wait in seconds in an attempt to find a valid plan before space-clearing operations are performed.", 5.0, 0, 100)
 gen.add("controller_patience", double_t, 0, "How long the controller will wait in seconds without receiving a valid control before space-clearing operations are performed.", 5.0, 0, 100)
+gen.add("max_planning_retries", int_t, 0, "How many times we will recall the planner in an attempt to find a valid plan before space-clearing operations are performed", -1, -1, 1000)
 gen.add("conservative_reset_dist", double_t, 0, "The distance away from the robot in meters at which obstacles will be cleared from the costmap when attempting to clear space in the map.", 3, 0, 50)
 
 gen.add("recovery_behavior_enabled", bool_t, 0, "Whether or not to enable the move_base recovery behaviors to attempt to clear out space.", True)

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -189,6 +189,8 @@ namespace move_base {
       tf::Stamped<tf::Pose> global_pose_;
       double planner_frequency_, controller_frequency_, inscribed_radius_, circumscribed_radius_;
       double planner_patience_, controller_patience_;
+      int32_t max_planning_retries_;
+      uint32_t planning_retries_;
       double conservative_reset_dist_, clearing_radius_;
       ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_;
       ros::Subscriber goal_sub_;


### PR DESCRIPTION
Add a max_planning_retries parameter as an alternative to planner_patience to limit the failed calls to global planner.

The new parameter is -1 by default, what means disabled and so the old good behavior based on planner patience.
