### PR TITLE
Publish status info about recovery behaviors when they occur

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -185,6 +185,7 @@ namespace move_base {
       std::string robot_base_frame_, global_frame_;
 
       std::vector<boost::shared_ptr<nav_core::RecoveryBehavior> > recovery_behaviors_;
+      std::vector<std::string> recovery_behavior_names_;
       unsigned int recovery_index_;
 
       geometry_msgs::PoseStamped global_pose_;
@@ -193,7 +194,7 @@ namespace move_base {
       int32_t max_planning_retries_;
       uint32_t planning_retries_;
       double conservative_reset_dist_, clearing_radius_;
-      ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_;
+      ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_, recovery_status_pub_;
       ros::Subscriber goal_sub_;
       ros::ServiceServer make_plan_srv_, clear_costmaps_srv_;
       bool shutdown_costmaps_, clearing_rotation_allowed_, recovery_behavior_enabled_;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -956,9 +956,9 @@ namespace move_base {
 
           move_base_msgs::RecoveryStatus msg;
           msg.pose_stamped = current_position;
-          msg.index = recovery_index_;
-          msg.size = recovery_behaviors_.size();
-          msg.name =  recovery_behavior_names_[recovery_index_];
+          msg.current_recovery_number = recovery_index_;
+          msg.total_number_of_recoveries = recovery_behaviors_.size();
+          msg.recovery_behavior_name =  recovery_behavior_names_[recovery_index_];
 
           recovery_status_pub_.publish(msg);
 

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -36,6 +36,7 @@
 *         Mike Phillips (put the planner in its own thread)
 *********************************************************************/
 #include <move_base/move_base.h>
+#include <move_base_msgs/RecoveryStatus.h>
 #include <cmath>
 
 #include <boost/algorithm/string.hpp>
@@ -97,6 +98,7 @@ namespace move_base {
 
     ros::NodeHandle action_nh("move_base");
     action_goal_pub_ = action_nh.advertise<move_base_msgs::MoveBaseActionGoal>("goal", 1);
+    recovery_status_pub_= action_nh.advertise<move_base_msgs::RecoveryStatus>("recovery_status", 1);
 
     //we'll provide a mechanism for some people to send goals as PoseStamped messages over a topic
     //they won't get any useful information back about its status, but this is useful for tools
@@ -951,6 +953,15 @@ namespace move_base {
         //we'll invoke whatever recovery behavior we're currently on if they're enabled
         if(recovery_behavior_enabled_ && recovery_index_ < recovery_behaviors_.size()){
           ROS_DEBUG_NAMED("move_base_recovery","Executing behavior %u of %zu", recovery_index_, recovery_behaviors_.size());
+
+          move_base_msgs::RecoveryStatus msg;
+          msg.pose_stamped = current_position;
+          msg.index = recovery_index_;
+          msg.size = recovery_behaviors_.size();
+          msg.name =  recovery_behavior_names_[recovery_index_];
+
+          recovery_status_pub_.publish(msg);
+
           recovery_behaviors_[recovery_index_]->runBehavior();
 
           //we at least want to give the robot some time to stop oscillating after executing the behavior
@@ -1066,6 +1077,7 @@ namespace move_base {
 
             //initialize the recovery behavior with its name
             behavior->initialize(behavior_list[i]["name"], &tf_, planner_costmap_ros_, controller_costmap_ros_);
+            recovery_behavior_names_.push_back(behavior_list[i]["name"]);
             recovery_behaviors_.push_back(behavior);
           }
           catch(pluginlib::PluginlibException& ex){

--- a/move_base_msgs/msg/RecoveryStatus.msg
+++ b/move_base_msgs/msg/RecoveryStatus.msg
@@ -1,0 +1,4 @@
+geometry_msgs/PoseStamped pose_stamped
+uint16 current_recovery_number
+uint16 total_number_of_recoveries
+string recovery_behavior_name

--- a/move_base_msgs/msg/RecoveryStatus.msg
+++ b/move_base_msgs/msg/RecoveryStatus.msg
@@ -1,4 +1,0 @@
-geometry_msgs/PoseStamped pose_stamped
-uint16 current_recovery_number
-uint16 total_number_of_recoveries
-string recovery_behavior_name


### PR DESCRIPTION
new message tells you where the behavior occured, the name, index,
and total number of behaviors.

Should I also do something for jade & kinetic? Seems like it would be appropriate.

Addresses #493 
