### PR TITLE
[jade] move_base: Add move_base_msgs to find_package.

### DIFF
--- a/move_base/CMakeLists.txt
+++ b/move_base/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED
         actionlib
         dynamic_reconfigure
         message_generation
+        move_base_msgs
         nav_core
         tf
 )


### PR DESCRIPTION
The `CMakeLists.txt` pf `move_base` was missing `move_base_msgs` in `find_package(catkin REQUIRED COMPONENTS ...)`, causing `catkin_make_isolated` builds to fail.

This PR should fix the problem by adding the `move_base_msgs` to the list of packages. It is already listed in `package.xml`.
