### PR TITLE
Fixed race condition with costmaps

### DIFF
--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -78,6 +78,10 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
+  // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
+  // implement thread unsafe updateBounds() functions.
+  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
+
   // if we're using a rolling buffer costmap... we need to update the origin using the robot's position
   if (rolling_window_)
   {
@@ -91,10 +95,6 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 
   minx_ = miny_ = 1e30;
   maxx_ = maxy_ = -1e30;
-
-  // Lock for the remainder of this function, some plugins (e.g. VoxelLayer)
-  // implement thread unsafe updateBounds() functions.
-  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
 
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
        ++plugin)


### PR DESCRIPTION
Modifying minx_, miny_, maxx_, and maxy_ without locking the mutex is
unsafe and is a race condition if updateMap is called from multiple
threads.
