### PR TITLE
Fix for #523: global planner called much more times than expected

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -619,54 +619,59 @@ namespace move_base {
         wait_for_wake = false;
       }
       ros::Time start_time = ros::Time::now();
-
-      //time to plan! get a copy of the goal and unlock the mutex
-      geometry_msgs::PoseStamped temp_goal = planner_goal_;
       lock.unlock();
-      ROS_DEBUG_NAMED("move_base_plan_thread","Planning...");
 
-      //run planner
-      planner_plan_->clear();
-      bool gotPlan = n.ok() && makePlan(temp_goal, *planner_plan_);
+      if(state_==PLANNING){
+        //time to plan! get a copy of the goal and unlock the mutex
+        geometry_msgs::PoseStamped temp_goal = planner_goal_;
+        ROS_DEBUG_NAMED("move_base_plan_thread","Planning...");
 
-      if(gotPlan){
-        ROS_DEBUG_NAMED("move_base_plan_thread","Got Plan with %zu points!", planner_plan_->size());
-        //pointer swap the plans under mutex (the controller will pull from latest_plan_)
-        std::vector<geometry_msgs::PoseStamped>* temp_plan = planner_plan_;
+        //run planner
+        planner_plan_->clear();
+        bool gotPlan = n.ok() && makePlan(temp_goal, *planner_plan_);
 
-        lock.lock();
-        planner_plan_ = latest_plan_;
-        latest_plan_ = temp_plan;
-        last_valid_plan_ = ros::Time::now();
-        planning_retries_ = 0;
-        new_global_plan_ = true;
+        if(gotPlan){
+          ROS_DEBUG_NAMED("move_base_plan_thread","Got Plan with %zu points!", planner_plan_->size());
+          //pointer swap the plans under mutex (the controller will pull from latest_plan_)
+          std::vector<geometry_msgs::PoseStamped>* temp_plan = planner_plan_;
 
-        ROS_DEBUG_NAMED("move_base_plan_thread","Generated a plan from the base_global_planner");
+          lock.lock();
+          planner_plan_ = latest_plan_;
+          latest_plan_ = temp_plan;
+          last_valid_plan_ = ros::Time::now();
+          planning_retries_ = 0;
+          new_global_plan_ = true;
 
-        //make sure we only start the controller if we still haven't reached the goal
-        if(runPlanner_)
-          state_ = CONTROLLING;
-        if(planner_frequency_ <= 0)
-          runPlanner_ = false;
-        lock.unlock();
-      }
-      //if we didn't get a plan and we are in the planning state (the robot isn't moving)
-      else if(state_==PLANNING){
-        ROS_DEBUG_NAMED("move_base_plan_thread","No Plan...");
-        ros::Time attempt_end = last_valid_plan_ + ros::Duration(planner_patience_);
+          ROS_DEBUG_NAMED("move_base_plan_thread","Generated a plan from the base_global_planner");
 
-        //check if we've tried to make a plan for over our time limit or our maximum number of retries
-        //issue #496: we stop planning when one of the conditions is true, but if max_planning_retries_
-        //is negative (the default), it is just ignored and we have the same behavior as ever
-        lock.lock();
-        if(runPlanner_ &&
-           (ros::Time::now() > attempt_end || ++planning_retries_ > uint32_t(max_planning_retries_))){
-          //we'll move into our obstacle clearing mode
-          state_ = CLEARING;
-          publishZeroVelocity();
-          recovery_trigger_ = PLANNING_R;
+          //make sure we only start the controller if we still haven't reached the goal
+          if(runPlanner_)
+            state_ = CONTROLLING;
+          if(planner_frequency_ <= 0)
+            runPlanner_ = false;
+          lock.unlock();
         }
-        lock.unlock();
+        //if we didn't get a plan and we are in the planning state (the robot isn't moving)
+        else{
+          ROS_DEBUG_NAMED("move_base_plan_thread","No Plan...");
+          ros::Time attempt_end = last_valid_plan_ + ros::Duration(planner_patience_);
+
+          //check if we've tried to make a plan for over our time limit or our maximum number of retries
+          //issue #496: we stop planning when one of the conditions is true, but if max_planning_retries_
+          //is negative (the default), it is just ignored and we have the same behavior as ever
+          lock.lock();
+          planning_retries_++;
+          if(runPlanner_ &&
+             (ros::Time::now() > attempt_end || planning_retries_ > uint32_t(max_planning_retries_))){
+            //we'll move into our obstacle clearing mode
+            state_ = CLEARING;
+            wait_for_wake = true;
+            publishZeroVelocity();
+            recovery_trigger_ = PLANNING_R;
+          }
+
+          lock.unlock();
+        }
       }
 
       //take the mutex for the next iteration
@@ -996,6 +1001,8 @@ namespace move_base {
 
           //we'll check if the recovery behavior actually worked
           ROS_DEBUG_NAMED("move_base_recovery","Going back to planning state");
+          last_valid_plan_ = ros::Time::now();
+          planning_retries_ = 0;
           state_ = PLANNING;
 
           //update the index of the next recovery behavior that we'll try

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -619,11 +619,11 @@ namespace move_base {
         wait_for_wake = false;
       }
       ros::Time start_time = ros::Time::now();
-      lock.unlock();
 
       if(state_==PLANNING){
         //time to plan! get a copy of the goal and unlock the mutex
         geometry_msgs::PoseStamped temp_goal = planner_goal_;
+        lock.unlock();
         ROS_DEBUG_NAMED("move_base_plan_thread","Planning...");
 
         //run planner
@@ -672,6 +672,11 @@ namespace move_base {
 
           lock.unlock();
         }
+      }
+      else
+      {
+        //not planning, so just unlock the mutex
+        lock.unlock();
       }
 
       //take the mutex for the next iteration


### PR DESCRIPTION
So now planner is called 1 + max_planning_retries in a first try, and then 1 + max_planning_retries after every recovery behavior. Or up to  planner_patiente seconds after every recovery. I think this is the expected operation.

Seems to work fine now, but move_base.cpp code is quite messy, so probably needs at least one independent tester.
