### PR TITLE
Speedup (~60%) inflation layer update

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(costmap_2d)
 
-# Required to use is_sorted and all_of algorithms
-add_definitions("-std=c++11")
-
 find_package(catkin REQUIRED
         COMPONENTS
             cmake_modules

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(costmap_2d)
 
+# Required to use is_sorted and all_of algorithms
+add_definitions("-std=c++11")
+
 find_package(catkin REQUIRED
         COMPONENTS
             cmake_modules

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -44,7 +44,6 @@
 #include <costmap_2d/InflationPluginConfig.h>
 #include <dynamic_reconfigure/server.h>
 #include <boost/thread.hpp>
-#include <queue>
 
 namespace costmap_2d
 {
@@ -57,7 +56,6 @@ class CellData
 public:
   /**
    * @brief  Constructor for a CellData objects
-   * @param  d The distance to the nearest obstacle, used for ordering in the priority queue
    * @param  i The index of the cell in the cost map
    * @param  x The x coordinate of the cell in the cost map
    * @param  y The y coordinate of the cell in the cost map
@@ -65,24 +63,14 @@ public:
    * @param  sy The y coordinate of the closest obstacle cell in the costmap
    * @return
    */
-  CellData(double d, double i, unsigned int x, unsigned int y, unsigned int sx, unsigned int sy) :
-      distance_(d), index_(i), x_(x), y_(y), src_x_(sx), src_y_(sy)
+  CellData(double i, unsigned int x, unsigned int y, unsigned int sx, unsigned int sy) :
+      index_(i), x_(x), y_(y), src_x_(sx), src_y_(sy)
   {
   }
-  double distance_;
   unsigned int index_;
   unsigned int x_, y_;
   unsigned int src_x_, src_y_;
 };
-
-/**
- * @brief Provide an ordering between CellData objects in the priority queue
- * @return We want the lowest distance to have the highest priority... so this returns true if a has higher priority than b
- */
-inline bool operator<(const CellData &a, const CellData &b)
-{
-  return a.distance_ > b.distance_;
-}
 
 class InflationLayer : public Layer
 {
@@ -185,7 +173,7 @@ private:
   double inflation_radius_, inscribed_radius_, weight_;
   unsigned int cell_inflation_radius_;
   unsigned int cached_cell_inflation_radius_;
-  std::priority_queue<CellData> inflation_queue_;
+  std::map<double, std::vector<CellData>> inflation_cells_;
 
   double resolution_;
 

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -173,7 +173,7 @@ private:
   double inflation_radius_, inscribed_radius_, weight_;
   unsigned int cell_inflation_radius_;
   unsigned int cached_cell_inflation_radius_;
-  std::map<double, std::vector<CellData>> inflation_cells_;
+  std::map<double, std::vector<CellData> > inflation_cells_;
 
   double resolution_;
 

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -232,10 +232,12 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
   std::map<double, std::vector<CellData> >::iterator bin;
   for (bin = inflation_cells_.begin(); bin != inflation_cells_.end(); ++bin)
   {
-    for (std::vector<CellData>::iterator cell = bin->second.begin(); cell != bin->second.end(); ++cell)
+    for (int i = 0; i < bin->second.size(); ++i)
     {
       // process all cells at distance dist_bin.first
-      unsigned int index = cell->index_;
+      const CellData& cell = bin->second[i];
+
+      unsigned int index = cell.index_;
 
       // ignore if already visited
       if (seen_[index])
@@ -245,10 +247,10 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
 
       seen_[index] = true;
 
-      unsigned int mx = cell->x_;
-      unsigned int my = cell->y_;
-      unsigned int sx = cell->src_x_;
-      unsigned int sy = cell->src_y_;
+      unsigned int mx = cell.x_;
+      unsigned int my = cell.y_;
+      unsigned int sx = cell.src_x_;
+      unsigned int sy = cell.src_y_;
 
       // assign the cost associated with the distance from an obstacle to the cell
       unsigned char cost = costLookup(mx, my, sx, sy);

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -213,7 +213,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
   // We use a map<distance, list> to emulate the priority queue used before, with a notable performance boost
 
   // Start with lethal obstacles: by definition distance is 0.0
-  auto& obs_bin = inflation_cells_[0.0];
+  std::vector<CellData>& obs_bin = inflation_cells_[0.0];
   for (int j = min_j; j < max_j; j++)
   {
     for (int i = min_i; i < max_i; i++)
@@ -229,12 +229,13 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
 
   // Process cells by increasing distance; new cells are appended to the corresponding distance bin, so they
   // can overtake previously inserted but farther away cells
-  for (auto& dist_bin: inflation_cells_)
+  std::map<double, std::vector<CellData> >::iterator bin;
+  for (bin = inflation_cells_.begin(); bin != inflation_cells_.end(); ++bin)
   {
-    for (auto& current_cell: dist_bin.second)
+    for (std::vector<CellData>::iterator cell = bin->second.begin(); cell != bin->second.end(); ++cell)
     {
       // process all cells at distance dist_bin.first
-      unsigned int index = current_cell.index_;
+      unsigned int index = cell->index_;
 
       // ignore if already visited
       if (seen_[index])
@@ -244,10 +245,10 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
 
       seen_[index] = true;
 
-      unsigned int mx = current_cell.x_;
-      unsigned int my = current_cell.y_;
-      unsigned int sx = current_cell.src_x_;
-      unsigned int sy = current_cell.src_y_;
+      unsigned int mx = cell->x_;
+      unsigned int my = cell->y_;
+      unsigned int sx = cell->src_x_;
+      unsigned int sy = cell->src_y_;
 
       // assign the cost associated with the distance from an obstacle to the cell
       unsigned char cost = costLookup(mx, my, sx, sy);

--- a/costmap_2d/test/inflation_tests.cpp
+++ b/costmap_2d/test/inflation_tests.cpp
@@ -77,47 +77,47 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
   std::map<double, std::vector<CellData> > m;
   CellData initial(costmap->getIndex(mx, my), mx, my, mx, my);
   m[0].push_back(initial);
-  for (auto& dist_bin: m)
+  for (std::map<double, std::vector<CellData> >::iterator bin = m.begin(); bin != m.end(); ++bin)
   {
-    for (auto& cell: dist_bin.second)
+    for (std::vector<CellData>::iterator cell = bin->second.begin(); cell != bin->second.end(); ++cell)
     {
-      if (!seen[cell.index_])
+      if (!seen[cell->index_])
       {
-        seen[cell.index_] = true;
-        unsigned int dx = abs(cell.x_ - cell.src_x_);
-        unsigned int dy = abs(cell.y_ - cell.src_y_);
+        seen[cell->index_] = true;
+        unsigned int dx = abs(cell->x_ - cell->src_x_);
+        unsigned int dy = abs(cell->y_ - cell->src_y_);
         double dist = hypot(dx, dy);
 
         unsigned char expected_cost = ilayer->computeCost(dist);
-        ASSERT_TRUE(costmap->getCost(cell.x_, cell.y_) >= expected_cost);
+        ASSERT_TRUE(costmap->getCost(cell->x_, cell->y_) >= expected_cost);
 
         if (dist > inflation_radius)
         {
           continue;
         }
 
-        if (cell.x_ > 0)
+        if (cell->x_ > 0)
         {
-          CellData data(costmap->getIndex(cell.x_-1, cell.y_),
-                        cell.x_-1, cell.y_, cell.src_x_, cell.src_y_);
+          CellData data(costmap->getIndex(cell->x_-1, cell->y_),
+                        cell->x_-1, cell->y_, cell->src_x_, cell->src_y_);
           m[dist].push_back(data);
         }
-        if (cell.y_ > 0)
+        if (cell->y_ > 0)
         {
-          CellData data(costmap->getIndex(cell.x_, cell.y_-1),
-                        cell.x_, cell.y_-1, cell.src_x_, cell.src_y_);
+          CellData data(costmap->getIndex(cell->x_, cell->y_-1),
+                        cell->x_, cell->y_-1, cell->src_x_, cell->src_y_);
           m[dist].push_back(data);
         }
-        if (cell.x_ < costmap->getSizeInCellsX() - 1)
+        if (cell->x_ < costmap->getSizeInCellsX() - 1)
         {
-          CellData data(costmap->getIndex(cell.x_+1, cell.y_),
-                        cell.x_+1, cell.y_, cell.src_x_, cell.src_y_);
+          CellData data(costmap->getIndex(cell->x_+1, cell->y_),
+                        cell->x_+1, cell->y_, cell->src_x_, cell->src_y_);
           m[dist].push_back(data);
         }
-        if (cell.y_ < costmap->getSizeInCellsY() - 1)
+        if (cell->y_ < costmap->getSizeInCellsY() - 1)
         {
-          CellData data(costmap->getIndex(cell.x_, cell.y_+1),
-                        cell.x_, cell.y_+1, cell.src_x_, cell.src_y_);
+          CellData data(costmap->getIndex(cell->x_, cell->y_+1),
+                        cell->x_, cell->y_+1, cell->src_x_, cell->src_y_);
           m[dist].push_back(data);
         }
       }

--- a/costmap_2d/test/inflation_tests.cpp
+++ b/costmap_2d/test/inflation_tests.cpp
@@ -74,7 +74,7 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
 {
   bool* seen = new bool[costmap->getSizeInCellsX() * costmap->getSizeInCellsY()];
   memset(seen, false, costmap->getSizeInCellsX() * costmap->getSizeInCellsY() * sizeof(bool));
-  std::map<double, std::vector<CellData>> m;
+  std::map<double, std::vector<CellData> > m;
   CellData initial(costmap->getIndex(mx, my), mx, my, mx, my);
   m[0].push_back(initial);
   for (auto& dist_bin: m)

--- a/costmap_2d/test/inflation_tests.cpp
+++ b/costmap_2d/test/inflation_tests.cpp
@@ -31,6 +31,7 @@
  * @author David Lu!!
  * Test harness for InflationLayer for Costmap2D
  */
+#include <map>
 
 #include <costmap_2d/costmap_2d.h>
 #include <costmap_2d/layered_costmap.h>
@@ -38,8 +39,6 @@
 #include <costmap_2d/inflation_layer.h>
 #include <costmap_2d/observation_buffer.h>
 #include <costmap_2d/testing_helper.h>
-#include <queue>
-#include <set>
 #include <gtest/gtest.h>
 #include <tf/transform_listener.h>
 
@@ -75,54 +74,54 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
 {
   bool* seen = new bool[costmap->getSizeInCellsX() * costmap->getSizeInCellsY()];
   memset(seen, false, costmap->getSizeInCellsX() * costmap->getSizeInCellsY() * sizeof(bool));
-  std::priority_queue<CellData> q;
-  CellData initial(0, costmap->getIndex(mx, my), mx, my, mx, my);
-  q.push(initial);
-  while (!q.empty())
+  std::map<double, std::vector<CellData>> m;
+  CellData initial(costmap->getIndex(mx, my), mx, my, mx, my);
+  m[0].push_back(initial);
+  for (auto& dist_bin: m)
   {
-    const CellData& cell = q.top();
-    if (!seen[cell.index_])
+    for (auto& cell: dist_bin.second)
     {
-      seen[cell.index_] = true;
-      unsigned int dx = abs(cell.x_ - cell.src_x_);
-      unsigned int dy = abs(cell.y_ - cell.src_y_);
-      double dist = hypot(dx, dy);
+      if (!seen[cell.index_])
+      {
+        seen[cell.index_] = true;
+        unsigned int dx = abs(cell.x_ - cell.src_x_);
+        unsigned int dy = abs(cell.y_ - cell.src_y_);
+        double dist = hypot(dx, dy);
 
-      unsigned char expected_cost = ilayer->computeCost(dist);
-      ASSERT_TRUE(costmap->getCost(cell.x_, cell.y_) >= expected_cost);
+        unsigned char expected_cost = ilayer->computeCost(dist);
+        ASSERT_TRUE(costmap->getCost(cell.x_, cell.y_) >= expected_cost);
 
-      if (dist > inflation_radius)
-      {
-        q.pop();
-        continue;
-      }
+        if (dist > inflation_radius)
+        {
+          continue;
+        }
 
-      if (cell.x_ > 0)
-      {
-        CellData data(dist, costmap->getIndex(cell.x_-1, cell.y_),
-                      cell.x_-1, cell.y_, cell.src_x_, cell.src_y_);
-        q.push(data);
-      }
-      if (cell.y_ > 0)
-      {
-        CellData data(dist, costmap->getIndex(cell.x_, cell.y_-1),
-                      cell.x_, cell.y_-1, cell.src_x_, cell.src_y_);
-        q.push(data);
-      }
-      if (cell.x_ < costmap->getSizeInCellsX() - 1)
-      {
-        CellData data(dist, costmap->getIndex(cell.x_+1, cell.y_),
-                      cell.x_+1, cell.y_, cell.src_x_, cell.src_y_);
-        q.push(data);
-      }
-      if (cell.y_ < costmap->getSizeInCellsY() - 1)
-      {
-        CellData data(dist, costmap->getIndex(cell.x_, cell.y_+1),
-                      cell.x_, cell.y_+1, cell.src_x_, cell.src_y_);
-        q.push(data);
+        if (cell.x_ > 0)
+        {
+          CellData data(costmap->getIndex(cell.x_-1, cell.y_),
+                        cell.x_-1, cell.y_, cell.src_x_, cell.src_y_);
+          m[dist].push_back(data);
+        }
+        if (cell.y_ > 0)
+        {
+          CellData data(costmap->getIndex(cell.x_, cell.y_-1),
+                        cell.x_, cell.y_-1, cell.src_x_, cell.src_y_);
+          m[dist].push_back(data);
+        }
+        if (cell.x_ < costmap->getSizeInCellsX() - 1)
+        {
+          CellData data(costmap->getIndex(cell.x_+1, cell.y_),
+                        cell.x_+1, cell.y_, cell.src_x_, cell.src_y_);
+          m[dist].push_back(data);
+        }
+        if (cell.y_ < costmap->getSizeInCellsY() - 1)
+        {
+          CellData data(costmap->getIndex(cell.x_, cell.y_+1),
+                        cell.x_, cell.y_+1, cell.src_x_, cell.src_y_);
+          m[dist].push_back(data);
+        }
       }
     }
-    q.pop();
   }
   delete[] seen;
 }
@@ -242,11 +241,11 @@ TEST(costmap, testCostFunctionCorrectness){
 
 /**
  * Test that there is no regression and that costs do not get
- * underestimated due to the underlying priority queue being
- * misused. This is a more thorough test of the cost function being
- * correctly applied.
+ * underestimated with the distance-as-key map used to replace
+ * the previously used priority queue. This is a more thorough
+ * test of the cost function being correctly applied.
  */
-TEST(costmap, testPriorityQueueUseCorrectness){
+TEST(costmap, testInflationOrderCorrectness){
   tf::TransformListener tf;
   LayeredCostmap layers("frame", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);

--- a/costmap_2d/test/inflation_tests.cpp
+++ b/costmap_2d/test/inflation_tests.cpp
@@ -79,45 +79,46 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
   m[0].push_back(initial);
   for (std::map<double, std::vector<CellData> >::iterator bin = m.begin(); bin != m.end(); ++bin)
   {
-    for (std::vector<CellData>::iterator cell = bin->second.begin(); cell != bin->second.end(); ++cell)
+    for (int i = 0; i < bin->second.size(); ++i)
     {
-      if (!seen[cell->index_])
+      const CellData& cell = bin->second[i];
+      if (!seen[cell.index_])
       {
-        seen[cell->index_] = true;
-        unsigned int dx = abs(cell->x_ - cell->src_x_);
-        unsigned int dy = abs(cell->y_ - cell->src_y_);
+        seen[cell.index_] = true;
+        unsigned int dx = abs(cell.x_ - cell.src_x_);
+        unsigned int dy = abs(cell.y_ - cell.src_y_);
         double dist = hypot(dx, dy);
 
         unsigned char expected_cost = ilayer->computeCost(dist);
-        ASSERT_TRUE(costmap->getCost(cell->x_, cell->y_) >= expected_cost);
+        ASSERT_TRUE(costmap->getCost(cell.x_, cell.y_) >= expected_cost);
 
         if (dist > inflation_radius)
         {
           continue;
         }
 
-        if (cell->x_ > 0)
+        if (cell.x_ > 0)
         {
-          CellData data(costmap->getIndex(cell->x_-1, cell->y_),
-                        cell->x_-1, cell->y_, cell->src_x_, cell->src_y_);
+          CellData data(costmap->getIndex(cell.x_-1, cell.y_),
+                        cell.x_-1, cell.y_, cell.src_x_, cell.src_y_);
           m[dist].push_back(data);
         }
-        if (cell->y_ > 0)
+        if (cell.y_ > 0)
         {
-          CellData data(costmap->getIndex(cell->x_, cell->y_-1),
-                        cell->x_, cell->y_-1, cell->src_x_, cell->src_y_);
+          CellData data(costmap->getIndex(cell.x_, cell.y_-1),
+                        cell.x_, cell.y_-1, cell.src_x_, cell.src_y_);
           m[dist].push_back(data);
         }
-        if (cell->x_ < costmap->getSizeInCellsX() - 1)
+        if (cell.x_ < costmap->getSizeInCellsX() - 1)
         {
-          CellData data(costmap->getIndex(cell->x_+1, cell->y_),
-                        cell->x_+1, cell->y_, cell->src_x_, cell->src_y_);
+          CellData data(costmap->getIndex(cell.x_+1, cell.y_),
+                        cell.x_+1, cell.y_, cell.src_x_, cell.src_y_);
           m[dist].push_back(data);
         }
-        if (cell->y_ < costmap->getSizeInCellsY() - 1)
+        if (cell.y_ < costmap->getSizeInCellsY() - 1)
         {
-          CellData data(costmap->getIndex(cell->x_, cell->y_+1),
-                        cell->x_, cell->y_+1, cell->src_x_, cell->src_y_);
+          CellData data(costmap->getIndex(cell.x_, cell.y_+1),
+                        cell.x_, cell.y_+1, cell.src_x_, cell.src_y_);
           m[dist].push_back(data);
         }
       }


### PR DESCRIPTION
Following [this discussion](https://github.com/ros-planning/navigation/issues/468), the pop in the priority_queue used for sorting the cells to inflate takes a lot of CPU. I replaced it by a map containing cells to inflate split by distance from the closest obstacle. 

I have played around with the changes for a while, and it seems to work fine, also scaling well to higher resolutions and inflation radius. After profiling my changes, the new biggest CPU eater is the map lookup for distances on enqueue method. Maybe someone with better understanding of STL containers can give an extra speedup, knowing this.

I require C++11. Hope it's not an issue for indigo code.
