### PR TITLE
renamed targets for message generation (gencpp -> generate_messages_c…

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -96,7 +96,7 @@ add_library(costmap_2d
   src/footprint.cpp
   src/costmap_layer.cpp
 )
-add_dependencies(costmap_2d geometry_msgs_gencpp)
+add_dependencies(costmap_2d geometry_msgs_generate_messages_cpp)
 target_link_libraries(costmap_2d
   ${PCL_LIBRARIES}
   ${Boost_LIBRARIES}
@@ -116,16 +116,16 @@ target_link_libraries(layers
 
 add_dependencies(costmap_2d costmap_2d_gencfg)
 add_dependencies(layers costmap_2d_gencfg)
-add_dependencies(costmap_2d costmap_2d_gencpp)
+add_dependencies(costmap_2d costmap_2d_generate_messages_cpp)
 
 add_executable(costmap_2d_markers src/costmap_2d_markers.cpp)
-add_dependencies(costmap_2d_markers visualization_msgs_gencpp)
+add_dependencies(costmap_2d_markers visualization_msgs_generate_messages_cpp)
 target_link_libraries(costmap_2d_markers
     costmap_2d
     )
 
 add_executable(costmap_2d_cloud src/costmap_2d_cloud.cpp)
-add_dependencies(costmap_2d_cloud sensor_msgs_gencpp)
+add_dependencies(costmap_2d_cloud sensor_msgs_generate_messages_cpp)
 target_link_libraries(costmap_2d_cloud
     costmap_2d
     )


### PR DESCRIPTION
…pp) in order to avoid warnings for non-existing target dependencies
