### PR TITLE
address gcc6 build error

### DIFF
--- a/move_slow_and_clear/CMakeLists.txt
+++ b/move_slow_and_clear/CMakeLists.txt
@@ -20,9 +20,8 @@ find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
-    SYSTEM
-        ${EIGEN3_INCLUDE_DIRS}
-        ${PCL_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
 )
 add_definitions(${EIGEN3_DEFINITIONS})
 

--- a/navfn/CMakeLists.txt
+++ b/navfn/CMakeLists.txt
@@ -22,7 +22,6 @@ remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
-    SYSTEM
     ${EIGEN3_INCLUDE_DIRS}
     ${PCL_INCLUDE_DIRS}
 )


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`, as including '-isystem /usr/include' breaks with gcc6, cf., https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for this package in the same way it was addressed in various other ROS packages. A list of related commits and pull requests is at https://github.com/ros/rosdistro/issues/12783

The SYSTEM attribute for the eigen and pcl include directories was added in commit 9e876d2b [1] on 2012-09-16 during the package's transition to ROS Groovy. The reason for using the SYSTEM attribute cannot be inferred from that commit.

This attribute remained in the CMakeLists.txt during further refinements in commits be4aebdb [2] and 3a156140 [3] on 2014-02-24, and commit 4a7578b0 [4] on 2016-10-23.

[1] https://github.com/ros-planning/navigation/commit/9e876d2b45aca2e2166ac5a508b0e7c7abc50717
[2] https://github.com/ros-planning/navigation/commit/be4aebdb658381104b8e70f832091926e67ea0b4
[3] https://github.com/ros-planning/navigation/commit/3a156140439ea2300aaad45f7f2a65dab503ff24
[4] https://github.com/ros-planning/navigation/commit/4a7578b04dca866e3ab81b31cd9b86e68733a597
