### PR TITLE
Set frame_id and stamp on Path message even if path is not found.

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -337,10 +337,8 @@ void GlobalPlanner::publishPlan(const std::vector<geometry_msgs::PoseStamped>& p
     nav_msgs::Path gui_path;
     gui_path.poses.resize(path.size());
 
-    if (!path.empty()) {
-        gui_path.header.frame_id = path[0].header.frame_id;
-        gui_path.header.stamp = path[0].header.stamp;
-    }
+    gui_path.header.frame_id = frame_id_;
+    gui_path.header.stamp = ros::Time::now();
 
     // Extract the plan in world co-ordinates, we assume the path is all in the same frame
     for (unsigned int i = 0; i < path.size(); i++) {


### PR DESCRIPTION
When path planning is failed, global planner publishes nav_msgs::Path without frame_id and stamp now. It causes error on rviz. Fix it to publish nav_msgs::Path with frame_id and stamp even if path planning was failed.

Before:

```
header: 
  seq: 24
  stamp: 
    secs: 0
    nsecs:         0
  frame_id: ''
poses: []
```

After:

```
header: 
  seq: 122
  stamp: 
    secs: 1477468563
    nsecs: 495041114
  frame_id: map
poses: []

```
