### PR TITLE
Make BaseGlobalPlanner::makePlan overload return. [Jade]

### DIFF
--- a/nav_core/include/nav_core/base_global_planner.h
+++ b/nav_core/include/nav_core/base_global_planner.h
@@ -70,7 +70,7 @@ namespace nav_core {
                             double& cost)
       {
         cost = 0;
-        makePlan(start, goal, plan);
+        return makePlan(start, goal, plan);
       }
 
       /**


### PR DESCRIPTION
Jade version of #535.

> The [BaseGlobalPlanner::makePlan](https://github.com/locusrobotics/navigation/blob/jade-devel/nav_core/include/nav_core/base_global_planner.h#L68) overload which returns calculated cost does not actually return anything by default, causing compiler warnings and potential undefined behavior.