### PR TITLE
Add a max_planning_retries parameter to move_base [kinetic]

### DIFF
--- a/move_base/cfg/MoveBase.cfg
+++ b/move_base/cfg/MoveBase.cfg
@@ -2,7 +2,7 @@
 
 PACKAGE = 'move_base'
 
-from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, str_t, double_t, bool_t
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, str_t, double_t, bool_t, int_t
 
 gen = ParameterGenerator()
 
@@ -15,6 +15,7 @@ gen.add("planner_frequency", double_t, 0, "The rate in Hz at which to run the pl
 gen.add("controller_frequency", double_t, 0, "The rate in Hz at which to run the control loop and send velocity commands to the base.", 20, 0, 100)
 gen.add("planner_patience", double_t, 0, "How long the planner will wait in seconds in an attempt to find a valid plan before space-clearing operations are performed.", 5.0, 0, 100)
 gen.add("controller_patience", double_t, 0, "How long the controller will wait in seconds without receiving a valid control before space-clearing operations are performed.", 5.0, 0, 100)
+gen.add("max_planning_retries", int_t, 0, "How many times we will recall the planner in an attempt to find a valid plan before space-clearing operations are performed", -1, -1, 1000)
 gen.add("conservative_reset_dist", double_t, 0, "The distance away from the robot in meters at which obstacles will be cleared from the costmap when attempting to clear space in the map.", 3, 0, 50)
 
 gen.add("recovery_behavior_enabled", bool_t, 0, "Whether or not to enable the move_base recovery behaviors to attempt to clear out space.", True)

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -189,6 +189,8 @@ namespace move_base {
       tf::Stamped<tf::Pose> global_pose_;
       double planner_frequency_, controller_frequency_, inscribed_radius_, circumscribed_radius_;
       double planner_patience_, controller_patience_;
+      int32_t max_planning_retries_;
+      uint32_t planning_retries_;
       double conservative_reset_dist_, clearing_radius_;
       ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_;
       ros::Subscriber goal_sub_;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -561,11 +561,11 @@ namespace move_base {
         wait_for_wake = false;
       }
       ros::Time start_time = ros::Time::now();
-      lock.unlock();
 
       if(state_==PLANNING){
         //time to plan! get a copy of the goal and unlock the mutex
         geometry_msgs::PoseStamped temp_goal = planner_goal_;
+        lock.unlock();
         ROS_DEBUG_NAMED("move_base_plan_thread","Planning...");
 
         //run planner
@@ -614,6 +614,11 @@ namespace move_base {
 
           lock.unlock();
         }
+      }
+      else
+      {
+        //not planning, so just unlock the mutex
+        lock.unlock();
       }
 
       //take the mutex for the next iteration

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -72,6 +72,7 @@ namespace move_base {
     private_nh.param("controller_frequency", controller_frequency_, 20.0);
     private_nh.param("planner_patience", planner_patience_, 5.0);
     private_nh.param("controller_patience", controller_patience_, 15.0);
+    private_nh.param("max_planning_retries", max_planning_retries_, -1);  // disabled by default
 
     private_nh.param("oscillation_timeout", oscillation_timeout_, 0.0);
     private_nh.param("oscillation_distance", oscillation_distance_, 0.5);
@@ -203,6 +204,7 @@ namespace move_base {
 
     planner_patience_ = config.planner_patience;
     controller_patience_ = config.controller_patience;
+    max_planning_retries_ = config.max_planning_retries;
     conservative_reset_dist_ = config.conservative_reset_dist;
 
     recovery_behavior_enabled_ = config.recovery_behavior_enabled;
@@ -578,6 +580,7 @@ namespace move_base {
         planner_plan_ = latest_plan_;
         latest_plan_ = temp_plan;
         last_valid_plan_ = ros::Time::now();
+        planning_retries_ = 0;
         new_global_plan_ = true;
 
         ROS_DEBUG_NAMED("move_base_plan_thread","Generated a plan from the base_global_planner");
@@ -594,9 +597,12 @@ namespace move_base {
         ROS_DEBUG_NAMED("move_base_plan_thread","No Plan...");
         ros::Time attempt_end = last_valid_plan_ + ros::Duration(planner_patience_);
 
-        //check if we've tried to make a plan for over our time limit
+        //check if we've tried to make a plan for over our time limit or our maximum number of retries
+        //issue #496: we stop planning when one of the conditions is true, but if max_planning_retries_
+        //is negative (the default), it is just ignored and we have the same behavior as ever
         lock.lock();
-        if(ros::Time::now() > attempt_end && runPlanner_){
+        if(runPlanner_ &&
+           (ros::Time::now() > attempt_end || ++planning_retries_ > uint32_t(max_planning_retries_))){
           //we'll move into our obstacle clearing mode
           state_ = CLEARING;
           publishZeroVelocity();
@@ -649,6 +655,7 @@ namespace move_base {
     last_valid_control_ = ros::Time::now();
     last_valid_plan_ = ros::Time::now();
     last_oscillation_reset_ = ros::Time::now();
+    planning_retries_ = 0;
 
     ros::NodeHandle n;
     while(n.ok())
@@ -687,10 +694,11 @@ namespace move_base {
           ROS_DEBUG_NAMED("move_base","move_base has received a goal of x: %.2f, y: %.2f", goal.pose.position.x, goal.pose.position.y);
           current_goal_pub_.publish(goal);
 
-          //make sure to reset our timeouts
+          //make sure to reset our timeouts and counters
           last_valid_control_ = ros::Time::now();
           last_valid_plan_ = ros::Time::now();
           last_oscillation_reset_ = ros::Time::now();
+          planning_retries_ = 0;
         }
         else {
           //if we've been preempted explicitly we need to shut things down
@@ -724,10 +732,11 @@ namespace move_base {
         ROS_DEBUG_NAMED("move_base","The global frame for move_base has changed, new frame: %s, new goal position x: %.2f, y: %.2f", goal.header.frame_id.c_str(), goal.pose.position.x, goal.pose.position.y);
         current_goal_pub_.publish(goal);
 
-        //make sure to reset our timeouts
+        //make sure to reset our timeouts and counters
         last_valid_control_ = ros::Time::now();
         last_valid_plan_ = ros::Time::now();
         last_oscillation_reset_ = ros::Time::now();
+        planning_retries_ = 0;
       }
 
       //for timing that gives real time even in simulation
@@ -901,6 +910,7 @@ namespace move_base {
           else{
             //otherwise, if we can't find a valid control, we'll go back to planning
             last_valid_plan_ = ros::Time::now();
+            planning_retries_ = 0;
             state_ = PLANNING;
             publishZeroVelocity();
 


### PR DESCRIPTION
It's an alternative to planner_patience to limit the failed calls to global planner, much better suited for planners that take long to compute a plan (and so you cannot set a low patiente) but short to fail, e.g. sbpl lattice planner.

This PR combines #498 (merged on indigo) and #523 (still open) for Kinetic. I included #523 because it fixes move_base in a way that makes #498 fully effective (explanation in the open PR)
