### PR TITLE
Set default name for uncomplete path

### DIFF
--- a/map_server/src/map_saver.cpp
+++ b/map_server/src/map_saver.cpp
@@ -153,6 +153,9 @@ int main(int argc, char** argv)
       return 1;
     }
   }
+
+  if(*mapname.rbegin() == '/')
+    mapname += "map";
   
   MapGenerator mg(mapname);
 


### PR DESCRIPTION
In the case we run:
`rosrun map_server map_saver -f /tmp/`
The map will be created as '.pgm' and '.yaml'. With this fix the map
will be created as 'map.pgm' and 'map.yaml' as in the case no -f parameter is set.