### PR TITLE
Fix to check index value before accessing to element of potential array

### DIFF
--- a/global_planner/src/astar.cpp
+++ b/global_planner/src/astar.cpp
@@ -76,6 +76,9 @@ bool AStarExpansion::calculatePotentials(unsigned char* costs, double start_x, d
 
 void AStarExpansion::add(unsigned char* costs, float* potential, float prev_potential, int next_i, int end_x,
                          int end_y) {
+    if (next_i < 0 || next_i >= ns_)
+        return;
+
     if (potential[next_i] < POT_HIGH)
         return;
 


### PR DESCRIPTION
`next_i` can be out of range, and it may cause segmentation fault.