### PR TITLE
added message generation and runtime to navfn package.xml

### DIFF
--- a/navfn/package.xml
+++ b/navfn/package.xml
@@ -34,7 +34,9 @@
     <build_depend>roscpp</build_depend>
     <build_depend>tf</build_depend>
     <build_depend>visualization_msgs</build_depend>
-
+    <build_depend>message_generation</build_depend>
+  
+    <run_depend>message_runtime</run_depend>
     <run_depend>costmap_2d</run_depend>
     <run_depend>geometry_msgs</run_depend>
     <run_depend>nav_core</run_depend>


### PR DESCRIPTION
Hello,

It is juste a small change I needed to do to compile using `catkin build move_base`. 

I just added:

```
<build_depend>message_generation</build_depend>
<run_depend>message_runtime</run_depend>
```
to `package.xml`

Otherwise, I had this error:

```
Traceback (most recent call last):
  File "/home/malcolm/ros_catkin_ws/source_indigo/install_isolated/share/genjava/cmake/../../../lib/genjava/genjava_gradle_project.py", line 14, in <module>
    genjava.main(sys.argv)
  File "/home/malcolm/ros_catkin_ws/source_indigo/install_isolated/lib/python2.7/site-packages/genjava/genjava_main.py", line 82, in main
    gradle_project.create(args.package, args.output_dir)
  File "/home/malcolm/ros_catkin_ws/source_indigo/install_isolated/lib/python2.7/site-packages/genjava/gradle_project.py", line 152, in create
    raise IOError("could not find %s among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?" % msg_pkg_name)
IOError: could not find navfn among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?
CMakeFiles/navfn_generate_messages_java_gradle.dir/build.make:75: recipe for target 'java/navfn/build.gradle' failed
make[2]: *** [java/navfn/build.gradle] Error 1
CMakeFiles/Makefile2:1605: recipe for target 'CMakeFiles/navfn_generate_messages_java_gradle.dir/all' failed
make[1]: *** [CMakeFiles/navfn_generate_messages_java_gradle.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 26%] Built target navfn_generate_messages_cpp
Traceback (most recent call last):
  File "/home/malcolm/ros_catkin_ws/source_indigo/install_isolated/share/genjava/cmake/../../../lib/genjava/genjava_gradle_project.py", line 14, in <module>
    genjava.main(sys.argv)
  File "/home/malcolm/ros_catkin_ws/source_indigo/install_isolated/lib/python2.7/site-packages/genjava/genjava_main.py", line 82, in main
    gradle_project.create(args.package, args.output_dir)
  File "/home/malcolm/ros_catkin_ws/source_indigo/install_isolated/lib/python2.7/site-packages/genjava/gradle_project.py", line 152, in create
    raise IOError("could not find %s among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?" % msg_pkg_name)
IOError: could not find navfn among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?
CMakeFiles/navfn_generate_messages_java.dir/build.make:74: recipe for target 'java/navfn/build.gradle' failed
make[2]: *** [java/navfn/build.gradle] Error 1
CMakeFiles/Makefile2:1573: recipe for target 'CMakeFiles/navfn_generate_messages_java.dir/all' failed
make[1]: *** [CMakeFiles/navfn_generate_messages_java.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
```

The same is needed for the kinetic branch.