### PR TITLE
update map_server to support Python 2 and 3

### DIFF
--- a/map_server/scripts/crop_map
+++ b/map_server/scripts/crop_map
@@ -1,4 +1,38 @@
 #!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import print_function
 
 import sys
 import yaml
@@ -41,7 +75,7 @@ def computed_cropped_origin(map_image, bounds, resolution, origin):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print >> sys.stderr, "Usage: %s map.yaml [cropped.yaml]" % sys.argv[0]
+        print("Usage: %s map.yaml [cropped.yaml]" % sys.argv[0], file=sys.stderr)
         sys.exit(1)
 
     with open(sys.argv[1]) as f:

--- a/map_server/test/consumer.py
+++ b/map_server/test/consumer.py
@@ -32,6 +32,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+from __future__ import print_function
+
 PKG = 'static_map_server'
 NAME = 'consumer'
 
@@ -50,7 +52,7 @@ class TestConsumer(unittest.TestCase):
         self.success = False
 
     def callback(self, data):
-        print rospy.get_caller_id(), "I heard %s" % data.data
+        print(rospy.get_caller_id(), "I heard %s" % data.data)
         self.success = data.data and data.data.startswith('hello world')
         rospy.signal_shutdown('test done')
 
@@ -59,7 +61,7 @@ class TestConsumer(unittest.TestCase):
         mapsrv = rospy.ServiceProxy('static_map', GetMap)
         resp = mapsrv()
         self.success = True
-        print resp
+        print(resp)
         while not rospy.is_shutdown() and not self.success:  # and time.time() < timeout_t: <== timeout_t doesn't exists??
             time.sleep(0.1)
         self.assert_(self.success)


### PR DESCRIPTION
I also added a missing copyright header to one of the files.

On a side note, I'm not sure what `map_server/test/consumer.py` is used for either. It isn't referenced from anything. It could probably be removed.