### PR TITLE
fix cmake use of yaml-cpp and sdl / sdl-image in map_server

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -8,33 +8,49 @@ find_package(catkin REQUIRED
             nav_msgs
         )
 
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(SDL REQUIRED)
+find_package(SDL_image REQUIRED)
 
-find_package(PkgConfig)
-pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
-if(NEW_YAMLCPP_FOUND)
-add_definitions(-DHAVE_NEW_YAMLCPP)
-endif(NEW_YAMLCPP_FOUND)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(YAMLCPP yaml-cpp REQUIRED)
+if(YAMLCPP_VERSION VERSION_GREATER "0.5.0")
+    add_definitions(-DHAVE_YAMLCPP_GT_0_5_0)
+endif()
 
 catkin_package(
     INCLUDE_DIRS
         include
+        ${SDL_INCLUDE_DIR}
+        ${SDL_IMAGE_INCLUDE_DIRS}
     LIBRARIES
         map_server_image_loader
+        ${SDL_LIBRARY}
+        ${SDL_IMAGE_LIBRARIES}
     CATKIN_DEPENDS
         roscpp
         tf
         nav_msgs
 )
 
-include_directories( include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
+include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+    ${SDL_INCLUDE_DIR}
+    ${SDL_IMAGE_INCLUDE_DIRS}
+    ${YAMLCPP_INCLUDE_DIRS}
+)
+
 add_library(map_server_image_loader src/image_loader.cpp)
-target_link_libraries(map_server_image_loader SDL SDL_image ${Boost_LIBRARIES})
+target_link_libraries(map_server_image_loader
+    ${catkin_LIBRARIES}
+    ${SDL_LIBRARY}
+    ${SDL_IMAGE_LIBRARIES}
+)
 
 add_executable(map_server src/main.cpp)
 target_link_libraries(map_server
     map_server_image_loader
-    yaml-cpp
+    ${YAMLCPP_LIBRARIES}
     ${catkin_LIBRARIES}
 )
 
@@ -42,7 +58,7 @@ add_executable(map_server-map_saver src/map_saver.cpp)
 set_target_properties(map_server-map_saver PROPERTIES OUTPUT_NAME map_saver)
 target_link_libraries(map_server-map_saver
     ${catkin_LIBRARIES}
-    )
+)
 
 # copy test data to same place as tests are run
 function(copy_test_data)
@@ -58,7 +74,11 @@ if(CATKIN_ENABLE_TESTING)
       test/testmap.bmp
       test/testmap.png )
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp test/test_constants.cpp)
-  target_link_libraries(${PROJECT_NAME}_utest map_server_image_loader SDL SDL_image)
+  target_link_libraries(${PROJECT_NAME}_utest
+    map_server_image_loader
+    ${SDL_LIBRARY}
+    ${SDL_IMAGE_LIBRARIES}
+  )
 
   add_executable(rtest test/rtest.cpp test/test_constants.cpp)
   target_link_libraries( rtest

--- a/map_server/package.xml
+++ b/map_server/package.xml
@@ -18,6 +18,7 @@
     <build_depend>nav_msgs</build_depend>
     <build_depend>roscpp</build_depend>
     <build_depend>rostest</build_depend>
+    <build_depend>sdl</build_depend>
     <build_depend>sdl-image</build_depend>
     <build_depend>tf</build_depend>
     <build_depend>yaml-cpp</build_depend>
@@ -25,6 +26,7 @@
     <run_depend>nav_msgs</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>rostest</run_depend>
+    <run_depend>sdl</run_depend>
     <run_depend>sdl-image</run_depend>
     <run_depend>tf</run_depend>
     <run_depend>yaml-cpp</run_depend>

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -46,7 +46,7 @@
 #include "nav_msgs/MapMetaData.h"
 #include "yaml-cpp/yaml.h"
 
-#ifdef HAVE_NEW_YAMLCPP
+#ifdef HAVE_YAMLCPP_GT_0_5_0
 // The >> operator disappeared in yaml-cpp 0.5, so this function is
 // added to provide support for code written under the yaml-cpp 0.3 API.
 template<typename T>
@@ -79,7 +79,7 @@ class MapServer
           ROS_ERROR("Map_server could not open %s.", fname.c_str());
           exit(-1);
         }
-#ifdef HAVE_NEW_YAMLCPP
+#ifdef HAVE_YAMLCPP_GT_0_5_0
         // The document loading process changed in yaml-cpp 0.5.
         YAML::Node doc = YAML::Load(fin);
 #else


### PR DESCRIPTION
While hacking on a port of this for ROS 2 (for a demo) I found that the cmake, especially with respect to finding and using dependencies, was more fragile than it has to be. So I open this pr, which:

- removes `find_package()` of boost (it's not used directly)
- changes the logic to find yaml-cpp and actually use the result
- change the compiler definition which indicates yaml-cpp >= 5.0.0 to be more self describing
- actually does `find_package()` the existing dep `SDL-image` and the implicit dep on `SDL`
  - It did not compile for me on `macOS` because `SDL-image` headers assume they are installed to the same folder as `SDL` headers, which is not the case with Homebrew.
- adds a `package.xml` dependency on `SDL` (https://github.com/ros/rosdistro/blob/7249ca98502a9efef4d96ef9c0feb09e9c0fc62c/rosdep/base.yaml#L3756-L3761)

Also, I would have used `target_include_directories`, but I think I need CMake 3.0.2 for that and I didn't want to mess with the minimum CMake version, but I might propose something like that in the future.