### PR TITLE
Add "lethal" costmap update method

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -103,6 +103,16 @@ protected:
    * Updates the master_grid within the specified
    * bounding box using this layer's values.
    *
+   * Overwrites the master's grid values with the this layer's values, if
+   * this layer's value is not NO_INFORMATION. If the master's value is
+   * NO_INFORMATION it is only updated if this layer's value is LETHAL_OBSTACLE.
+   */
+  void updateLethalIgnoreUnknown(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+
+  /*
+   * Updates the master_grid within the specified
+   * bounding box using this layer's values.
+   *
    * Sets the new value to the sum of the master grid's value
    * and this layer's value. If the master value is NO_INFORMATION,
    * it is overwritten with the layer's value. If the layer's value

--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -86,7 +86,7 @@ private:
   bool has_updated_data_;
   unsigned int x_, y_, width_, height_;
   bool track_unknown_space_;
-  bool use_maximum_;
+  std::string update_method_;     ///< @brief Method for updating the costmap (Allowed values: "override", "maximum", "lethal")
   bool first_map_only_;      ///< @brief Store the first static map and reuse it on reinitializing
   bool trinary_costmap_;
   ros::Subscriber map_sub_, map_update_sub_;

--- a/costmap_2d/src/costmap_layer.cpp
+++ b/costmap_2d/src/costmap_layer.cpp
@@ -69,6 +69,30 @@ void CostmapLayer::updateWithMax(costmap_2d::Costmap2D& master_grid, int min_i, 
   }
 }
 
+void CostmapLayer::updateLethalIgnoreUnknown(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  if (!enabled_)
+    return;
+
+  unsigned char* master_array = master_grid.getCharMap();
+  unsigned int span = master_grid.getSizeInCellsX();
+
+  for (int j = min_j; j < max_j; j++)
+  {
+    unsigned int it = j * span + min_i;
+    for (int i = min_i; i < max_i; i++)
+    {
+      if (costmap_[it] == NO_INFORMATION || (master_array[it] == NO_INFORMATION && costmap_[it] != LETHAL_OBSTACLE)){
+        it++;
+        continue;
+      }
+
+      master_array[it] = costmap_[it];
+      it++;
+    }
+  }
+}
+
 void CostmapLayer::updateWithTrueOverwrite(costmap_2d::Costmap2D& master_grid, int min_i, int min_j,
                                            int max_i, int max_j)
 {


### PR DESCRIPTION
### Use scenario

I have a use scenario where I use a costmap for exploring the environment. A pixel contains `NO_INFORMATION` if it has not been explored. Explored pixels are marked as `FREE_SPACE`. The static layer is used to process the available map to mark some pixels as `LETHAL_OBSTACLE` on the costmap, for buffering them (inflation layer) and avoiding obstacles as explore target. Unknown pixels must be ignored when updating the costmap.

### Problem

At this moment the static layer has two options for updating the costmap from the map information, namely using the `maximum` or `overwrite` method. This is controlled by the option `use_maximum`. A third option is required to solve the use scenario.

### Solution

Add an extra update method in the costmap code which implements the desired behaviour, and use this update method for the static costmap, if the user desires it. This requires changing the static costmap layer option from a boolean `use_maximum` to a string `update_method` where each possible update method is a named option.

### Changes

- Added costmap update method `CostmapLayer::updateLethalIgnoreUnknown`.
- Changed parameter `use_maximum` (`boolean`) to `update_method` (`std::string`)

---

If required, I can re-add the old parameter `use_maximum` which adds backward compatibility.