### PR TITLE
Added parameter for allowing inflation in unknown cells

### DIFF
--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -7,5 +7,6 @@ gen = ParameterGenerator()
 gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
 gen.add("cost_scaling_factor", double_t, 0, "A scaling factor to apply to cost values during inflation.", 10, 0, 100)
 gen.add("inflation_radius", double_t, 0, "The radius in meters to which the map inflates obstacle cost values.", 0.55, 0, 50)
+gen.add("inflate_unknown", bool_t, 0, "Whether to inflate unknown cells.", False)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "InflationPlugin"))

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -120,8 +120,9 @@ public:
    * @brief Change the values of the inflation radius parameters
    * @param inflation_radius The new inflation radius
    * @param cost_scaling_factor The new weight
+   * @param inflate_unknown Whether to inflate unknown cells
    */
-  void setInflationParameters(double inflation_radius, double cost_scaling_factor);
+  void setInflationParameters(double inflation_radius, double cost_scaling_factor, bool inflate_unknown);
 
 protected:
   virtual void onFootprintChanged();
@@ -171,6 +172,7 @@ private:
                       unsigned int src_x, unsigned int src_y);
 
   double inflation_radius_, inscribed_radius_, weight_;
+  bool inflate_unknown_;
   unsigned int cell_inflation_radius_;
   unsigned int cached_cell_inflation_radius_;
   std::map<double, std::vector<CellData> > inflation_cells_;

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -120,9 +120,8 @@ public:
    * @brief Change the values of the inflation radius parameters
    * @param inflation_radius The new inflation radius
    * @param cost_scaling_factor The new weight
-   * @param inflate_unknown Whether to inflate unknown cells
    */
-  void setInflationParameters(double inflation_radius, double cost_scaling_factor, bool inflate_unknown);
+  void setInflationParameters(double inflation_radius, double cost_scaling_factor);
 
 protected:
   virtual void onFootprintChanged();

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -100,10 +100,11 @@ void InflationLayer::onInitialize()
 
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)
 {
-  setInflationParameters(config.inflation_radius, config.cost_scaling_factor, config.inflate_unknown);
+  setInflationParameters(config.inflation_radius, config.cost_scaling_factor);
 
-  if (enabled_ != config.enabled) {
+  if (enabled_ != config.enabled || inflate_unknown_ != inflate_unknown) {
     enabled_ = config.enabled;
+    inflate_unknown_ = config.inflate_unknown;
     need_reinflation_ = true;
   }
 }
@@ -363,9 +364,9 @@ void InflationLayer::deleteKernels()
   }
 }
 
-void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor, bool inflate_unknown)
+void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor)
 {
-  if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius || inflate_unknown_ != inflate_unknown)
+  if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -374,7 +375,6 @@ void InflationLayer::setInflationParameters(double inflation_radius, double cost
     inflation_radius_ = inflation_radius;
     cell_inflation_radius_ = cellDistance(inflation_radius_);
     weight_ = cost_scaling_factor;
-    inflate_unknown_ = inflate_unknown;
     need_reinflation_ = true;
     computeCaches();
   }

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -257,7 +257,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
       // assign the cost associated with the distance from an obstacle to the cell
       unsigned char cost = costLookup(mx, my, sx, sy);
       unsigned char old_cost = master_array[index];
-      if (old_cost == NO_INFORMATION && ((inflate_unknown_ && cost > FREE_SPACE) || (!inflate_unknown_ && cost >= INSCRIBED_INFLATED_OBSTACLE)))
+      if (old_cost == NO_INFORMATION && (inflate_unknown_ ? (cost > FREE_SPACE) : (cost >= INSCRIBED_INFLATED_OBSTACLE)))
         master_array[index] = cost;
       else
         master_array[index] = std::max(old_cost, cost);

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -102,7 +102,7 @@ void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, ui
 {
   setInflationParameters(config.inflation_radius, config.cost_scaling_factor);
 
-  if (enabled_ != config.enabled || inflate_unknown_ != inflate_unknown) {
+  if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
     inflate_unknown_ = config.inflate_unknown;
     need_reinflation_ = true;


### PR DESCRIPTION
### Problem

Unknown space might have a cost moving over it, especially if the used sensor has a small range. To have the global or local planner make better paths inflation costs are required for unknown space. 

### Current situation 

Only lethal costs are inflated over unknown areas. 

### Solution

I've added a parameter `inflate_unknown` where *any* cost can be inflated over unknown areas. The default value is `false` resulting in the previous behavior for backwards compatibility.

### Screenshots 

Screenshots from `rviz`. The difference is in the top right corner: before no inflation is done over the unknown area, while after the inflated area (red and dark blue) is extended into the unknown area.

Before:
![inflate-known](https://cloud.githubusercontent.com/assets/1073881/24541046/196d7b22-15f6-11e7-9b80-7b5dab5f4e26.png)

After:
![inflate-unknown](https://cloud.githubusercontent.com/assets/1073881/24541038/17c75478-15f6-11e7-9a1f-6c090cf57365.png)

