### PR TITLE
make rostest in CMakeLists optional (ros/rosdistro#3010)

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(catkin REQUIRED
             dynamic_reconfigure
             nav_core
             pcl_conversions
-            rostest
             costmap_2d
             pluginlib
             angles
@@ -129,6 +128,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
   catkin_add_gtest(base_local_planner_utest
     test/gtest_main.cpp
     test/utest.cpp


### PR DESCRIPTION
It is minor change that might be worthwhile to be back-ported to the other branches. There is no need to backport for my use case, though.