### PR TITLE
Add cost function to prevent unnecessary spinning

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(base_local_planner
 	src/simple_scored_sampling_planner.cpp
 	src/simple_trajectory_generator.cpp
 	src/trajectory.cpp
+	src/twirling_cost_function.cpp
 	src/voxel_grid_model.cpp)
 add_dependencies(base_local_planner base_local_planner_gencfg)
 add_dependencies(base_local_planner base_local_planner_generate_messages_cpp)

--- a/base_local_planner/include/base_local_planner/twirling_cost_function.h
+++ b/base_local_planner/include/base_local_planner/twirling_cost_function.h
@@ -1,0 +1,64 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Morgan Quigley
+ *********************************************************************/
+
+#ifndef TWIRLING_COST_FUNCTION_H
+#define TWIRLING_COST_FUNCTION_H
+
+#include <base_local_planner/trajectory_cost_function.h>
+
+namespace base_local_planner {
+
+/**
+ * This class provides a cost based on how much a robot "twirls" on its
+ * way to the goal. With differential-drive robots, there isn't a choice,
+ * but with holonomic or near-holonomic robots, sometimes a robot spins
+ * more than you'd like on its way to a goal. This class provides a way
+ * to assign a penalty purely to rotational velocities.
+ */
+class TwirlingCostFunction: public base_local_planner::TrajectoryCostFunction {
+public:
+
+  TwirlingCostFunction() {}
+  ~TwirlingCostFunction() {}
+
+  double scoreTrajectory(Trajectory &traj);
+
+  bool prepare() {return true;};
+};
+
+} /* namespace base_local_planner */
+#endif /* TWIRLING_COST_FUNCTION_H_ */

--- a/base_local_planner/src/twirling_cost_function.cpp
+++ b/base_local_planner/src/twirling_cost_function.cpp
@@ -1,0 +1,18 @@
+/*
+ * twirling_cost_function.cpp
+ *
+ *  Created on: Apr 20, 2016
+ *      Author: Morgan Quigley
+ */
+
+#include <base_local_planner/twirling_cost_function.h>
+
+#include <math.h>
+
+namespace base_local_planner {
+
+double TwirlingCostFunction::scoreTrajectory(Trajectory &traj) {
+  return fabs(traj.thetav_);  // add cost for making the robot spin
+}
+
+} /* namespace base_local_planner */

--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -19,6 +19,7 @@ gen.add("angular_sim_granularity", double_t, 0, "The granularity with which to c
 gen.add("path_distance_bias", double_t, 0, "The weight for the path distance part of the cost function", 32.0, 0.0)
 gen.add("goal_distance_bias", double_t, 0, "The weight for the goal distance part of the cost function", 24.0, 0.0)
 gen.add("occdist_scale", double_t, 0, "The weight for the obstacle distance part of the cost function", 0.01, 0.0)
+gen.add("twirling_scale", double_t, 0, "The weight for penalizing any changes in robot heading", 0.0, 0.0)
 
 gen.add("stop_time_buffer", double_t, 0, "The amount of time that the robot must stop before a collision in order for a trajectory to be considered valid in seconds", 0.2, 0)
 gen.add("oscillation_reset_dist", double_t, 0, "The distance the robot must travel before oscillation flags are reset, in meters", 0.05, 0)

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -58,6 +58,7 @@
 #include <base_local_planner/oscillation_cost_function.h>
 #include <base_local_planner/map_grid_cost_function.h>
 #include <base_local_planner/obstacle_cost_function.h>
+#include <base_local_planner/twirling_cost_function.h>
 #include <base_local_planner/simple_scored_sampling_planner.h>
 
 #include <nav_msgs/Path.h>
@@ -175,6 +176,7 @@ namespace dwa_local_planner {
       base_local_planner::MapGridCostFunction goal_costs_;
       base_local_planner::MapGridCostFunction goal_front_costs_;
       base_local_planner::MapGridCostFunction alignment_costs_;
+      base_local_planner::TwirlingCostFunction twirling_costs_;
 
       base_local_planner::SimpleScoredSamplingPlanner scored_sampling_planner_;
   };

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -83,6 +83,8 @@ namespace dwa_local_planner {
     // obstacle costs can vary due to scaling footprint feature
     obstacle_costs_.setParams(config.max_trans_vel, config.max_scaling_factor, config.scaling_speed);
 
+    twirling_costs_.setScale(config.twirling_scale);
+
     int vx_samp, vy_samp, vth_samp;
     vx_samp = config.vx_samples;
     vy_samp = config.vy_samples;
@@ -171,6 +173,7 @@ namespace dwa_local_planner {
     critics.push_back(&alignment_costs_); // prefers trajectories that keep the robot nose on nose path
     critics.push_back(&path_costs_); // prefers trajectories on global path
     critics.push_back(&goal_costs_); // prefers trajectories that go towards (local) goal, based on wave propagation
+    critics.push_back(&twirling_costs_); // optionally prefer trajectories that don't spin
 
     // trajectory generators
     std::vector<base_local_planner::TrajectorySampleGenerator*> generator_list;


### PR DESCRIPTION
Adds a cost function and configuration parameter to penalize changes in robot heading. This isn't relevant for diff-drive robots, where heading changes are typically necessary to move towards goals. However, this is useful for having control of the 'twirling' behavior of holonomic robots. Setting the twirling_scale parameter to a high value, say 50, causes the dwa planner to prefer to 'strafe' towards
goals rather than (eventually) aiming the robot at the goal while driving. For some applications this is much preferred. This parameter defaults to zero, which maintains the existing behavior unless it is explicitly set to a non-zero value.

I'm happy to iterate on this as needed to get it ready to merge :chicken: 