### PR TITLE
Add runtime reload map feature

### DIFF
--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -30,10 +30,10 @@
 /* Author: Brian Gerkey */
 
 #define USAGE "\nUSAGE: map_server <map.yaml>\n" \
-              "  map.yaml: map description file\n" \
-              "DEPRECATED USAGE: map_server <map> <resolution>\n" \
-              "  map: image file to load\n"\
-              "  resolution: map resolution [meters/pixel]"
+    "  map.yaml: map description file\n" \
+    "DEPRECATED USAGE: map_server <map> <resolution>\n" \
+    "  map: image file to load\n"\
+    "  resolution: map resolution [meters/pixel]"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,12 +45,14 @@
 #include "map_server/image_loader.h"
 #include "nav_msgs/MapMetaData.h"
 #include "yaml-cpp/yaml.h"
+#include "std_msgs/String.h"
+#include <boost/algorithm/string/trim.hpp>
 
 #ifdef HAVE_YAMLCPP_GT_0_5_0
 // The >> operator disappeared in yaml-cpp 0.5, so this function is
 // added to provide support for code written under the yaml-cpp 0.3 API.
 template<typename T>
-void operator >> (const YAML::Node& node, T& i)
+void operator >>(const YAML::Node & node, T & i)
 {
   i = node.as<T>();
 }
@@ -58,178 +60,243 @@ void operator >> (const YAML::Node& node, T& i)
 
 class MapServer
 {
-  public:
-    /** Trivial constructor */
-    MapServer(const std::string& fname, double res)
-    {
-      std::string mapfname = "";
-      double origin[3];
-      int negate;
-      double occ_th, free_th;
-      MapMode mode = TRINARY;
-      std::string frame_id;
-      ros::NodeHandle private_nh("~");
-      private_nh.param("frame_id", frame_id, std::string("map"));
-      deprecated = (res != 0);
-      if (!deprecated) {
-        //mapfname = fname + ".pgm";
-        //std::ifstream fin((fname + ".yaml").c_str());
-        std::ifstream fin(fname.c_str());
-        if (fin.fail()) {
-          ROS_ERROR("Map_server could not open %s.", fname.c_str());
-          exit(-1);
-        }
-#ifdef HAVE_YAMLCPP_GT_0_5_0
-        // The document loading process changed in yaml-cpp 0.5.
-        YAML::Node doc = YAML::Load(fin);
-#else
-        YAML::Parser parser(fin);
-        YAML::Node doc;
-        parser.GetNextDocument(doc);
-#endif
-        try {
-          doc["resolution"] >> res;
-        } catch (YAML::InvalidScalar) {
-          ROS_ERROR("The map does not contain a resolution tag or it is invalid.");
-          exit(-1);
-        }
-        try {
-          doc["negate"] >> negate;
-        } catch (YAML::InvalidScalar) {
-          ROS_ERROR("The map does not contain a negate tag or it is invalid.");
-          exit(-1);
-        }
-        try {
-          doc["occupied_thresh"] >> occ_th;
-        } catch (YAML::InvalidScalar) {
-          ROS_ERROR("The map does not contain an occupied_thresh tag or it is invalid.");
-          exit(-1);
-        }
-        try {
-          doc["free_thresh"] >> free_th;
-        } catch (YAML::InvalidScalar) {
-          ROS_ERROR("The map does not contain a free_thresh tag or it is invalid.");
-          exit(-1);
-        }
-        try {
-          std::string modeS = "";
-          doc["mode"] >> modeS;
+public:
+  /** Trivial constructor */
+  MapServer(const std::string & fname, double res)
+  {
+    ros::NodeHandle private_nh("~");
+    bool success = loadMapFromFile(fname, private_nh, res);
 
-          if(modeS=="trinary")
-            mode = TRINARY;
-          else if(modeS=="scale")
-            mode = SCALE;
-          else if(modeS=="raw")
-            mode = RAW;
-          else{
-            ROS_ERROR("Invalid mode tag \"%s\".", modeS.c_str());
-            exit(-1);
-          }
-        } catch (YAML::Exception) {
-          ROS_DEBUG("The map does not contain a mode tag or it is invalid... assuming Trinary");
-          mode = TRINARY;
-        }
-        try {
-          doc["origin"][0] >> origin[0];
-          doc["origin"][1] >> origin[1];
-          doc["origin"][2] >> origin[2];
-        } catch (YAML::InvalidScalar) {
-          ROS_ERROR("The map does not contain an origin tag or it is invalid.");
-          exit(-1);
-        }
-        try {
-          doc["image"] >> mapfname;
-          // TODO: make this path-handling more robust
-          if(mapfname.size() == 0)
-          {
-            ROS_ERROR("The image tag cannot be an empty string.");
-            exit(-1);
-          }
-          if(mapfname[0] != '/')
-          {
-            // dirname can modify what you pass it
-            char* fname_copy = strdup(fname.c_str());
-            mapfname = std::string(dirname(fname_copy)) + '/' + mapfname;
-            free(fname_copy);
-          }
-        } catch (YAML::InvalidScalar) {
-          ROS_ERROR("The map does not contain an image tag or it is invalid.");
-          exit(-1);
-        }
-      } else {
-        private_nh.param("negate", negate, 0);
-        private_nh.param("occupied_thresh", occ_th, 0.65);
-        private_nh.param("free_thresh", free_th, 0.196);
-        mapfname = fname;
-        origin[0] = origin[1] = origin[2] = 0.0;
+    if (not success)
+    {
+      exit(-1);
+    }
+    map_config_file = fname;
+
+    service = n.advertiseService("static_map", &MapServer::mapCallback, this);
+    //pub = n.advertise<nav_msgs::MapMetaData>("map_metadata", 1,
+
+    // Latched publisher for metadata
+    metadata_pub = n.advertise<nav_msgs::MapMetaData>("map_metadata", 1, true);
+    metadata_pub.publish(meta_data_message_);
+
+    // Latched publisher for data
+    map_pub = n.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
+    map_pub.publish(map_resp_.map);
+
+    // Reload map subscriber
+    reload_sub = private_nh.subscribe("reload", 1, &MapServer::reloadCallback, this);
+  }
+
+private:
+  ros::NodeHandle n;
+  ros::Publisher map_pub;
+  ros::Publisher metadata_pub;
+  ros::Subscriber reload_sub;
+  ros::ServiceServer service;
+  std::string map_config_file;
+  bool deprecated;
+
+  /** Callback invoked when someone requests our service */
+  bool mapCallback(nav_msgs::GetMap::Request & req, nav_msgs::GetMap::Response & res)
+  {
+    // request is empty; we ignore it
+
+    // = operator is overloaded to make deep copy (tricky!)
+    res = map_resp_;
+    ROS_INFO("Sending map");
+
+    return true;
+  }
+
+  /** Callback invoked when someone requests a map reload */
+  void reloadCallback(const std_msgs::String::ConstPtr & msg)
+  {
+    std::string filePath = msg->data;
+    boost::algorithm::trim(filePath);
+
+    if (filePath.length() == 0)
+    {
+      filePath = map_config_file;
+    }
+
+    ROS_INFO("Reloading %s", filePath.c_str());
+
+    ros::NodeHandle private_nh("~");
+    bool success = loadMapFromFile(filePath, private_nh);
+    if (not success)
+    {
+      return;
+    }
+    map_config_file = filePath;
+
+    metadata_pub.publish(meta_data_message_);
+    map_pub.publish(map_resp_.map);
+  }
+
+  bool loadMapFromFile(const std::string & fname, const ros::NodeHandle & private_nh, double res = 0)
+  {
+    std::string mapfname = "";
+    double origin[3];
+    int negate;
+    double occ_th, free_th;
+    MapMode mode = TRINARY;
+    std::string frame_id;
+    private_nh.param("frame_id", frame_id, std::string("map"));
+    deprecated = (res != 0);
+    if (not deprecated)
+    {
+      std::ifstream fin(fname.c_str());
+      if (fin.fail())
+      {
+        ROS_ERROR("Map_server could not open %s.", fname.c_str());
+        return false;
       }
+#ifdef HAVE_YAMLCPP_GT_0_5_0
+      // The document loading process changed in yaml-cpp 0.5.
+      YAML::Node doc = YAML::Load(fin);
+#else
+      YAML::Parser parser (fin);
+      YAML::Node doc;
+      parser.GetNextDocument (doc);
+#endif
+      try
+      {
+        doc["resolution"] >> res;
+      }
+      catch (YAML::InvalidScalar)
+      {
+        ROS_ERROR("The map does not contain a resolution tag or it is invalid.");
+        return false;
+      }
+      try
+      {
+        doc["negate"] >> negate;
+      }
+      catch (YAML::InvalidScalar)
+      {
+        ROS_ERROR("The map does not contain a negate tag or it is invalid.");
+        return false;
+      }
+      try
+      {
+        doc["occupied_thresh"] >> occ_th;
+      }
+      catch (YAML::InvalidScalar)
+      {
+        ROS_ERROR("The map does not contain an occupied_thresh tag or it is invalid.");
+        return false;
+      }
+      try
+      {
+        doc["free_thresh"] >> free_th;
+      }
+      catch (YAML::InvalidScalar)
+      {
+        ROS_ERROR("The map does not contain a free_thresh tag or it is invalid.");
+        return false;
+      }
+      try
+      {
+        std::string modeS = "";
+        doc["mode"] >> modeS;
 
-      ROS_INFO("Loading map from image \"%s\"", mapfname.c_str());
-      map_server::loadMapFromFile(&map_resp_,mapfname.c_str(),res,negate,occ_th,free_th, origin, mode);
-      map_resp_.map.info.map_load_time = ros::Time::now();
-      map_resp_.map.header.frame_id = frame_id;
-      map_resp_.map.header.stamp = ros::Time::now();
-      ROS_INFO("Read a %d X %d map @ %.3lf m/cell",
-               map_resp_.map.info.width,
-               map_resp_.map.info.height,
-               map_resp_.map.info.resolution);
-      meta_data_message_ = map_resp_.map.info;
-
-      service = n.advertiseService("static_map", &MapServer::mapCallback, this);
-      //pub = n.advertise<nav_msgs::MapMetaData>("map_metadata", 1,
-
-      // Latched publisher for metadata
-      metadata_pub= n.advertise<nav_msgs::MapMetaData>("map_metadata", 1, true);
-      metadata_pub.publish( meta_data_message_ );
-
-      // Latched publisher for data
-      map_pub = n.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
-      map_pub.publish( map_resp_.map );
+        if (modeS == "trinary")
+          mode = TRINARY;
+        else if (modeS == "scale")
+          mode = SCALE;
+        else if (modeS == "raw")
+          mode = RAW;
+        else
+        {
+          ROS_ERROR("Invalid mode tag \"%s\".", modeS.c_str());
+          return false;
+        }
+      }
+      catch (YAML::Exception)
+      {
+        ROS_DEBUG("The map does not contain a mode tag or it is invalid... assuming Trinary");
+        mode = TRINARY;
+      }
+      try
+      {
+        doc["origin"][0] >> origin[0];
+        doc["origin"][1] >> origin[1];
+        doc["origin"][2] >> origin[2];
+      }
+      catch (YAML::InvalidScalar)
+      {
+        ROS_ERROR("The map does not contain an origin tag or it is invalid.");
+        return false;
+      }
+      try
+      {
+        doc["image"] >> mapfname;
+        // TODO: make this path-handling more robust
+        if (mapfname.size() == 0)
+        {
+          ROS_ERROR("The image tag cannot be an empty string.");
+          return false;
+        }
+        if (mapfname[0] != '/')
+        {
+          // dirname can modify what you pass it
+          char *fname_copy = strdup(fname.c_str());
+          mapfname = std::string(dirname(fname_copy)) + '/' + mapfname;
+          free(fname_copy);
+        }
+      }
+      catch (YAML::InvalidScalar)
+      {
+        ROS_ERROR("The map does not contain an image tag or it is invalid.");
+        return false;
+      }
     }
-
-  private:
-    ros::NodeHandle n;
-    ros::Publisher map_pub;
-    ros::Publisher metadata_pub;
-    ros::ServiceServer service;
-    bool deprecated;
-
-    /** Callback invoked when someone requests our service */
-    bool mapCallback(nav_msgs::GetMap::Request  &req,
-                     nav_msgs::GetMap::Response &res )
+    else
     {
-      // request is empty; we ignore it
-
-      // = operator is overloaded to make deep copy (tricky!)
-      res = map_resp_;
-      ROS_INFO("Sending map");
-
-      return true;
+      private_nh.param("negate", negate, 0);
+      private_nh.param("occupied_thresh", occ_th, 0.65);
+      private_nh.param("free_thresh", free_th, 0.196);
+      mapfname = fname;
+      origin[0] = origin[1] = origin[2] = 0.0;
     }
 
-    /** The map data is cached here, to be sent out to service callers
-     */
-    nav_msgs::MapMetaData meta_data_message_;
-    nav_msgs::GetMap::Response map_resp_;
+    ROS_INFO("Loading map from image \"%s\"", mapfname.c_str());
+    map_server::loadMapFromFile(&map_resp_, mapfname.c_str(), res, negate, occ_th, free_th, origin, mode);
+    map_resp_.map.info.map_load_time = ros::Time::now();
+    map_resp_.map.header.frame_id = frame_id;
+    map_resp_.map.header.stamp = ros::Time::now();
+    ROS_INFO("Read a %d X %d map @ %.3lf m/cell", map_resp_.map.info.width, map_resp_.map.info.height,
+             map_resp_.map.info.resolution);
+    meta_data_message_ = map_resp_.map.info;
+    return true;
 
-    /*
-    void metadataSubscriptionCallback(const ros::SingleSubscriberPublisher& pub)
-    {
-      pub.publish( meta_data_message_ );
-    }
-    */
+  }
+
+  /** The map data is cached here, to be sent out to service callers
+   */
+  nav_msgs::MapMetaData meta_data_message_;
+  nav_msgs::GetMap::Response map_resp_;
+
+  /*
+   void metadataSubscriptionCallback(const ros::SingleSubscriberPublisher& pub)
+   {
+   pub.publish( meta_data_message_ );
+   }
+   */
 
 };
 
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "map_server", ros::init_options::AnonymousName);
-  if(argc != 3 && argc != 2)
+  if (argc != 3 && argc != 2)
   {
     ROS_ERROR("%s", USAGE);
     exit(-1);
   }
-  if (argc != 2) {
+  if (argc != 2)
+  {
     ROS_WARN("Using deprecated map server interface. Please switch to new interface.");
   }
   std::string fname(argv[1]);
@@ -240,7 +307,7 @@ int main(int argc, char **argv)
     MapServer ms(fname, res);
     ros::spin();
   }
-  catch(std::runtime_error& e)
+  catch (std::runtime_error & e)
   {
     ROS_ERROR("map_server exception: %s", e.what());
     return -1;
@@ -248,4 +315,3 @@ int main(int argc, char **argv)
 
   return 0;
 }
-


### PR DESCRIPTION
subscribed topic: 
        ~/reload (std_msgs/String) 
Provides a non-action interface to map_server for reloading the map information while map_server 
is running. 
Message data is a string with the file name.
If message data is empty, map_server reloads the map from the last specified file.