### PR TITLE
Fix Debian Stretch compilation error on -lQt5::Widgets

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(Boost REQUIRED
 
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
+# For debian: https://github.com/ros-perception/perception_pcl/issues/139
+find_package(Qt5Widgets QUIET)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -32,6 +32,8 @@
     <build_depend>nav_core</build_depend>
     <build_depend>pcl_conversions</build_depend>
     <build_depend>pcl_ros</build_depend>
+    <!-- qtbase5-dev needed due to error in qt5 -->
+    <build_depend>qtbase5-dev</build_depend>
     <build_depend>eigen</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>message_generation</build_depend>
@@ -43,6 +45,8 @@
     <run_depend>tf</run_depend>
     <run_depend>rospy</run_depend>
     <run_depend>pluginlib</run_depend>
+    <!-- qtbase5-dev needed due to error in qt5 -->
+    <run_depend>qtbase5-dev</run_depend>
     <run_depend>costmap_2d</run_depend>
     <run_depend>voxel_grid</run_depend>
     <run_depend>angles</run_depend>

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -23,6 +23,8 @@ find_package(catkin REQUIRED
         )
 
 find_package(PCL REQUIRED)
+# For debian: https://github.com/ros-perception/perception_pcl/issues/139
+find_package(Qt5Widgets QUIET)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -32,6 +32,8 @@
     <build_depend>pcl_conversions</build_depend>
     <build_depend>pcl_ros</build_depend>
     <build_depend>pluginlib</build_depend>
+    <!-- qtbase5-dev needed due to error in qt5 -->
+    <build_depend>qtbase5-dev</build_depend>
     <build_depend>roscpp</build_depend>
     <build_depend>rostest</build_depend>
     <build_depend>sensor_msgs</build_depend>
@@ -50,6 +52,8 @@
     <run_depend>pcl_conversions</run_depend>
     <run_depend>pcl_ros</run_depend>
     <run_depend>pluginlib</run_depend>
+    <!-- qtbase5-dev needed due to error in qt5 -->
+    <run_depend>qtbase5-dev</run_depend>
     <run_depend>rosconsole</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>rostest</run_depend>


### PR DESCRIPTION
`pcl_ros` propagates the `-lQt5::Widgets` flag on Debian Stretch so we need to find_package Qt5Widgets (see https://github.com/ros-perception/perception_pcl/issues/139).
This is the only outstanding erro to get navigation released into Lunar.