### PR TITLE
Fixed planner race condition

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -253,6 +253,8 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     unsigned int start_x_i, start_y_i, goal_x_i, goal_y_i;
     double start_x, start_y, goal_x, goal_y;
 
+    boost::unique_lock<costmap_2d::Costmap2D::mutex_t> costmap_lock(*costmap_->getMutex());
+
     if (!costmap_->worldToMap(wx, wy, start_x_i, start_y_i)) {
         ROS_WARN(
                 "The robot's start position is off the global costmap. Planning will always fail, are you sure the robot has been properly localized?");


### PR DESCRIPTION
There was a race condition inside planner's makePlan() function, which was especially dangerous for high frequencies (for me: 15 Hz for planner, 10 Hz for costmap). 

Actually it would be better to ensure that **all** costmap's functions are thread-safe, but this hotfix seems to work for me.

Cheers and thanks for your work :)