### PR TITLE
amcl: fix compilation with gcc v7

### DIFF
--- a/amcl/src/amcl/map/map_cspace.cpp
+++ b/amcl/src/amcl/map/map_cspace.cpp
@@ -86,8 +86,8 @@ get_distance_map(double scale, double max_dist)
   return cdm;
 }
 
-void enqueue(map_t* map, unsigned int i, unsigned int j, 
-	     unsigned int src_i, unsigned int src_j,
+void enqueue(map_t* map, int i, int j,
+	     int src_i, int src_j,
 	     std::priority_queue<CellData>& Q,
 	     CachedDistanceMap* cdm,
 	     unsigned char* marked)
@@ -95,8 +95,8 @@ void enqueue(map_t* map, unsigned int i, unsigned int j,
   if(marked[MAP_INDEX(map, i, j)])
     return;
 
-  unsigned int di = abs(i - src_i);
-  unsigned int dj = abs(j - src_j);
+  int di = abs(i - src_i);
+  int dj = abs(j - src_j);
   double distance = cdm->distances_[di][dj];
 
   if(distance > cdm->cell_radius_)


### PR DESCRIPTION
When building amcl with recent enough gcc v7 compilation fails with
the error
```
src/amcl/map/map_cspace.cpp: In function 'void enqueue(map_t*, unsigned int, unsigned int, unsigned int, unsigned int, std::priority_queue<CellData>&, CachedDistanceMap*, unsigned char*)':
src/amcl/map/map_cspace.cpp:98:34: error: call of overloaded 'abs(unsigned int)' is ambiguous
   unsigned int di = abs(i - src_i);
```
Use `int abs(int)` flavour of the abs() function.