### PR TITLE
Cleanup PCL imports: fixes compilation on zesty and stretch

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -21,9 +21,7 @@ find_package(Boost REQUIRED
         )
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
-# For debian: https://github.com/ros-perception/perception_pcl/issues/139
-find_package(Qt5Widgets QUIET)
+find_package(PCL REQUIRED COMPONENTS common)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -35,6 +35,7 @@
     <build_depend>eigen</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>message_generation</build_depend>
+    <build_depend>libpcl-all-dev</build_depend>
 
     <run_depend>std_msgs</run_depend>
     <run_depend>nav_msgs</run_depend>
@@ -53,6 +54,7 @@
     <run_depend>eigen</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>message_generation</run_depend>
+    <run_depend>libpcl-all-dev</run_depend>
 
     <export>
         <nav_core plugin="${prefix}/blp_plugin.xml" />

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -32,8 +32,6 @@
     <build_depend>nav_core</build_depend>
     <build_depend>pcl_conversions</build_depend>
     <build_depend>pcl_ros</build_depend>
-    <!-- qtbase5-dev needed due to error in qt5 -->
-    <build_depend>qtbase5-dev</build_depend>
     <build_depend>eigen</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>message_generation</build_depend>
@@ -45,8 +43,6 @@
     <run_depend>tf</run_depend>
     <run_depend>rospy</run_depend>
     <run_depend>pluginlib</run_depend>
-    <!-- qtbase5-dev needed due to error in qt5 -->
-    <run_depend>qtbase5-dev</run_depend>
     <run_depend>costmap_2d</run_depend>
     <run_depend>voxel_grid</run_depend>
     <run_depend>angles</run_depend>

--- a/clear_costmap_recovery/CMakeLists.txt
+++ b/clear_costmap_recovery/CMakeLists.txt
@@ -12,13 +12,11 @@ find_package(catkin REQUIRED
         )
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
-    ${PCL_INCLUDE_DIRS}
 )
 add_definitions(${EIGEN3_DEFINITIONS})
 

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -22,9 +22,7 @@ find_package(catkin REQUIRED
             voxel_grid
         )
 
-find_package(PCL REQUIRED)
-# For debian: https://github.com/ros-perception/perception_pcl/issues/139
-find_package(Qt5Widgets QUIET)
+find_package(PCL REQUIRED COMPONENTS common)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -32,8 +32,6 @@
     <build_depend>pcl_conversions</build_depend>
     <build_depend>pcl_ros</build_depend>
     <build_depend>pluginlib</build_depend>
-    <!-- qtbase5-dev needed due to error in qt5 -->
-    <build_depend>qtbase5-dev</build_depend>
     <build_depend>roscpp</build_depend>
     <build_depend>rostest</build_depend>
     <build_depend>sensor_msgs</build_depend>
@@ -52,8 +50,6 @@
     <run_depend>pcl_conversions</run_depend>
     <run_depend>pcl_ros</run_depend>
     <run_depend>pluginlib</run_depend>
-    <!-- qtbase5-dev needed due to error in qt5 -->
-    <run_depend>qtbase5-dev</run_depend>
     <run_depend>rosconsole</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>rostest</run_depend>

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -25,6 +25,7 @@
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>geometry_msgs</build_depend>
     <build_depend>laser_geometry</build_depend>
+    <build_depend>libpcl-all-dev</build_depend>
     <build_depend>map_msgs</build_depend>
     <build_depend>message_filters</build_depend>
     <build_depend>message_generation</build_depend>
@@ -43,6 +44,7 @@
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>geometry_msgs</run_depend>
     <run_depend>laser_geometry</run_depend>
+    <run_depend>libpcl-all-dev</run_depend>
     <run_depend>map_msgs</run_depend>
     <run_depend>message_filters</run_depend>
     <run_depend>message_runtime</run_depend>

--- a/dwa_local_planner/CMakeLists.txt
+++ b/dwa_local_planner/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED
         )
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include

--- a/dwa_local_planner/package.xml
+++ b/dwa_local_planner/package.xml
@@ -27,6 +27,7 @@
     <build_depend>costmap_2d</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>eigen</build_depend>
+    <build_depend>libpcl-all-dev</build_depend>
     <build_depend>nav_core</build_depend>
     <build_depend>nav_msgs</build_depend>
     <build_depend>pluginlib</build_depend>
@@ -38,6 +39,7 @@
     <run_depend>costmap_2d</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>eigen</run_depend>
+    <run_depend>libpcl-all-dev</run_depend>
     <run_depend>nav_core</run_depend>
     <run_depend>nav_msgs</run_depend>
     <run_depend>pluginlib</run_depend>

--- a/move_slow_and_clear/CMakeLists.txt
+++ b/move_slow_and_clear/CMakeLists.txt
@@ -14,14 +14,12 @@ find_package(catkin REQUIRED
 
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
-    ${PCL_INCLUDE_DIRS}
 )
 add_definitions(${EIGEN3_DEFINITIONS})
 

--- a/navfn/CMakeLists.txt
+++ b/navfn/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(catkin REQUIRED
         )
 
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
+find_package(PCL REQUIRED COMPONENT common)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include

--- a/navfn/package.xml
+++ b/navfn/package.xml
@@ -24,6 +24,7 @@
     <build_depend>cmake_modules</build_depend>
     <build_depend>costmap_2d</build_depend>
     <build_depend>geometry_msgs</build_depend>
+    <build_depend>libpcl-all-dev</build_depend>
     <build_depend>message_generation</build_depend>
     <build_depend>nav_core</build_depend>
     <build_depend>nav_msgs</build_depend>
@@ -38,6 +39,7 @@
 
     <run_depend>costmap_2d</run_depend>
     <run_depend>geometry_msgs</run_depend>
+    <run_depend>libpcl-all-dev</run_depend>
     <run_depend>message_runtime</run_depend>
     <run_depend>nav_core</run_depend>
     <run_depend>nav_msgs</run_depend>


### PR DESCRIPTION
This is a more elegant alternative to #578 , this fixes compilation errors on Zesty and Stretch.
It also allow to reduce the amount of PCL libraries these packages link against and add missing dependencies on pcl for packages using it.