### PR TITLE
Adding "start clearing range" to the Obstacle Layer. 

### DIFF
--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -51,7 +51,7 @@ public:
    * @brief  Creates an empty observation
    */
   Observation() :
-    cloud_(new pcl::PointCloud<pcl::PointXYZ>()), obstacle_range_(0.0), raytrace_range_(0.0), start_clearing_range_(0.0)
+    cloud_(new pcl::PointCloud<pcl::PointXYZ>()), obstacle_range_(0.0), max_raytrace_range_(0.0), min_raytrace_range_(0.0)
   {
   }
 
@@ -61,16 +61,34 @@ public:
   }
 
   /**
+   * @brief  Creates an observation from an origin point and a point cloud.
+   * This constructor is deprecated, use the constructor with min and max raytrace range now.
+   * @param origin The origin point of the observation
+   * @param cloud The point cloud of the observation
+   * @param obstacle_range The range out to which an observation should be able to insert obstacles
+   * @param max_raytrace_range The range out to which an observation should be able to clear via raytracing
+   */
+  ROS_DEPRECATED
+  Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
+              double obstacle_range, double max_raytrace_range) :
+      origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
+      obstacle_range_(obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range)
+  {
+  }
+
+  /**
    * @brief  Creates an observation from an origin point and a point cloud
    * @param origin The origin point of the observation
    * @param cloud The point cloud of the observation
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
-   * @param raytrace_range The range out to which an observation should be able to clear via raytracing
+   * @param min_raytrace_range The range from which an observation should be able to clear via raytracing
+   * @param max_raytrace_range The range out to which an observation should be able to clear via raytracing
    */
   Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
-              double obstacle_range, double raytrace_range, double start_clearing_range=0.0) :
-      origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
-      obstacle_range_(obstacle_range), raytrace_range_(raytrace_range),start_clearing_range_(start_clearing_range)
+              double obstacle_range, double min_raytrace_range, double max_raytrace_range) :
+          origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
+          obstacle_range_(obstacle_range), min_raytrace_range_(min_raytrace_range),
+          max_raytrace_range_(max_raytrace_range)
   {
   }
 
@@ -80,8 +98,8 @@ public:
    */
   Observation(const Observation& obs) :
       origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))),
-      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_),
-      start_clearing_range_(obs.start_clearing_range_)
+      obstacle_range_(obs.obstacle_range_), min_raytrace_range_(obs.min_raytrace_range_),
+      max_raytrace_range_(obs.max_raytrace_range_)
   {
   }
 
@@ -91,16 +109,14 @@ public:
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
    */
   Observation(pcl::PointCloud<pcl::PointXYZ> cloud, double obstacle_range) :
-      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), obstacle_range_(obstacle_range), raytrace_range_(0.0),
-      start_clearing_range_(0.0)
+      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), obstacle_range_(obstacle_range), min_raytrace_range_(0.0),
+      max_raytrace_range_(0.0)
   {
   }
 
   geometry_msgs::Point origin_;
   pcl::PointCloud<pcl::PointXYZ>* cloud_;
-  double obstacle_range_, raytrace_range_;
-  double start_clearing_range_;
-
+  double obstacle_range_, min_raytrace_range_, max_raytrace_range_;
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -51,7 +51,7 @@ public:
    * @brief  Creates an empty observation
    */
   Observation() :
-    cloud_(new pcl::PointCloud<pcl::PointXYZ>()), obstacle_range_(0.0), max_raytrace_range_(0.0), min_raytrace_range_(0.0)
+    cloud_(new pcl::PointCloud<pcl::PointXYZ>()), max_obstacle_range_(0.0), max_raytrace_range_(0.0), min_raytrace_range_(0.0)
   {
   }
 
@@ -65,14 +65,14 @@ public:
    * This constructor is deprecated, use the constructor with min and max raytrace range now.
    * @param origin The origin point of the observation
    * @param cloud The point cloud of the observation
-   * @param obstacle_range The range out to which an observation should be able to insert obstacles
+   * @param max_obstacle_range The range out to which an observation should be able to insert obstacles
    * @param max_raytrace_range The range out to which an observation should be able to clear via raytracing
    */
   ROS_DEPRECATED
   Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
-              double obstacle_range, double max_raytrace_range) :
+              double max_obstacle_range, double max_raytrace_range) :
       origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
-      obstacle_range_(obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range)
+      max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range)
   {
   }
 
@@ -80,14 +80,14 @@ public:
    * @brief  Creates an observation from an origin point and a point cloud
    * @param origin The origin point of the observation
    * @param cloud The point cloud of the observation
-   * @param obstacle_range The range out to which an observation should be able to insert obstacles
+   * @param max_obstacle_range The range out to which an observation should be able to insert obstacles
    * @param min_raytrace_range The range from which an observation should be able to clear via raytracing
    * @param max_raytrace_range The range out to which an observation should be able to clear via raytracing
    */
   Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
-              double obstacle_range, double min_raytrace_range, double max_raytrace_range) :
+              double max_obstacle_range, double min_raytrace_range, double max_raytrace_range) :
           origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
-          obstacle_range_(obstacle_range), min_raytrace_range_(min_raytrace_range),
+          max_obstacle_range_(max_obstacle_range), min_raytrace_range_(min_raytrace_range),
           max_raytrace_range_(max_raytrace_range)
   {
   }
@@ -98,7 +98,7 @@ public:
    */
   Observation(const Observation& obs) :
       origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))),
-      obstacle_range_(obs.obstacle_range_), min_raytrace_range_(obs.min_raytrace_range_),
+      max_obstacle_range_(obs.max_obstacle_range_), min_raytrace_range_(obs.min_raytrace_range_),
       max_raytrace_range_(obs.max_raytrace_range_)
   {
   }
@@ -106,17 +106,17 @@ public:
   /**
    * @brief  Creates an observation from a point cloud
    * @param cloud The point cloud of the observation
-   * @param obstacle_range The range out to which an observation should be able to insert obstacles
+   * @param max_obstacle_range The range out to which an observation should be able to insert obstacles
    */
-  Observation(pcl::PointCloud<pcl::PointXYZ> cloud, double obstacle_range) :
-      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), obstacle_range_(obstacle_range), min_raytrace_range_(0.0),
+  Observation(pcl::PointCloud<pcl::PointXYZ> cloud, double max_obstacle_range) :
+      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0),
       max_raytrace_range_(0.0)
   {
   }
 
   geometry_msgs::Point origin_;
   pcl::PointCloud<pcl::PointXYZ>* cloud_;
-  double obstacle_range_, min_raytrace_range_, max_raytrace_range_;
+  double max_obstacle_range_, min_raytrace_range_, max_raytrace_range_;
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -51,7 +51,7 @@ public:
    * @brief  Creates an empty observation
    */
   Observation() :
-    cloud_(new pcl::PointCloud<pcl::PointXYZ>()), obstacle_range_(0.0), raytrace_range_(0.0)
+    cloud_(new pcl::PointCloud<pcl::PointXYZ>()), obstacle_range_(0.0), raytrace_range_(0.0), start_clearing_range_(0.0)
   {
   }
 
@@ -68,9 +68,9 @@ public:
    * @param raytrace_range The range out to which an observation should be able to clear via raytracing
    */
   Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
-              double obstacle_range, double raytrace_range) :
+              double obstacle_range, double raytrace_range, double start_clearing_range=0.0) :
       origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
-      obstacle_range_(obstacle_range), raytrace_range_(raytrace_range)
+      obstacle_range_(obstacle_range), raytrace_range_(raytrace_range),start_clearing_range_(start_clearing_range)
   {
   }
 
@@ -80,7 +80,8 @@ public:
    */
   Observation(const Observation& obs) :
       origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))),
-      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_)
+      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_),
+      start_clearing_range_(obs.start_clearing_range_)
   {
   }
 
@@ -90,13 +91,16 @@ public:
    * @param obstacle_range The range out to which an observation should be able to insert obstacles
    */
   Observation(pcl::PointCloud<pcl::PointXYZ> cloud, double obstacle_range) :
-      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), obstacle_range_(obstacle_range), raytrace_range_(0.0)
+      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), obstacle_range_(obstacle_range), raytrace_range_(0.0),
+      start_clearing_range_(0.0)
   {
   }
 
   geometry_msgs::Point origin_;
   pcl::PointCloud<pcl::PointXYZ>* cloud_;
   double obstacle_range_, raytrace_range_;
+  double start_clearing_range_;
+
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -71,7 +71,7 @@ public:
   ROS_DEPRECATED
   Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
               double max_obstacle_range, double max_raytrace_range) :
-      origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
+      origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), min_obstacle_range_(0.0),
       max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range)
   {
   }
@@ -80,13 +80,15 @@ public:
    * @brief  Creates an observation from an origin point and a point cloud
    * @param origin The origin point of the observation
    * @param cloud The point cloud of the observation
+   * @param min_obstacle_range The range from which an observation should be able to insert obstacles
    * @param max_obstacle_range The range out to which an observation should be able to insert obstacles
    * @param min_raytrace_range The range from which an observation should be able to clear via raytracing
    * @param max_raytrace_range The range out to which an observation should be able to clear via raytracing
    */
   Observation(geometry_msgs::Point& origin, pcl::PointCloud<pcl::PointXYZ> cloud,
-              double max_obstacle_range, double min_raytrace_range, double max_raytrace_range) :
-          origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),
+              double min_obstacle_range, double max_obstacle_range, double min_raytrace_range,
+              double max_raytrace_range) :
+          origin_(origin), cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)),min_obstacle_range_(min_obstacle_range),
           max_obstacle_range_(max_obstacle_range), min_raytrace_range_(min_raytrace_range),
           max_raytrace_range_(max_raytrace_range)
   {
@@ -98,8 +100,8 @@ public:
    */
   Observation(const Observation& obs) :
       origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))),
-      max_obstacle_range_(obs.max_obstacle_range_), min_raytrace_range_(obs.min_raytrace_range_),
-      max_raytrace_range_(obs.max_raytrace_range_)
+      min_obstacle_range_(obs.min_obstacle_range_), max_obstacle_range_(obs.max_obstacle_range_),
+      min_raytrace_range_(obs.min_raytrace_range_), max_raytrace_range_(obs.max_raytrace_range_)
   {
   }
 
@@ -109,14 +111,14 @@ public:
    * @param max_obstacle_range The range out to which an observation should be able to insert obstacles
    */
   Observation(pcl::PointCloud<pcl::PointXYZ> cloud, double max_obstacle_range) :
-      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0),
-      max_raytrace_range_(0.0)
+      cloud_(new pcl::PointCloud<pcl::PointXYZ>(cloud)), min_obstacle_range_(0.0),
+      max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(0.0)
   {
   }
 
   geometry_msgs::Point origin_;
   pcl::PointCloud<pcl::PointXYZ>* cloud_;
-  double max_obstacle_range_, min_raytrace_range_, max_raytrace_range_;
+  double min_obstacle_range_, max_obstacle_range_, min_raytrace_range_, max_raytrace_range_;
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -69,7 +69,7 @@ public:
    * @param  expected_update_rate How often this buffer is expected to be updated, 0 means there is no limit
    * @param  min_obstacle_height The minimum height of a hitpoint to be considered legal
    * @param  max_obstacle_height The minimum height of a hitpoint to be considered legal
-   * @param  obstacle_range The range to which the sensor should be trusted for inserting obstacles
+   * @param  max_obstacle_range The range to which the sensor should be trusted for inserting obstacles
    * @param  raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
    * @param  tf A reference to a TransformListener
    * @param  global_frame The frame to transform PointClouds into
@@ -78,7 +78,7 @@ public:
    */
   ROS_DEPRECATED
   ObservationBuffer(std::string topic_name, double observation_keep_time, double expected_update_rate,
-                    double min_obstacle_height, double max_obstacle_height, double obstacle_range,
+                    double min_obstacle_height, double max_obstacle_height, double max_obstacle_range,
                     double max_raytrace_range, tf::TransformListener& tf, std::string global_frame,
                     std::string sensor_frame, double tf_tolerance);
 
@@ -89,7 +89,7 @@ public:
    * @param  expected_update_rate How often this buffer is expected to be updated, 0 means there is no limit
    * @param  min_obstacle_height The minimum height of a hitpoint to be considered legal
    * @param  max_obstacle_height The minimum height of a hitpoint to be considered legal
-   * @param  obstacle_range The range to which the sensor should be trusted for inserting obstacles
+   * @param  max_obstacle_range The range to which the sensor should be trusted for inserting obstacles
    * @param  min_raytrace_range The range to which the sensor start to be trusted for clearing out space.
    * @param  raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
    * @param  tf A reference to a TransformListener
@@ -98,7 +98,7 @@ public:
    * @param  tf_tolerance The amount of time to wait for a transform to be available when setting a new global frame
    */
   ObservationBuffer(std::string topic_name, double observation_keep_time, double expected_update_rate,
-                    double min_obstacle_height, double max_obstacle_height, double obstacle_range,
+                    double min_obstacle_height, double max_obstacle_height, double max_obstacle_range,
                     double min_raytrace_range, double max_raytrace_range, tf::TransformListener& tf,
                     std::string global_frame, std::string sensor_frame, double tf_tolerance);
 
@@ -179,7 +179,7 @@ private:
   std::string topic_name_;
   double min_obstacle_height_, max_obstacle_height_;
   boost::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
-  double obstacle_range_, min_raytrace_range_, max_raytrace_range_;
+  double max_obstacle_range_, min_raytrace_range_, max_raytrace_range_;
   double tf_tolerance_;
 };
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -89,18 +89,19 @@ public:
    * @param  expected_update_rate How often this buffer is expected to be updated, 0 means there is no limit
    * @param  min_obstacle_height The minimum height of a hitpoint to be considered legal
    * @param  max_obstacle_height The minimum height of a hitpoint to be considered legal
+   * @param  min_obstacle_range The range from which the sensor should be trusted for inserting obstacles
    * @param  max_obstacle_range The range to which the sensor should be trusted for inserting obstacles
-   * @param  min_raytrace_range The range to which the sensor start to be trusted for clearing out space.
-   * @param  raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
+   * @param  min_raytrace_range The range from which the sensor start to be trusted for raytracing to clear out space
+   * @param  max_raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
    * @param  tf A reference to a TransformListener
    * @param  global_frame The frame to transform PointClouds into
    * @param  sensor_frame The frame of the origin of the sensor, can be left blank to be read from the messages
    * @param  tf_tolerance The amount of time to wait for a transform to be available when setting a new global frame
    */
   ObservationBuffer(std::string topic_name, double observation_keep_time, double expected_update_rate,
-                    double min_obstacle_height, double max_obstacle_height, double max_obstacle_range,
-                    double min_raytrace_range, double max_raytrace_range, tf::TransformListener& tf,
-                    std::string global_frame, std::string sensor_frame, double tf_tolerance);
+                    double min_obstacle_height, double max_obstacle_height, double min_obstacle_range,
+                    double max_obstacle_range, double min_raytrace_range, double max_raytrace_range,
+                    tf::TransformListener& tf, std::string global_frame, std::string sensor_frame, double tf_tolerance);
 
   /**
    * @brief  Destructor... cleans up
@@ -179,7 +180,7 @@ private:
   std::string topic_name_;
   double min_obstacle_height_, max_obstacle_height_;
   boost::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
-  double max_obstacle_range_, min_raytrace_range_, max_raytrace_range_;
+  double min_obstacle_range_, max_obstacle_range_, min_raytrace_range_, max_raytrace_range_;
   double tf_tolerance_;
 };
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -70,6 +70,7 @@ public:
    * @param  max_obstacle_height The minimum height of a hitpoint to be considered legal
    * @param  obstacle_range The range to which the sensor should be trusted for inserting obstacles
    * @param  raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
+   * @param  start_clearing_range The range to wich the sensor start to be trusted for clearing out space.
    * @param  tf A reference to a TransformListener
    * @param  global_frame The frame to transform PointClouds into
    * @param  sensor_frame The frame of the origin of the sensor, can be left blank to be read from the messages
@@ -77,8 +78,8 @@ public:
    */
   ObservationBuffer(std::string topic_name, double observation_keep_time, double expected_update_rate,
                     double min_obstacle_height, double max_obstacle_height, double obstacle_range,
-                    double raytrace_range, tf::TransformListener& tf, std::string global_frame,
-                    std::string sensor_frame, double tf_tolerance);
+                    double raytrace_range, double start_clearing_range, tf::TransformListener& tf,
+                    std::string global_frame, std::string sensor_frame, double tf_tolerance);
 
   /**
    * @brief  Destructor... cleans up
@@ -159,6 +160,7 @@ private:
   boost::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
   double obstacle_range_, raytrace_range_;
   double tf_tolerance_;
+  double start_clearing_range_;
 };
 }  // namespace costmap_2d
 #endif  // COSTMAP_2D_OBSERVATION_BUFFER_H_

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -63,6 +63,7 @@ class ObservationBuffer
 public:
   /**
    * @brief  Constructs an observation buffer
+   * This constructor is deprecated, use the constructor with min and max raytrace range.
    * @param  topic_name The topic of the observations, used as an identifier for error and warning messages
    * @param  observation_keep_time Defines the persistence of observations in seconds, 0 means only keep the latest
    * @param  expected_update_rate How often this buffer is expected to be updated, 0 means there is no limit
@@ -70,7 +71,27 @@ public:
    * @param  max_obstacle_height The minimum height of a hitpoint to be considered legal
    * @param  obstacle_range The range to which the sensor should be trusted for inserting obstacles
    * @param  raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
-   * @param  start_clearing_range The range to wich the sensor start to be trusted for clearing out space.
+   * @param  tf A reference to a TransformListener
+   * @param  global_frame The frame to transform PointClouds into
+   * @param  sensor_frame The frame of the origin of the sensor, can be left blank to be read from the messages
+   * @param  tf_tolerance The amount of time to wait for a transform to be available when setting a new global frame
+   */
+  ROS_DEPRECATED
+  ObservationBuffer(std::string topic_name, double observation_keep_time, double expected_update_rate,
+                    double min_obstacle_height, double max_obstacle_height, double obstacle_range,
+                    double max_raytrace_range, tf::TransformListener& tf, std::string global_frame,
+                    std::string sensor_frame, double tf_tolerance);
+
+  /**
+   * @brief  Constructs an observation buffer
+   * @param  topic_name The topic of the observations, used as an identifier for error and warning messages
+   * @param  observation_keep_time Defines the persistence of observations in seconds, 0 means only keep the latest
+   * @param  expected_update_rate How often this buffer is expected to be updated, 0 means there is no limit
+   * @param  min_obstacle_height The minimum height of a hitpoint to be considered legal
+   * @param  max_obstacle_height The minimum height of a hitpoint to be considered legal
+   * @param  obstacle_range The range to which the sensor should be trusted for inserting obstacles
+   * @param  min_raytrace_range The range to which the sensor start to be trusted for clearing out space.
+   * @param  raytrace_range The range to which the sensor should be trusted for raytracing to clear out space
    * @param  tf A reference to a TransformListener
    * @param  global_frame The frame to transform PointClouds into
    * @param  sensor_frame The frame of the origin of the sensor, can be left blank to be read from the messages
@@ -78,7 +99,7 @@ public:
    */
   ObservationBuffer(std::string topic_name, double observation_keep_time, double expected_update_rate,
                     double min_obstacle_height, double max_obstacle_height, double obstacle_range,
-                    double raytrace_range, double start_clearing_range, tf::TransformListener& tf,
+                    double min_raytrace_range, double max_raytrace_range, tf::TransformListener& tf,
                     std::string global_frame, std::string sensor_frame, double tf_tolerance);
 
   /**
@@ -158,9 +179,8 @@ private:
   std::string topic_name_;
   double min_obstacle_height_, max_obstacle_height_;
   boost::recursive_mutex lock_;  ///< @brief A lock for accessing data in callbacks safely
-  double obstacle_range_, raytrace_range_;
+  double obstacle_range_, min_raytrace_range_, max_raytrace_range_;
   double tf_tolerance_;
-  double start_clearing_range_;
 };
 }  // namespace costmap_2d
 #endif  // COSTMAP_2D_OBSERVATION_BUFFER_H_

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -170,6 +170,8 @@ protected:
 
 private:
   void reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint32_t level);
+  // Retrieve a parameter which can have two names (an old and a new one). If the old was found, print a warning.
+  static void getParam(ros::NodeHandle& nh, const std::string& oldName, const std::string& newName, double& value);
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -73,7 +73,8 @@ costmap_2d::ObstacleLayer* addObstacleLayer(costmap_2d::LayeredCostmap& layers, 
 }
 
 void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z = 0.0,
-                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z, double min_raytrace_range = 0.0){
+                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z, double min_raytrace_range = 0.0,
+                    double max_raytrace_range = 100.){
   pcl::PointCloud<pcl::PointXYZ> cloud;
   cloud.points.resize(1);
   cloud.points[0].x = x;
@@ -85,7 +86,7 @@ void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, doubl
   p.y = oy;
   p.z = oz;
 
-  costmap_2d::Observation obs(p, cloud, 100.0, min_raytrace_range, 100.0);  // obstacle range = raytrace range = 100.0
+  costmap_2d::Observation obs(p, cloud, 100.0, min_raytrace_range, max_raytrace_range); // obstacle range = 100.0
   olayer->addStaticObservation(obs, true, true);
 }
 

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -73,7 +73,7 @@ costmap_2d::ObstacleLayer* addObstacleLayer(costmap_2d::LayeredCostmap& layers, 
 }
 
 void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z = 0.0,
-                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z, double scr = 0.0){
+                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z, double min_raytrace_range = 0.0){
   pcl::PointCloud<pcl::PointXYZ> cloud;
   cloud.points.resize(1);
   cloud.points[0].x = x;
@@ -85,7 +85,7 @@ void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, doubl
   p.y = oy;
   p.z = oz;
 
-  costmap_2d::Observation obs(p, cloud, 100.0, 100.0, scr);  // obstacle range = raytrace range = 100.0
+  costmap_2d::Observation obs(p, cloud, 100.0, min_raytrace_range, 100.0);  // obstacle range = raytrace range = 100.0
   olayer->addStaticObservation(obs, true, true);
 }
 

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -74,7 +74,7 @@ costmap_2d::ObstacleLayer* addObstacleLayer(costmap_2d::LayeredCostmap& layers, 
 
 void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z = 0.0,
                     double ox = 0.0, double oy = 0.0, double oz = MAX_Z, double min_raytrace_range = 0.0,
-                    double max_raytrace_range = 100.){
+                    double max_raytrace_range = 100., double min_obstacle_range=0.0){
   pcl::PointCloud<pcl::PointXYZ> cloud;
   cloud.points.resize(1);
   cloud.points[0].x = x;
@@ -86,7 +86,8 @@ void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, doubl
   p.y = oy;
   p.z = oz;
 
-  costmap_2d::Observation obs(p, cloud, 100.0, min_raytrace_range, max_raytrace_range); // obstacle range = 100.0
+  // max obstacle range = 100.0
+  costmap_2d::Observation obs(p, cloud, min_obstacle_range, 100.0, min_raytrace_range, max_raytrace_range);
   olayer->addStaticObservation(obs, true, true);
 }
 

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -73,7 +73,7 @@ costmap_2d::ObstacleLayer* addObstacleLayer(costmap_2d::LayeredCostmap& layers, 
 }
 
 void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z = 0.0,
-                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z){
+                    double ox = 0.0, double oy = 0.0, double oz = MAX_Z, double scr = 0.0){
   pcl::PointCloud<pcl::PointXYZ> cloud;
   cloud.points.resize(1);
   cloud.points[0].x = x;
@@ -85,7 +85,7 @@ void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, doubl
   p.y = oy;
   p.z = oz;
 
-  costmap_2d::Observation obs(p, cloud, 100.0, 100.0);  // obstacle range = raytrace range = 100.0
+  costmap_2d::Observation obs(p, cloud, 100.0, 100.0, scr);  // obstacle range = raytrace range = 100.0
   olayer->addStaticObservation(obs, true, true);
 }
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -546,8 +546,8 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
         continue;
       }
       double scale_factor = clearing_observation.start_clearing_range_/obstacle_range;
-      double x_start_clearing = (wx-ox)*scale_factor;
-      double y_start_clearing = (wy-oy)*scale_factor;
+      double x_start_clearing = ox+(wx-ox)*scale_factor;
+      double y_start_clearing = oy+(wy-oy)*scale_factor;
       if (!worldToMap(x_start_clearing, y_start_clearing, x0, y0))
       {
         ROS_WARN_THROTTLE(

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -611,10 +611,11 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     if (!worldToMap(wx, wy, x1, y1))
       continue;
 
-    unsigned int cell_raytrace_range = cellDistance(clearing_observation.max_raytrace_range_);
+    unsigned int cell_raytrace_length = cellDistance(clearing_observation.max_raytrace_range_-
+                                                            clearing_observation.min_raytrace_range_);
     MarkCell marker(costmap_, FREE_SPACE);
     // and finally... we can execute our trace to clear obstacles along that line
-    raytraceLine(marker, x0, y0, x1, y1, cell_raytrace_range);
+    raytraceLine(marker, x0, y0, x1, y1, cell_raytrace_length);
 
     updateRaytraceBounds(ox, oy, wx, wy, clearing_observation.max_raytrace_range_, min_x, min_y, max_x, max_y);
   }

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -114,7 +114,7 @@ void ObstacleLayer::onInitialize()
       throw std::runtime_error("Only topics that use point clouds or laser scans are currently supported");
     }
 
-    std::string raytrace_range_param_name, obstacle_range_param_name, start_clearing_range_param_name;
+    std::string max_raytrace_range_param_name, obstacle_range_param_name, min_raytrace_range_param_name;
 
     // get the obstacle range for the sensor
     double obstacle_range = 2.5;
@@ -123,17 +123,27 @@ void ObstacleLayer::onInitialize()
       source_node.getParam(obstacle_range_param_name, obstacle_range);
     }
 
-    // get the raytrace range for the sensor
-    double raytrace_range = 3.0;
-    if (source_node.searchParam("raytrace_range", raytrace_range_param_name))
+    // get the max_raytrace range for the sensor
+    double max_raytrace_range = 3.0;
+    // We first try with the new name.
+    if (!source_node.searchParam("max_raytrace_range", max_raytrace_range_param_name))
     {
-      source_node.getParam(raytrace_range_param_name, raytrace_range);
+      // if not found we try with the old name a print a warining if the old name was used.
+      if (source_node.searchParam("raytrace_range", max_raytrace_range_param_name))
+      {
+        ROS_WARN_STREAM("Parameter raytrace_range is deprecated. It was renamed in max_raytrace_range.");
+      }
+    }
+    if (!max_raytrace_range_param_name.empty())
+    {
+      // If one of both names was found, we get the parameter.
+      source_node.getParam(max_raytrace_range_param_name, max_raytrace_range);
     }
 
-    double start_clearing_range = 0.0;
-    if (source_node.searchParam("start_clearing_range", start_clearing_range_param_name))
+    double min_raytrace_range = 0.0;
+    if (source_node.searchParam("min_raytrace_range", min_raytrace_range_param_name))
     {
-      source_node.getParam(start_clearing_range_param_name, start_clearing_range);
+      source_node.getParam(min_raytrace_range_param_name, min_raytrace_range);
     }
 
     ROS_DEBUG("Creating an observation buffer for source %s, topic %s, frame %s", source.c_str(), topic.c_str(),
@@ -143,7 +153,7 @@ void ObstacleLayer::onInitialize()
     observation_buffers_.push_back(
         boost::shared_ptr < ObservationBuffer
             > (new ObservationBuffer(topic, observation_keep_time, expected_update_rate, min_obstacle_height,
-                                     max_obstacle_height, obstacle_range, raytrace_range, start_clearing_range,
+                                     max_obstacle_height, obstacle_range, min_raytrace_range, max_raytrace_range,
                                      *tf_, global_frame_, sensor_frame, transform_tolerance)));
 
     // check if we'll add this buffer to our marking observation buffers
@@ -531,28 +541,32 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
   {
     double wx = cloud.points[i].x;
     double wy = cloud.points[i].y;
-    if(clearing_observation.start_clearing_range_ > 0)
+    if (clearing_observation.min_raytrace_range_ > 0)
     {
       // If this sensor start seeing obstacle at a certain range, we must move x0,y0 at this
       // range from the sensor (following the line going from the sensor to the point)
       double obstacle_range = hypot(wx-ox, wy-oy);
-      if(obstacle_range < clearing_observation.start_clearing_range_)
+      if (obstacle_range < clearing_observation.min_raytrace_range_)
       {
         // This may happens if parameter start_clearing_range was set to a range lesser than the minimal sensor range.
-        // In this particular case, we just don't set free spaces (after displaying a warning).
-        ROS_WARN_THROTTLE(
-                1.0, "Your start_clearing_range parameter seems to be too short because an observation was returned by"
-                "your sensor in this range. Cells between sensor and this observation was not cleared");
+        // In this particular case, we just don't set free spaces (after displaying a warning). We display the warning
+        // only if obstacle_range is > 0 to handle particular case of sensor returning 0 if they don't see anything.
+        if (obstacle_range > 0)
+        {
+          ROS_WARN_THROTTLE(
+                  60.0, "Your start_clearing_range parameter seems to be too short because an observation was returned by"
+                  "your sensor in this range. Cells between sensor and this observation was not cleared");
+        }
         continue;
       }
-      double scale_factor = clearing_observation.start_clearing_range_/obstacle_range;
-      double x_start_clearing = ox+(wx-ox)*scale_factor;
-      double y_start_clearing = oy+(wy-oy)*scale_factor;
-      if (!worldToMap(x_start_clearing, y_start_clearing, x0, y0))
+      double scale_factor = clearing_observation.min_raytrace_range_/obstacle_range;
+      double x_start_raytrace = ox+(wx-ox)*scale_factor;
+      double y_start_raytrace = oy+(wy-oy)*scale_factor;
+      if (!worldToMap(x_start_raytrace, y_start_raytrace, x0, y0))
       {
         ROS_WARN_THROTTLE(
                 1.0, "The start clearing point at (%.2f, %.2f) is out of map bounds. So, the costmap cannot raytrace for it.",
-                x_start_clearing, y_start_clearing);
+                x_start_raytrace, y_start_raytrace);
         continue;
       }
     }
@@ -597,12 +611,12 @@ void ObstacleLayer::raytraceFreespace(const Observation& clearing_observation, d
     if (!worldToMap(wx, wy, x1, y1))
       continue;
 
-    unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
+    unsigned int cell_raytrace_range = cellDistance(clearing_observation.max_raytrace_range_);
     MarkCell marker(costmap_, FREE_SPACE);
     // and finally... we can execute our trace to clear obstacles along that line
     raytraceLine(marker, x0, y0, x1, y1, cell_raytrace_range);
 
-    updateRaytraceBounds(ox, oy, wx, wy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
+    updateRaytraceBounds(ox, oy, wx, wy, clearing_observation.max_raytrace_range_, min_x, min_y, max_x, max_y);
   }
 }
 

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -352,14 +352,14 @@ void VoxelLayer::raytraceFreespace(const Observation& clearing_observation, doub
     double point_x, point_y, point_z;
     if (worldToMap3DFloat(wpx, wpy, wpz, point_x, point_y, point_z))
     {
-      unsigned int cell_raytrace_range = cellDistance(clearing_observation.raytrace_range_);
+      unsigned int cell_raytrace_range = cellDistance(clearing_observation.max_raytrace_range_);
 
       // voxel_grid_.markVoxelLine(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z);
       voxel_grid_.clearVoxelLineInMap(sensor_x, sensor_y, sensor_z, point_x, point_y, point_z, costmap_,
                                       unknown_threshold_, mark_threshold_, FREE_SPACE, NO_INFORMATION,
                                       cell_raytrace_range);
 
-      updateRaytraceBounds(ox, oy, wpx, wpy, clearing_observation.raytrace_range_, min_x, min_y, max_x, max_y);
+      updateRaytraceBounds(ox, oy, wpx, wpy, clearing_observation.max_raytrace_range_, min_x, min_y, max_x, max_y);
 
       if (publish_clearing_points)
       {

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -147,7 +147,7 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
     const pcl::PointCloud<pcl::PointXYZ>& cloud = *(obs.cloud_);
 
-    double sq_obstacle_range = obs.obstacle_range_ * obs.obstacle_range_;
+    double sq_max_obstacle_range = obs.max_obstacle_range_ * obs.max_obstacle_range_;
 
     for (unsigned int i = 0; i < cloud.points.size(); ++i)
     {
@@ -161,7 +161,7 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
           + (cloud.points[i].z - obs.origin_.z) * (cloud.points[i].z - obs.origin_.z);
 
       // if the point is far enough away... we won't consider it
-      if (sq_dist >= sq_obstacle_range)
+      if (sq_dist >= sq_max_obstacle_range)
         continue;
 
       // now we need to compute the map coordinates for the observation

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -50,13 +50,25 @@ namespace costmap_2d
 {
 ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_time, double expected_update_rate,
                                      double min_obstacle_height, double max_obstacle_height, double obstacle_range,
-                                     double raytrace_range, double start_clearing_range, TransformListener& tf,
+                                     double max_raytrace_range, TransformListener& tf, string global_frame,
+                                     string sensor_frame, double tf_tolerance) :
+    tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
+    last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
+    min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
+    obstacle_range_(obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range),
+    tf_tolerance_(tf_tolerance)
+{
+}
+
+ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_time, double expected_update_rate,
+                                     double min_obstacle_height, double max_obstacle_height, double obstacle_range,
+                                     double min_raytrace_range, double max_raytrace_range, TransformListener& tf,
                                      string global_frame, string sensor_frame, double tf_tolerance) :
     tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
     last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
     min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
-    obstacle_range_(obstacle_range), raytrace_range_(raytrace_range), tf_tolerance_(tf_tolerance),
-    start_clearing_range_(start_clearing_range)
+    obstacle_range_(obstacle_range), min_raytrace_range_(min_raytrace_range), max_raytrace_range_(max_raytrace_range),
+    tf_tolerance_(tf_tolerance)
 {
 }
 
@@ -149,9 +161,9 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
     observation_list_.front().origin_.z = global_origin.getZ();
 
     // make sure to pass on the raytrace/obstacle/start_clearing range of the observation buffer to the observations
-    observation_list_.front().raytrace_range_ = raytrace_range_;
+    observation_list_.front().max_raytrace_range_ = max_raytrace_range_;
     observation_list_.front().obstacle_range_ = obstacle_range_;
-    observation_list_.front().start_clearing_range_ = start_clearing_range_;
+    observation_list_.front().min_raytrace_range_ = min_raytrace_range_;
 
     pcl::PointCloud < pcl::PointXYZ > global_frame_cloud;
 

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -49,25 +49,25 @@ using namespace tf;
 namespace costmap_2d
 {
 ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_time, double expected_update_rate,
-                                     double min_obstacle_height, double max_obstacle_height, double obstacle_range,
+                                     double min_obstacle_height, double max_obstacle_height, double max_obstacle_range,
                                      double max_raytrace_range, TransformListener& tf, string global_frame,
                                      string sensor_frame, double tf_tolerance) :
     tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
     last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
     min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
-    obstacle_range_(obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range),
+    max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range),
     tf_tolerance_(tf_tolerance)
 {
 }
 
 ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_time, double expected_update_rate,
-                                     double min_obstacle_height, double max_obstacle_height, double obstacle_range,
+                                     double min_obstacle_height, double max_obstacle_height, double max_obstacle_range,
                                      double min_raytrace_range, double max_raytrace_range, TransformListener& tf,
                                      string global_frame, string sensor_frame, double tf_tolerance) :
     tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
     last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
     min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
-    obstacle_range_(obstacle_range), min_raytrace_range_(min_raytrace_range), max_raytrace_range_(max_raytrace_range),
+    max_obstacle_range_(max_obstacle_range), min_raytrace_range_(min_raytrace_range), max_raytrace_range_(max_raytrace_range),
     tf_tolerance_(tf_tolerance)
 {
 }
@@ -162,7 +162,7 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
 
     // make sure to pass on the raytrace/obstacle/start_clearing range of the observation buffer to the observations
     observation_list_.front().max_raytrace_range_ = max_raytrace_range_;
-    observation_list_.front().obstacle_range_ = obstacle_range_;
+    observation_list_.front().max_obstacle_range_ = max_obstacle_range_;
     observation_list_.front().min_raytrace_range_ = min_raytrace_range_;
 
     pcl::PointCloud < pcl::PointXYZ > global_frame_cloud;

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -54,21 +54,22 @@ ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_
                                      string sensor_frame, double tf_tolerance) :
     tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
     last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
-    min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
+    min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height), min_obstacle_range_(0.0),
     max_obstacle_range_(max_obstacle_range), min_raytrace_range_(0.0), max_raytrace_range_(max_raytrace_range),
     tf_tolerance_(tf_tolerance)
 {
 }
 
 ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_time, double expected_update_rate,
-                                     double min_obstacle_height, double max_obstacle_height, double max_obstacle_range,
-                                     double min_raytrace_range, double max_raytrace_range, TransformListener& tf,
-                                     string global_frame, string sensor_frame, double tf_tolerance) :
+                                     double min_obstacle_height, double max_obstacle_height, double min_obstacle_range,
+                                     double max_obstacle_range, double min_raytrace_range, double max_raytrace_range,
+                                     TransformListener& tf, string global_frame, string sensor_frame,
+                                     double tf_tolerance) :
     tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
     last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
     min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
-    max_obstacle_range_(max_obstacle_range), min_raytrace_range_(min_raytrace_range), max_raytrace_range_(max_raytrace_range),
-    tf_tolerance_(tf_tolerance)
+    min_obstacle_range_(min_obstacle_range),  max_obstacle_range_(max_obstacle_range),
+    min_raytrace_range_(min_raytrace_range), max_raytrace_range_(max_raytrace_range), tf_tolerance_(tf_tolerance)
 {
 }
 
@@ -161,9 +162,10 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
     observation_list_.front().origin_.z = global_origin.getZ();
 
     // make sure to pass on the raytrace/obstacle/start_clearing range of the observation buffer to the observations
-    observation_list_.front().max_raytrace_range_ = max_raytrace_range_;
-    observation_list_.front().max_obstacle_range_ = max_obstacle_range_;
     observation_list_.front().min_raytrace_range_ = min_raytrace_range_;
+    observation_list_.front().max_raytrace_range_ = max_raytrace_range_;
+    observation_list_.front().min_obstacle_range_ = min_obstacle_range_;
+    observation_list_.front().max_obstacle_range_ = max_obstacle_range_;
 
     pcl::PointCloud < pcl::PointXYZ > global_frame_cloud;
 

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -50,12 +50,13 @@ namespace costmap_2d
 {
 ObservationBuffer::ObservationBuffer(string topic_name, double observation_keep_time, double expected_update_rate,
                                      double min_obstacle_height, double max_obstacle_height, double obstacle_range,
-                                     double raytrace_range, TransformListener& tf, string global_frame,
-                                     string sensor_frame, double tf_tolerance) :
+                                     double raytrace_range, double start_clearing_range, TransformListener& tf,
+                                     string global_frame, string sensor_frame, double tf_tolerance) :
     tf_(tf), observation_keep_time_(observation_keep_time), expected_update_rate_(expected_update_rate),
     last_updated_(ros::Time::now()), global_frame_(global_frame), sensor_frame_(sensor_frame), topic_name_(topic_name),
     min_obstacle_height_(min_obstacle_height), max_obstacle_height_(max_obstacle_height),
-    obstacle_range_(obstacle_range), raytrace_range_(raytrace_range), tf_tolerance_(tf_tolerance)
+    obstacle_range_(obstacle_range), raytrace_range_(raytrace_range), tf_tolerance_(tf_tolerance),
+    start_clearing_range_(start_clearing_range)
 {
 }
 
@@ -147,9 +148,10 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
     observation_list_.front().origin_.y = global_origin.getY();
     observation_list_.front().origin_.z = global_origin.getZ();
 
-    // make sure to pass on the raytrace/obstacle range of the observation buffer to the observations
+    // make sure to pass on the raytrace/obstacle/start_clearing range of the observation buffer to the observations
     observation_list_.front().raytrace_range_ = raytrace_range_;
     observation_list_.front().obstacle_range_ = obstacle_range_;
+    observation_list_.front().start_clearing_range_ = start_clearing_range_;
 
     pcl::PointCloud < pcl::PointXYZ > global_frame_cloud;
 


### PR DESCRIPTION
Start clearing range is the minimal distance at which a sensor can see an obstacle. This is useful for all stereo based sensor (like RGBD and stereo cameras). Obstacles  will not be cleared between the sensor and this range.

I code this patch because I encounter the follwing problem. I have a mobile robot with an RGBD sensor moving in a place where there is a lot of shelfs (or low table). When the robot is far of this objects, there is no problem, they are seend as obstacles. But if the robot go close of this objects, they are cleared as the robot move...

If you want further explanation ask me, I can create a video With and Without my patch.