### PR TITLE
Fix compiler warning for GCC 8.

### DIFF
--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -89,25 +89,25 @@ class MapServer
 #endif
         try {
           doc["resolution"] >> res;
-        } catch (YAML::InvalidScalar) {
+        } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain a resolution tag or it is invalid.");
           exit(-1);
         }
         try {
           doc["negate"] >> negate;
-        } catch (YAML::InvalidScalar) {
+        } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain a negate tag or it is invalid.");
           exit(-1);
         }
         try {
           doc["occupied_thresh"] >> occ_th;
-        } catch (YAML::InvalidScalar) {
+        } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain an occupied_thresh tag or it is invalid.");
           exit(-1);
         }
         try {
           doc["free_thresh"] >> free_th;
-        } catch (YAML::InvalidScalar) {
+        } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain a free_thresh tag or it is invalid.");
           exit(-1);
         }
@@ -125,7 +125,7 @@ class MapServer
             ROS_ERROR("Invalid mode tag \"%s\".", modeS.c_str());
             exit(-1);
           }
-        } catch (YAML::Exception) {
+        } catch (YAML::Exception &) {
           ROS_DEBUG("The map does not contain a mode tag or it is invalid... assuming Trinary");
           mode = TRINARY;
         }
@@ -133,7 +133,7 @@ class MapServer
           doc["origin"][0] >> origin[0];
           doc["origin"][1] >> origin[1];
           doc["origin"][2] >> origin[2];
-        } catch (YAML::InvalidScalar) {
+        } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain an origin tag or it is invalid.");
           exit(-1);
         }
@@ -152,7 +152,7 @@ class MapServer
             mapfname = std::string(dirname(fname_copy)) + '/' + mapfname;
             free(fname_copy);
           }
-        } catch (YAML::InvalidScalar) {
+        } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain an image tag or it is invalid.");
           exit(-1);
         }


### PR DESCRIPTION
GCC 8 adds a warning for catching polymorphic exceptions by value.

```
warning: catching polymorphic type ‘class YAML::InvalidScalar’ by value [-Wcatch-value=]
```

connects to ros2/navigation#17