### PR TITLE
move_base_flex API support - more flexible navigation - BPI Change

### DIFF
--- a/nav_core/include/nav_core/abstract_global_planner.h
+++ b/nav_core/include/nav_core/abstract_global_planner.h
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2017, Sebastian Pütz
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  abstract_global_planner.h
+ *
+ *  author: Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *
+ */
+
+#ifndef NAV_CORE_ABSTRACT_GLOBAL_PLANNER_H_
+#define NAV_CORE_ABSTRACT_GLOBAL_PLANNER_H_
+
+#include <ros/ros.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <boost/shared_ptr.hpp>
+
+namespace nav_core
+{
+
+  class AbstractGlobalPlanner{
+
+    public:
+      typedef boost::shared_ptr< ::nav_core::AbstractGlobalPlanner > Ptr;
+
+      /**
+       * @brief Destructor
+       */
+      virtual ~AbstractGlobalPlanner(){};
+
+      /**
+       * @brief Given a goal pose in the world, compute a plan
+       * @param start The start pose
+       * @param goal The goal pose
+       * @param tolerance The tolerance to the goal pose
+       * @param plan The plan... filled by the planner
+       * @param cost The cost for the the plan
+       * @param plugin_code More detailed outcome in case of failure, so the high level executive
+       * can take better decisions. move_base_flex_msgs developers suggest to use one of the error
+       * codes defined in move_base_flex_msgs/GetPath action.
+       * Will be defaulted to DO_NOT_APPLY on planners not implementing the new move_base_flex API
+       * @param plugin_msg More detailed outcome as a string message
+       * @return True if a valid plan was found, false otherwise
+       */
+      virtual bool makePlan(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal,
+                            double tolerance, std::vector<geometry_msgs::PoseStamped>& plan, double& cost,
+                            uint8_t& plugin_code, std::string& plugin_msg) = 0;
+
+      /**
+       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @return True if a cancel has been successfully requested, false if not implemented.
+       */
+      virtual bool cancel() = 0;
+
+    protected:
+      /**
+       * @brief Constructor
+       */
+      AbstractGlobalPlanner(){};
+  };
+} /* namespace nav_core */
+
+#endif /* abstract_global_planner.h */

--- a/nav_core/include/nav_core/abstract_local_planner.h
+++ b/nav_core/include/nav_core/abstract_local_planner.h
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2017, Sebastian Pütz
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  abstract_local_planner.h
+ *
+ *  author: Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *
+ */
+
+#ifndef NAV_CORE_ABSTRACT_LOCAL_PLANNER_H_
+#define NAV_CORE_ABSTRACT_LOCAL_PLANNER_H_
+
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <tf/transform_listener.h>
+#include <boost/shared_ptr.hpp>
+
+namespace nav_core{
+
+  class AbstractLocalPlanner{
+
+    public:
+
+      typedef boost::shared_ptr< ::nav_core::AbstractLocalPlanner > Ptr;
+
+      /**
+       * @brief Destructor
+       */
+      virtual ~AbstractLocalPlanner(){};
+
+      /**
+       * @brief Given the current position, orientation, and velocity of the robot,
+       * compute velocity commands to send to the base.
+       * @param cmd_vel Will be filled with the velocity command to be passed to the robot base
+       * @param plugin_code More detailed outcome in case of failure, so the high level executive
+       * can take better decisions. move_base_flex_msgs developers suggest to use one of the error
+       * codes defined in move_base_flex_msgs/ExePath action.
+       * Will be defaulted to DO_NOT_APPLY on planners not implementing the new move_base_flex API
+       * @param plugin_msg More detailed outcome as a string message
+       * @return True if a valid velocity command was found, false otherwise
+       */
+      virtual bool computeVelocityCommands(geometry_msgs::Twist& cmd_vel,
+                                           uint8_t& plugin_code, std::string& plugin_msg) = 0;
+
+      /**
+       * @brief Check if the goal pose has been achieved by the local planner
+       * @param angle_tolerance The angle tolerance in which the current pose will be partly accepted as reached goal
+       * @param dist_tolerance The distance tolerance in which the current pose will be partly accepted as reached goal
+       * @return True if achieved, false otherwise
+       */
+      virtual bool isGoalReached(double dist_tolerance, double angle_tolerance) = 0;
+
+      /**
+       * @brief Set the plan that the local planner is following
+       * @param plan The plan to pass to the local planner
+       * @return True if the plan was updated successfully, false otherwise
+       */
+      virtual bool setPlan(const std::vector<geometry_msgs::PoseStamped>& plan) = 0;
+
+      /**
+       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @return True if a cancel has been successfully requested, false if not implemented.
+       */
+      virtual bool cancel() = 0;
+
+    protected:
+      /**
+       * @brief Constructor
+       */
+      AbstractLocalPlanner(){};
+  };
+} /* namespace nav_core */
+
+#endif /* abstract_local_planner.h */

--- a/nav_core/include/nav_core/abstract_recovery_behavior.h
+++ b/nav_core/include/nav_core/abstract_recovery_behavior.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2017, Sebastian Pütz
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  abstract_recovery_behavior.h
+ *
+ *  author: Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ *
+ */
+
+#ifndef NAV_CORE_ABSTRACT_RECOVERY_BEHAVIOR_H
+#define NAV_CORE_ABSTRACT_RECOVERY_BEHAVIOR_H
+
+namespace nav_core {
+  /**
+   * @class AbstractRecoveryBehavior
+   * @brief Provides an interface for recovery behaviors used in navigation.
+   * All recovery behaviors written as plugins for the navigation stack must adhere to this interface.
+   */
+  class AbstractRecoveryBehavior{
+    public:
+
+      typedef boost::shared_ptr< ::nav_core::AbstractRecoveryBehavior > Ptr;
+
+      /**
+       * @brief Runs the AbstractRecoveryBehavior
+       */
+      virtual void runBehavior() = 0;
+
+      /**
+       * @brief Virtual destructor for the interface
+       */
+      virtual ~AbstractRecoveryBehavior(){}
+
+      /**
+       * @brief Requests the recovery behavior to cancel, e.g. if it takes to much time.
+       * @return True if a cancel has been successfully requested, false if not implemented.
+       */
+      virtual bool cancel() = 0;
+
+    protected:
+      AbstractRecoveryBehavior(){}
+  };
+};  // namespace nav_core
+
+#endif  // NAV_CORE_ABSTRACT_RECOVERY_BEHAVIOR_H

--- a/nav_core/include/nav_core/base_global_planner.h
+++ b/nav_core/include/nav_core/base_global_planner.h
@@ -39,33 +39,43 @@
 
 #include <geometry_msgs/PoseStamped.h>
 #include <costmap_2d/costmap_2d_ros.h>
+#include "nav_core/abstract_global_planner.h"
 
 namespace nav_core {
   /**
    * @class BaseGlobalPlanner
    * @brief Provides an interface for global planners used in navigation. All global planners written as plugins for the navigation stack must adhere to this interface.
    */
-  class BaseGlobalPlanner{
+  class BaseGlobalPlanner : public AbstractGlobalPlanner{
     public:
-      /**
-       * @brief Given a goal pose in the world, compute a plan
-       * @param start The start pose 
-       * @param goal The goal pose 
-       * @param plan The plan... filled by the planner
-       * @return True if a valid plan was found, false otherwise
-       */
-      virtual bool makePlan(const geometry_msgs::PoseStamped& start, 
-          const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan) = 0;
+
+      typedef boost::shared_ptr< ::nav_core::BaseGlobalPlanner > Ptr;
+
 
       /**
        * @brief Given a goal pose in the world, compute a plan
-       * @param start The start pose 
-       * @param goal The goal pose 
+       * @param start The start pose
+       * @param goal The goal pose
+       * @param plan The plan... filled by the planner
+       * @return True if a valid plan was found, false otherwise
+       *
+       * @deprecated This method is deprecated in move_base_flex in favor of the one providing detailed result.
+       */
+      virtual bool makePlan(const geometry_msgs::PoseStamped& start,
+          const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan) = 0;
+
+
+      /**
+       * @brief Given a goal pose in the world, compute a plan
+       * @param start The start pose
+       * @param goal The goal pose
        * @param plan The plan... filled by the planner
        * @param cost The plans calculated cost
        * @return True if a valid plan was found, false otherwise
+       *
+       * @deprecated This method is deprecated in move_base_flex in favor of the one providing detailed result.
        */
-      virtual bool makePlan(const geometry_msgs::PoseStamped& start, 
+      virtual bool makePlan(const geometry_msgs::PoseStamped& start,
                             const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan,
                             double& cost)
       {
@@ -74,9 +84,38 @@ namespace nav_core {
       }
 
       /**
-       * @brief  Initialization function for the BaseGlobalPlanner
-       * @param  name The name of this planner
-       * @param  costmap_ros A pointer to the ROS wrapper of the costmap to use for planning
+       * @brief Given a goal pose in the world, compute a plan
+       * @param start The start pose
+       * @param goal The goal pose
+       * @param tolerance The tolerance to the goal pose
+       * @param plan The plan... filled by the planner
+       * @param cost The cost for the the plan
+       * @param plugin_code More detailed outcome; will be defaulted to DO_NOT_APPLY on planners
+       * implementing the old move_base API
+       * @param plugin_msg More detailed outcome as a string message
+       * @return True if a valid plan was found, false otherwise
+       */
+      virtual bool makePlan(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal,
+                            double tolerance, std::vector<geometry_msgs::PoseStamped>& plan, double& cost,
+                            uint8_t& plugin_code, std::string& plugin_msg)
+      {
+        plugin_code = 255;  // DO_NOT_APPLY
+        return makePlan(start, goal, plan, cost);
+      }
+
+      /**
+       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @return True if a cancel has been successfully requested, false if not implemented.
+       */
+      virtual bool cancel()
+      {
+        return false;
+      }
+
+      /**
+       * @brief Initialization function for the BaseGlobalPlanner
+       * @param name The name of this planner
+       * @param costmap_ros A pointer to the ROS wrapper of the costmap to use for planning
        */
       virtual void initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros) = 0;
 

--- a/nav_core/include/nav_core/recovery_behavior.h
+++ b/nav_core/include/nav_core/recovery_behavior.h
@@ -39,29 +39,45 @@
 
 #include <costmap_2d/costmap_2d_ros.h>
 #include <tf/transform_listener.h>
+#include "nav_core/abstract_recovery_behavior.h"
 
 namespace nav_core {
   /**
    * @class RecoveryBehavior
-   * @brief Provides an interface for recovery behaviors used in navigation. All recovery behaviors written as plugins for the navigation stack must adhere to this interface.
+   * @brief Provides an interface for recovery behaviors used in navigation.
+   * All recovery behaviors written as plugins for the navigation stack must adhere to this interface.
    */
-  class RecoveryBehavior{
+  class RecoveryBehavior : public AbstractRecoveryBehavior{
     public:
-      /**
-       * @brief  Initialization function for the RecoveryBehavior
-       * @param tf A pointer to a transform listener
-       * @param global_costmap A pointer to the global_costmap used by the navigation stack 
-       * @param local_costmap A pointer to the local_costmap used by the navigation stack 
-       */
-      virtual void initialize(std::string name, tf::TransformListener* tf, costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap) = 0;
+
+      typedef boost::shared_ptr< ::nav_core::RecoveryBehavior> Ptr;
 
       /**
-       * @brief   Runs the RecoveryBehavior
+       * @brief Initialization function for the RecoveryBehavior
+       * @param tf A pointer to a transform listener
+       * @param global_costmap A pointer to the global_costmap used by the navigation stack
+       * @param local_costmap A pointer to the local_costmap used by the navigation stack
+       */
+      virtual void initialize(std::string name, tf::TransformListener* tf,
+                              costmap_2d::Costmap2DROS* global_costmap,
+                              costmap_2d::Costmap2DROS* local_costmap) = 0;
+
+      /**
+       * @brief Runs the RecoveryBehavior
        */
       virtual void runBehavior() = 0;
 
       /**
-       * @brief  Virtual destructor for the interface
+       * @brief Requests the planner to cancel, e.g. if it takes to much time.
+       * @return True if a cancel has been successfully requested, false if not implemented.
+       */
+      virtual bool cancel()
+      {
+        return false;
+      }
+
+      /**
+       * @brief Virtual destructor for the interface
        */
       virtual ~RecoveryBehavior(){}
 

--- a/nav_core/package.xml
+++ b/nav_core/package.xml
@@ -4,12 +4,18 @@
     <name>nav_core</name>
     <version>1.14.0</version>
     <description>
-
-        This package provides common interfaces for navigation specific robot actions. Currently, this package provides the BaseGlobalPlanner, BaseLocalPlanner, and RecoveryBehavior interfaces, which can be used to build actions that can easily swap their planner, local controller, or recovery behavior for new versions adhering to the same interface.
-
+        This package provides common interfaces for navigation specific robot actions. Currently, this package provides
+        the BaseGlobalPlanner, BaseLocalPlanner, and RecoveryBehavior interfaces, which can be used to build actions
+        that can easily swap their planner, local controller, or recovery behavior for new versions adhering to the
+        same interface. Furthermore, it contains the AbstractGlobalPlanner, AbstractLocalPlanner and
+        AbstractRecoveryBehavior as more abstract base classes for the BaseGlobalPlanner, BaseLocalPlanner and
+        RecoveryBehavior. The abstract classes provides a more meaningful interface enabling the planners to return
+        additional information, e.g. why something went wring. The abstract interface also allow to implement planners
+        which do not use costmaps, e.g., for planning in 3D.
     </description>
     <author>Eitan Marder-Eppstein</author>
     <author>contradict@gmail.com</author>
+    <author email="spuetz@uni-osnabrueck.de">Sebastian Pütz</author>
     <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
     <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
     <license>BSD</license>


### PR DESCRIPTION
Changes for Move Base Flex. We want plugins / planners which can be used with move_base as well as with Move Base Flex in Lunar. We'll present Move Base Flex at the ROSCon 2017 in Vancouver.  So this pull request is a bit urgent. @mikeferguson 
See  https://github.com/magazino/move_base_flex

About MoveBaseFlex:
Move Base Flex (MBF) is a backwards-compatible replacement for move_base. MBF can use existing plugins for move_base, and provides an enhanced version of the same ROS interface. It exposes action servers for planning, controlling and recovering, providing detailed information of the current state and the plugin's feedback. An external executive logic can use MBF and its actions to perform smart and flexible navigation strategies. For example, Magazino has successfully deployed MBF at customer facilities to control TORU robots in highly dynamical environments. Furthermore, MBF enables the use of other map representations, e.g. meshes. The core features are:

1. Fully backwards-compatible with current ROS navigation.
2. Actions for the submodules planning, controlling and recovering, and services to query the costmaps are provided. This interface allows external executives, e.g. SMACH, or Behavior Trees, to run highly flexible and complex navigation strategies.
3. Comprehensive result and feedback information on all actions, including error codes and messages from the loaded plugins. For users still relying on a unique navigation interface, we have extended move_base action with detailed result and feedback information (though we still provide the current one).
4. Separation between an abstract navigation framework and concrete implementations, allowing faster development of new applications, e.g. 3D navigation. 