### PR TITLE
Use occupancy values when saving a map

### DIFF
--- a/map_server/src/map_saver.cpp
+++ b/map_server/src/map_saver.cpp
@@ -73,11 +73,11 @@ class MapGenerator
       for(unsigned int y = 0; y < map->info.height; y++) {
         for(unsigned int x = 0; x < map->info.width; x++) {
           unsigned int i = x + (map->info.height - y - 1) * map->info.width;
-          if (map->data[i] == 0) { //occ [0,0.1)
+          if (map->data[i] >= 0 && map->data[i] < 25) { //occ [0,0.25)
             fputc(254, out);
-          } else if (map->data[i] == +100) { //occ (0.65,1]
+          } else if (map->data[i] > 65) { //occ (0.65,1]
             fputc(000, out);
-          } else { //occ [0.1,0.65]
+          } else { //occ [0.25,0.65]
             fputc(205, out);
           }
         }


### PR DESCRIPTION
This is to allow cartographer's maps to be saved.

The occupancy limits are comments within the source, but they are not enforced by the logic they are next to.