### PR TITLE
remove offending library export (fixes #612)

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -21,12 +21,8 @@ endif()
 catkin_package(
     INCLUDE_DIRS
         include
-        ${SDL_INCLUDE_DIR}
-        ${SDL_IMAGE_INCLUDE_DIRS}
     LIBRARIES
         map_server_image_loader
-        ${SDL_LIBRARY}
-        ${SDL_IMAGE_LIBRARIES}
     CATKIN_DEPENDS
         roscpp
         nav_msgs


### PR DESCRIPTION
* remove LIBRARY export that is broken in SDL. public builds were
  working fine before this, trying to quickly fix them.
* remove INCLUDE exports as well, since none of our headers actually
  include SDL headers.