### PR TITLE
Adding "cutoff distance" as param to Obstacle Layer

### DIFF
--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -141,6 +141,12 @@ public:
    */
   void resetLastUpdated();
 
+  /**
+   * @brief Used to gain access to the raytrace range
+   * @return the raytrace_range_ attribute
+   */
+  double getRaytraceRange();
+
 private:
   /**
    * @brief  Removes any stale observations from the buffer list

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -151,6 +151,7 @@ protected:
 
   std::string global_frame_;  ///< @brief The global frame for the costmap
   double max_obstacle_height_;  ///< @brief Max Obstacle Height
+  double cutoff_distance_;    ///< @brief Points are excluded, if their distance value is exceeding this threshold.
 
   laser_geometry::LaserProjection projector_;  ///< @brief Used to project laser scans into point clouds
 

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -151,7 +151,6 @@ protected:
 
   std::string global_frame_;  ///< @brief The global frame for the costmap
   double max_obstacle_height_;  ///< @brief Max Obstacle Height
-  double cutoff_distance_;    ///< @brief Points are excluded, if their distance value is exceeding this threshold.
 
   laser_geometry::LaserProjection projector_;  ///< @brief Used to project laser scans into point clouds
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -114,7 +114,7 @@ void ObstacleLayer::onInitialize()
       throw std::runtime_error("Only topics that use point clouds or laser scans are currently supported");
     }
 
-    std::string raytrace_range_param_name, obstacle_range_param_name, cutoff_distance_param_name;
+    std::string raytrace_range_param_name, obstacle_range_param_name;
 
     // get the obstacle range for the sensor
     double obstacle_range = 2.5;
@@ -128,13 +128,6 @@ void ObstacleLayer::onInitialize()
     if (source_node.searchParam("raytrace_range", raytrace_range_param_name))
     {
       source_node.getParam(raytrace_range_param_name, raytrace_range);
-    }
-
-    // get the cutoff distance
-    cutoff_distance_ = -1.0;
-    if (source_node.searchParam("cutoff_distance", cutoff_distance_param_name))
-    {
-      source_node.getParam(cutoff_distance_param_name, cutoff_distance_);
     }
 
     ROS_DEBUG("Creating an observation buffer for source %s, topic %s, frame %s", source.c_str(), topic.c_str(),
@@ -266,13 +259,13 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& mess
   // project the scan into a point cloud
   try
   {
-    projector_.transformLaserScanToPointCloud(message->header.frame_id, *message, cloud, *tf_, cutoff_distance_);
+    projector_.transformLaserScanToPointCloud(message->header.frame_id, *message, cloud, *tf_, buffer->getRaytraceRange());
   }
   catch (tf::TransformException &ex)
   {
     ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s", global_frame_.c_str(),
              ex.what());
-    projector_.projectLaser(*message, cloud, cutoff_distance_);
+    projector_.projectLaser(*message, cloud, buffer->getRaytraceRange());
   }
 
   // buffer the point cloud
@@ -303,13 +296,13 @@ void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstP
   // project the scan into a point cloud
   try
   {
-    projector_.transformLaserScanToPointCloud(message.header.frame_id, message, cloud, *tf_, cutoff_distance_);
+    projector_.transformLaserScanToPointCloud(message.header.frame_id, message, cloud, *tf_, buffer->getRaytraceRange());
   }
   catch (tf::TransformException &ex)
   {
     ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s",
              global_frame_.c_str(), ex.what());
-    projector_.projectLaser(message, cloud, cutoff_distance_);
+    projector_.projectLaser(message, cloud, buffer->getRaytraceRange());
   }
 
   // buffer the point cloud

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -114,7 +114,7 @@ void ObstacleLayer::onInitialize()
       throw std::runtime_error("Only topics that use point clouds or laser scans are currently supported");
     }
 
-    std::string raytrace_range_param_name, obstacle_range_param_name;
+    std::string raytrace_range_param_name, obstacle_range_param_name, cutoff_distance_param_name;
 
     // get the obstacle range for the sensor
     double obstacle_range = 2.5;
@@ -128,6 +128,13 @@ void ObstacleLayer::onInitialize()
     if (source_node.searchParam("raytrace_range", raytrace_range_param_name))
     {
       source_node.getParam(raytrace_range_param_name, raytrace_range);
+    }
+
+    // get the cutoff distance
+    cutoff_distance_ = -1.0;
+    if (source_node.searchParam("cutoff_distance", cutoff_distance_param_name))
+    {
+      source_node.getParam(cutoff_distance_param_name, cutoff_distance_);
     }
 
     ROS_DEBUG("Creating an observation buffer for source %s, topic %s, frame %s", source.c_str(), topic.c_str(),
@@ -259,13 +266,13 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& mess
   // project the scan into a point cloud
   try
   {
-    projector_.transformLaserScanToPointCloud(message->header.frame_id, *message, cloud, *tf_);
+    projector_.transformLaserScanToPointCloud(message->header.frame_id, *message, cloud, *tf_, cutoff_distance_);
   }
   catch (tf::TransformException &ex)
   {
     ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s", global_frame_.c_str(),
              ex.what());
-    projector_.projectLaser(*message, cloud);
+    projector_.projectLaser(*message, cloud, cutoff_distance_);
   }
 
   // buffer the point cloud
@@ -296,13 +303,13 @@ void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstP
   // project the scan into a point cloud
   try
   {
-    projector_.transformLaserScanToPointCloud(message.header.frame_id, message, cloud, *tf_);
+    projector_.transformLaserScanToPointCloud(message.header.frame_id, message, cloud, *tf_, cutoff_distance_);
   }
   catch (tf::TransformException &ex)
   {
     ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s",
              global_frame_.c_str(), ex.what());
-    projector_.projectLaser(message, cloud);
+    projector_.projectLaser(message, cloud, cutoff_distance_);
   }
 
   // buffer the point cloud

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -254,5 +254,10 @@ void ObservationBuffer::resetLastUpdated()
 {
   last_updated_ = ros::Time::now();
 }
+
+double ObservationBuffer::getRaytraceRange()
+{
+  return raytrace_range_;
+}
 }  // namespace costmap_2d
 


### PR DESCRIPTION
Priviously laser scan measurements with a distances value greater than the sensors max range are always excluded from the costmap clearing. A parameter let's the user decide whether distance measurements exceeding the max range can be used for clearing. Therefore the `cutoff_distance` parameter has to be set to a threshold distance value corresponding to the limit of trustworthiness. All measurements exceeding this threshold are discarded.