### PR TITLE
Initialize all the costmap variables.

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -60,10 +60,27 @@ void move_parameter(ros::NodeHandle& old_h, ros::NodeHandle& new_h, std::string 
 }
 
 Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
-    layered_costmap_(NULL), name_(name), tf_(tf), stop_updates_(false), initialized_(true), stopped_(false),
-    robot_stopped_(false), map_update_thread_(NULL), last_publish_(0),
-    plugin_loader_("costmap_2d", "costmap_2d::Layer"), publisher_(NULL)
+    layered_costmap_(NULL),
+    name_(name),
+    tf_(tf),
+    transform_tolerance_(0.0),
+    map_update_thread_shutdown_(false),
+    stop_updates_(false),
+    initialized_(true),
+    stopped_(false),
+    robot_stopped_(false),
+    map_update_thread_(NULL),
+    last_publish_(0),
+    plugin_loader_("costmap_2d", "costmap_2d::Layer"),
+    publisher_(NULL),
+    dsrv_(NULL),
+    got_footprint_(false),
+    footprint_padding_(0.0)
 {
+  // Initialize old pose with something
+  old_pose_.setIdentity();
+  old_pose_.setOrigin(tf::Vector3(1e30, 1e30, 1e30));
+
   ros::NodeHandle private_nh("~/" + name);
   ros::NodeHandle g_nh;
 

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -48,7 +48,22 @@ namespace costmap_2d
 {
 
 LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bool track_unknown) :
-    costmap_(), global_frame_(global_frame), rolling_window_(rolling_window), initialized_(false), size_locked_(false)
+    costmap_(),
+    global_frame_(global_frame),
+    rolling_window_(rolling_window),
+    current_(false),
+    minx_(0.0),
+    miny_(0.0),
+    maxx_(0.0),
+    maxy_(0.0),
+    bx0_(0),
+    bxn_(0),
+    by0_(0),
+    byn_(0),
+    initialized_(false),
+    size_locked_(false),
+    circumscribed_radius_(1.0),
+    inscribed_radius_(0.1)
 {
   if (track_unknown)
     costmap_.setDefaultValue(255);


### PR DESCRIPTION
Was running valgrind on navigation, and found a lot of warning about use of un-initialized variables.