### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -39,7 +39,7 @@
 #include <vector>
 
 //register this planner as a RecoveryBehavior plugin
-PLUGINLIB_DECLARE_CLASS(clear_costmap_recovery, ClearCostmapRecovery, clear_costmap_recovery::ClearCostmapRecovery, nav_core::RecoveryBehavior)
+PLUGINLIB_EXPORT_CLASS(clear_costmap_recovery::ClearCostmapRecovery, nav_core::RecoveryBehavior)
 
 using costmap_2d::NO_INFORMATION;
 

--- a/move_slow_and_clear/src/move_slow_and_clear.cpp
+++ b/move_slow_and_clear/src/move_slow_and_clear.cpp
@@ -38,8 +38,7 @@
 #include <pluginlib/class_list_macros.h>
 #include <costmap_2d/obstacle_layer.h>
 
-PLUGINLIB_DECLARE_CLASS(move_slow_and_clear, MoveSlowAndClear, move_slow_and_clear::MoveSlowAndClear,
-    nav_core::RecoveryBehavior)
+PLUGINLIB_EXPORT_CLASS(move_slow_and_clear::MoveSlowAndClear, nav_core::RecoveryBehavior)
 
 namespace move_slow_and_clear
 {

--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -43,7 +43,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 //register this planner as a BaseGlobalPlanner plugin
-PLUGINLIB_DECLARE_CLASS(navfn, NavfnROS, navfn::NavfnROS, nav_core::BaseGlobalPlanner)
+PLUGINLIB_EXPORT_CLASS(navfn::NavfnROS, nav_core::BaseGlobalPlanner)
 
 namespace navfn {
 

--- a/rotate_recovery/src/rotate_recovery.cpp
+++ b/rotate_recovery/src/rotate_recovery.cpp
@@ -38,7 +38,7 @@
 #include <pluginlib/class_list_macros.h>
 
 //register this planner as a RecoveryBehavior plugin
-PLUGINLIB_DECLARE_CLASS(rotate_recovery, RotateRecovery, rotate_recovery::RotateRecovery, nav_core::RecoveryBehavior)
+PLUGINLIB_EXPORT_CLASS(rotate_recovery::RotateRecovery, nav_core::RecoveryBehavior)
 
 namespace rotate_recovery {
 RotateRecovery::RotateRecovery(): global_costmap_(NULL), local_costmap_(NULL), 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

I'm targeting the kinetic-devel branch as it is the default but I can target the lunar branch if it's preferred