### PR TITLE
Print SDL error on IMG_Load failure in server_map

### DIFF
--- a/map_server/src/image_loader.cpp
+++ b/map_server/src/image_loader.cpp
@@ -76,7 +76,7 @@ loadMapFromFile(nav_msgs::GetMap::Response* resp,
   if(!(img = IMG_Load(fname)))
   {
     std::string errmsg = std::string("failed to open image file \"") +
-            std::string(fname) + std::string("\"");
+            std::string(fname) + std::string("\": ") + IMG_GetError();
     throw std::runtime_error(errmsg);
   }
 

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -165,7 +165,15 @@ class MapServer
       }
 
       ROS_INFO("Loading map from image \"%s\"", mapfname.c_str());
-      map_server::loadMapFromFile(&map_resp_,mapfname.c_str(),res,negate,occ_th,free_th, origin, mode);
+      try
+      {
+          map_server::loadMapFromFile(&map_resp_,mapfname.c_str(),res,negate,occ_th,free_th, origin, mode);
+      }
+      catch (std::runtime_error e)
+      {
+          ROS_ERROR("%s", e.what());
+          exit(-1);
+      }
       map_resp_.map.info.map_load_time = ros::Time::now();
       map_resp_.map.header.frame_id = frame_id;
       map_resp_.map.header.stamp = ros::Time::now();


### PR DESCRIPTION
When `IMG_Load` from SDL fail to load an image, the node stop without any message because a `std::runtime_error` is thrown without being catch.

This PR expose the SDL Error in the exception and then catch it properly, to print it as a `ROS_ERROR`.

For instance, if the image is too big, we get this log before the node stop:

```
[ INFO] [1509093324.779196221]: Loading map from image "map.png"
[ERROR] [1509093324.779879685]: failed to open image file "map.png": Out of memory
```