### PR TITLE
Fix bounds bug in Costmap2D

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -234,7 +234,7 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   {
     mx = 0;
   }
-  else if (wx > resolution_ * size_x_ + origin_x_)
+  else if (wx >= resolution_ * size_x_ + origin_x_)
   {
     mx = size_x_ - 1;
   }
@@ -247,7 +247,7 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   {
     my = 0;
   }
-  else if (wy > resolution_ * size_y_ + origin_y_)
+  else if (wy >= resolution_ * size_y_ + origin_y_)
   {
     my = size_y_ - 1;
   }


### PR DESCRIPTION
Ostensibly, Costmap2D::worldToMapEnforceBounds takes an x and y in world coordinates and converts it to valid cell coordinates, clamping to the map bounds if the input point is outside the map. However, the upper bound has a bug: given an map of `resolution_ = 1, size_x_ = 10, origin_x_ = 0`, an input of `wx=9.5` produces `mx=9`,  an input of `wx=10.5` produces `mx=9`, but an input of `wx=10` produces `mx=10`, an invalid index. This PR fixes that.