### PR TITLE
CostmapModel: Make lineCost and pointCost public

### DIFF
--- a/base_local_planner/include/base_local_planner/costmap_model.h
+++ b/base_local_planner/include/base_local_planner/costmap_model.h
@@ -73,7 +73,6 @@ namespace base_local_planner {
       virtual double footprintCost(const geometry_msgs::Point& position, const std::vector<geometry_msgs::Point>& footprint,
           double inscribed_radius, double circumscribed_radius);
 
-    private:
       /**
        * @brief  Rasterizes a line in the costmap grid and checks for collisions
        * @param x0 The x position of the first cell in grid coordinates
@@ -82,7 +81,7 @@ namespace base_local_planner {
        * @param y1 The y position of the second cell in grid coordinates
        * @return A positive cost for a legal line... negative otherwise
        */
-      double lineCost(int x0, int x1, int y0, int y1);
+      double lineCost(int x0, int x1, int y0, int y1) const;
 
       /**
        * @brief  Checks the cost of a point in the costmap
@@ -90,8 +89,9 @@ namespace base_local_planner {
        * @param y The y position of the point in cell coordinates 
        * @return A positive cost for a legal point... negative otherwise
        */
-      double pointCost(int x, int y);
+      double pointCost(int x, int y) const;
 
+    private:
       const costmap_2d::Costmap2D& costmap_; ///< @brief Allows access of costmap obstacle information
 
   };

--- a/base_local_planner/src/costmap_model.cpp
+++ b/base_local_planner/src/costmap_model.cpp
@@ -107,9 +107,7 @@ namespace base_local_planner {
   }
 
   //calculate the cost of a ray-traced line
-  double CostmapModel::lineCost(int x0, int x1, 
-      int y0, int y1){
-    
+  double CostmapModel::lineCost(int x0, int x1, int y0, int y1) const {
     double line_cost = 0.0;
     double point_cost = -1.0;
 
@@ -127,7 +125,7 @@ namespace base_local_planner {
     return line_cost;
   }
 
-  double CostmapModel::pointCost(int x, int y){
+  double CostmapModel::pointCost(int x, int y) const {
     unsigned char cost = costmap_.getCost(x, y);
     //if the cell is in an obstacle the path is invalid
     //if(cost == LETHAL_OBSTACLE){


### PR DESCRIPTION
The CostmapModel class of the base_local_planner package contains two methods `lineCost` and `pointCost`. They can be quite useful, however they are currently private, so they cannot be used outside the class.

To avoid the need for reimplementing the exact same functionality, I propose this pull request to simply make them public. Both methods do not change the class instance (I also made them `const` to ensure and emphasise this), so I do not think that making them public can cause any problem.