### PR TITLE
[lunar] fix 'enable' for static_layer with rolling window (#659)

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -293,6 +293,9 @@ void StaticLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int
   if (!map_received_)
     return;
 
+  if (!enabled_)
+    return;
+
   if (!layered_costmap_->isRolling())
   {
     // if not rolling, the layered costmap (master_grid) has same coordinates as this layer


### PR DESCRIPTION
follow up of #659 