### PR TITLE
Fixing issue in Voxel clearing (issue #662)

### DIFF
--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -80,7 +80,8 @@ public:
    */
   Observation(const Observation& obs) :
       origin_(obs.origin_), cloud_(new pcl::PointCloud<pcl::PointXYZ>(*(obs.cloud_))),
-      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_)
+      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_),
+      within_range_(obs.within_range_)
   {
   }
 
@@ -97,6 +98,7 @@ public:
   geometry_msgs::Point origin_;
   pcl::PointCloud<pcl::PointXYZ>* cloud_;
   double obstacle_range_, raytrace_range_;
+  std::vector<bool> within_range_;
 };
 
 }  // namespace costmap_2d

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -152,14 +152,15 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
     for (unsigned int i = 0; i < cloud.points.size(); ++i)
     {
+      const pcl::PointXYZ& point = cloud.points[i];
       // if the obstacle is too high or too far away from the robot we won't add it
-      if (in_range[i] == false || cloud.points[i].z > max_obstacle_height_)
+      if (in_range[i] == false || point.z > max_obstacle_height_ )
         continue;
 
       // compute the squared distance from the hitpoint to the pointcloud's origin
-      double sq_dist = (cloud.points[i].x - obs.origin_.x) * (cloud.points[i].x - obs.origin_.x)
-          + (cloud.points[i].y - obs.origin_.y) * (cloud.points[i].y - obs.origin_.y)
-          + (cloud.points[i].z - obs.origin_.z) * (cloud.points[i].z - obs.origin_.z);
+      double sq_dist = (point.x - obs.origin_.x) * (point.x - obs.origin_.x)
+          + (point.y - obs.origin_.y) * (point.y - obs.origin_.y)
+          + (point.z - obs.origin_.z) * (point.z - obs.origin_.z);
 
       // if the point is far enough away... we won't consider it
       if (sq_dist >= sq_obstacle_range)
@@ -167,12 +168,12 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
       // now we need to compute the map coordinates for the observation
       unsigned int mx, my, mz;
-      if (cloud.points[i].z < origin_z_)
+      if (point.z < origin_z_)
       {
-        if (!worldToMap3D(cloud.points[i].x, cloud.points[i].y, origin_z_, mx, my, mz))
+        if (!worldToMap3D(point.x, point.y, origin_z_, mx, my, mz))
           continue;
       }
-      else if (!worldToMap3D(cloud.points[i].x, cloud.points[i].y, cloud.points[i].z, mx, my, mz))
+      else if (!worldToMap3D(point.x, point.y, point.z, mx, my, mz))
       {
         continue;
       }
@@ -183,7 +184,7 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
         unsigned int index = getIndex(mx, my);
 
         costmap_[index] = LETHAL_OBSTACLE;
-        touch((double)cloud.points[i].x, (double)cloud.points[i].y, min_x, min_y, max_x, max_y);
+        touch((double)point.x, (double)point.y, min_x, min_y, max_x, max_y);
       }
     }
   }

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -143,13 +143,15 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
                             pcl_conversions::fromPCL(cloud.header).stamp, origin_frame);
     tf_.waitForTransform(global_frame_, local_origin.frame_id_, local_origin.stamp_, ros::Duration(0.5));
     tf_.transformPoint(global_frame_, local_origin, global_origin);
-    observation_list_.front().origin_.x = global_origin.getX();
-    observation_list_.front().origin_.y = global_origin.getY();
-    observation_list_.front().origin_.z = global_origin.getZ();
+    
+    Observation &observation_front = observation_list_.front();
+    observation_front.origin_.x = global_origin.getX();
+    observation_front.origin_.y = global_origin.getY();
+    observation_front.origin_.z = global_origin.getZ();
 
     // make sure to pass on the raytrace/obstacle range of the observation buffer to the observations
-    observation_list_.front().raytrace_range_ = raytrace_range_;
-    observation_list_.front().obstacle_range_ = obstacle_range_;
+    observation_front.raytrace_range_ = raytrace_range_;
+    observation_front.obstacle_range_ = obstacle_range_;
 
     pcl::PointCloud < pcl::PointXYZ > global_frame_cloud;
 
@@ -158,8 +160,8 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
     global_frame_cloud.header.stamp = cloud.header.stamp;
 
     // now we need to remove observations from the cloud that are below or above our height thresholds
-    pcl::PointCloud < pcl::PointXYZ > &observation_cloud = *(observation_list_.front().cloud_);
-    std::vector<bool> &in_range = observation_list_.front().within_range_;
+    pcl::PointCloud < pcl::PointXYZ > &observation_cloud = *(observation_front.cloud_);
+    std::vector<bool> &in_range = observation_front.within_range_;
 
     unsigned int cloud_size = global_frame_cloud.points.size();
     observation_cloud.points = global_frame_cloud.points; // copy all the points

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -159,22 +159,19 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
 
     // now we need to remove observations from the cloud that are below or above our height thresholds
     pcl::PointCloud < pcl::PointXYZ > &observation_cloud = *(observation_list_.front().cloud_);
-    unsigned int cloud_size = global_frame_cloud.points.size();
-    observation_cloud.points.resize(cloud_size);
-    unsigned int point_count = 0;
+    std::vector<bool> &in_range = observation_list_.front().within_range_;
 
-    // copy over the points that are within our height bounds
+    unsigned int cloud_size = global_frame_cloud.points.size();
+    observation_cloud.points = global_frame_cloud.points; // copy all the points
+    in_range.resize(cloud_size);
+
     for (unsigned int i = 0; i < cloud_size; ++i)
     {
-      if (global_frame_cloud.points[i].z <= max_obstacle_height_
-          && global_frame_cloud.points[i].z >= min_obstacle_height_)
-      {
-        observation_cloud.points[point_count++] = global_frame_cloud.points[i];
-      }
+      const double Z = global_frame_cloud.points[i].z;
+      const bool within_obstacle_range = (Z <= max_obstacle_height_ && Z >= min_obstacle_height_);
+      in_range[i] = within_obstacle_range;
     }
 
-    // resize the cloud for the number of legal points
-    observation_cloud.points.resize(point_count);
     observation_cloud.header.stamp = cloud.header.stamp;
     observation_cloud.header.frame_id = global_frame_cloud.header.frame_id;
   }


### PR DESCRIPTION
Hi,

this commit https://github.com/ros-planning/navigation/commit/435a5a762036958e099bf5873b4bbccf82e39660 should solve the problem reported.

The idea is simple: use ALL the valid rays to clear.

The second commit is purely a pedantic "code simplification" that you can just ignore if you want.

Clearing points were discarded because either their height Z are outside the marking limits or because the Z coordinate of the point exceeded the size_z_ of the grid.

You can compare the results before:

https://vimeo.com/255893590

and after the changes

https://vimeo.com/256061162

You will noticed that there are still few voxels which are not cleared. The reason is that some rays of the velodyne are not hitting any object (they are pointing at the sky), therefore they are discarded by the velodyne_pointcloud driver.
In other words, PointCloud and VoxelLayer do not provide the equivalent of "infinite is valid", for this reason there are still marked voxel that can not be cleared.

