### PR TITLE
Update laser_model_type enum on AMCL.cfg

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -49,7 +49,7 @@ gen.add("laser_sigma_hit", double_t, 0, "Standard deviation for Gaussian model u
 gen.add("laser_lambda_short", double_t, 0, "Exponential decay parameter for z_short part of model.", .1, 0, 10)
 gen.add("laser_likelihood_max_dist", double_t, 0, "Maximum distance to do obstacle inflation on map, for use in likelihood_field model.", 2, 0, 20)
 
-lmt = gen.enum([gen.const("beam_const", str_t, "beam", "Use beam laser model"), gen.const("likelihood_field_const", str_t, "likelihood_field", "Use likelihood_field laser model")], "Laser Models")
+lmt = gen.enum([gen.const("beam_const", str_t, "beam", "Use beam laser model"), gen.const("likelihood_field_const", str_t, "likelihood_field", "Use likelihood_field laser model"), gen.const("likelihood_field_prob", str_t, "likelihood_field_prob", "Use likelihood_field_prob laser model")], "Laser Models")
 gen.add("laser_model_type", str_t, 0, "Which model to use, either beam, likelihood_field or likelihood_field_prob.", "likelihood_field", edit_method=lmt)
 
 # Odometry Model Parameters


### PR DESCRIPTION
Adding likelihood_field_prob laser model option on AMCL.cfg to be able to control dynamic parameters with this laser sensor model.

Likely to affect all branches that implement this laser_sensor_model.