### PR TITLE
Fixed race condition with costmaps in LayeredCostmap::resizeMap()

### DIFF
--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -67,6 +67,7 @@ LayeredCostmap::~LayeredCostmap()
 void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                                double origin_y, bool size_locked)
 {
+  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
   size_locked_ = size_locked;
   costmap_.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();


### PR DESCRIPTION
I found a thread-unsafety issue and wrote some code for it.

I am trying to use rtabmap_ros and navigation modules. The rtabmap_ros slam module updates static_layer map incrementally. It is not a ordinary situation but I thought navigation modules should support it.

The issue is as follows:

LayeredCostmap::updateMap() and LayeredCostmap::resizeMap() write to the master grid costmap.
And these two functions can be called by different threads at the same time.
One example of these cases is a race condition between subscriber callback thread
dealing with dynamically-size-changing static_layer and periodical updateMap() calls from Costmap2DROS thread. 

Under the situation the master grid costmap is not thread-safe.
LayeredCostmap::updateMap() already used the master grid costmap's lock.