### PR TITLE
Make sure to call setFootprint() before an in-place rotation

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -118,7 +118,8 @@ namespace dwa_local_planner {
        * @param  new_plan The new global plan
        */
       void updatePlanAndLocalCosts(tf::Stamped<tf::Pose> global_pose,
-          const std::vector<geometry_msgs::PoseStamped>& new_plan);
+          const std::vector<geometry_msgs::PoseStamped>& new_plan,
+          std::vector<geometry_msgs::Point> footprint_spec);
 
       /**
        * @brief Get the period at which the local planner is expected to run

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -242,11 +242,14 @@ namespace dwa_local_planner {
 
   void DWAPlanner::updatePlanAndLocalCosts(
       tf::Stamped<tf::Pose> global_pose,
-      const std::vector<geometry_msgs::PoseStamped>& new_plan) {
+      const std::vector<geometry_msgs::PoseStamped>& new_plan,
+      std::vector<geometry_msgs::Point> footprint_spec) {
     global_plan_.resize(new_plan.size());
     for (unsigned int i = 0; i < new_plan.size(); ++i) {
       global_plan_[i] = new_plan[i];
     }
+
+    obstacle_costs_.setFootprint(footprint_spec);
 
     // costs for going away from path
     path_costs_.setTargetPoses(global_plan_);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -269,7 +269,7 @@ namespace dwa_local_planner {
     ROS_DEBUG_NAMED("dwa_local_planner", "Received a transformed plan with %zu points.", transformed_plan.size());
 
     // update plan in dwa_planner even if we just stop and rotate, to allow checkTrajectory
-    dp_->updatePlanAndLocalCosts(current_pose_, transformed_plan);
+    dp_->updatePlanAndLocalCosts(current_pose_, transformed_plan, costmap_ros_->getRobotFootprint());
 
     if (latchedStopRotateController_.isPositionReached(&planner_util_, current_pose_)) {
       //publish an empty plan because we've reached our goal position


### PR DESCRIPTION
This PR should fix #327, which we ran into on a project recently. I'm sure that there are a variety of ways to address the issue, but this set of changes seems to me the least intrusive way to ensure that `setFootprint()` is called before what might be an in-place rotation without any prior translation.