### PR TITLE
Map server wait for a valid time, fix #573

### DIFF
--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -174,6 +174,8 @@ class MapServer
           ROS_ERROR("%s", e.what());
           exit(-1);
       }
+      // To make sure get a consistent time in simulation
+      ros::Time::waitForValid();
       map_resp_.map.info.map_load_time = ros::Time::now();
       map_resp_.map.header.frame_id = frame_id;
       map_resp_.map.header.stamp = ros::Time::now();


### PR DESCRIPTION
When launching the map_server with Gazebo, the current time is picked
before the simulation is started and then has a value of 0.
Later when querying the stamp of the map, a value of has a special
signification on tf transform for example.