### PR TITLE
Allow specification of free/occupied thresholds for map_saver

### DIFF
--- a/map_server/src/map_saver.cpp
+++ b/map_server/src/map_saver.cpp
@@ -131,7 +131,7 @@ free_thresh: 0.196
 
 #define USAGE "Usage: \n" \
               "  map_saver -h\n"\
-              "  map_saver [-to <threshold_occupied>] [-tf <threshold_free>] [-f <mapname>] [ROS remapping args]"
+              "  map_saver [--occ <threshold_occupied>] [--free <threshold_free>] [-f <mapname>] [ROS remapping args]"
 
 int main(int argc, char** argv)
 {
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
         return 1;
       }
     }
-    else if (!strcmp(argv[i], "-to"))
+    else if (!strcmp(argv[i], "--occ"))
     {
       if (++i < argc)
       {
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
         return 1;
       }
     }
-    else if (!strcmp(argv[i], "-tf"))
+    else if (!strcmp(argv[i], "--free"))
     {
       if (++i < argc)
       {


### PR DESCRIPTION
Adds optional `-to` and `-tf` arguments to map_saver to specify free and occupied thresholds rather than hardcoding free to exactly 0 and occupied to exactly 100.

This helps f.e. with saving maps generated by cartographer.