### PR TITLE
[melodic] tf2_buffer_ -> tf2_buffer_ptr_

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -127,7 +127,7 @@ class AmclNode
     // Use a child class to get access to tf2::Buffer class inside of tf_
     struct TransformListenerWrapper : public tf::TransformListener
     {
-      inline tf2_ros::Buffer &getBuffer() {return tf2_buffer_;}
+      inline std::shared_ptr<tf2_ros::Buffer> getBuffer() {return tf2_buffer_ptr_;}
     };
 
     TransformListenerWrapper* tf_;
@@ -649,7 +649,7 @@ void AmclNode::runFromBag(const std::string &in_bag_fn)
       tf_pub.publish(msg);
       for (size_t ii=0; ii<tf_msg->transforms.size(); ++ii)
       {
-        tf_->getBuffer().setTransform(tf_msg->transforms[ii], "rosbag_authority");
+        tf_->getBuffer()->setTransform(tf_msg->transforms[ii], "rosbag_authority");
       }
       continue;
     }


### PR DESCRIPTION
DO NOT MERGE TO base: ```lunar``` That's just the only branch I can open a PR to. 
I think this should go into ```melodic-devel```.

Change required due to changes in upstream dependencies:
ros/geometry#163: "Maintain & expose tf2 Buffer in shared_ptr for tf"

fixes ros-planning/navigation#717 (for compile errors at least.)