### PR TITLE
AMCL dynamic reconfigure: Extend parameter range

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -29,7 +29,7 @@ gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scan
 
 gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via TF.  When false, do not.", True)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)
-gen.add("save_pose_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used on subsequent runs to initialize the filter. -1.0 to disable.", .5, 0, 10)
+gen.add("save_pose_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used on subsequent runs to initialize the filter. -1.0 to disable.", .5, -1, 10)
 
 gen.add("use_map_topic", bool_t, 0, "When set to true, AMCL will subscribe to the map topic rather than making a service call to receive its map.", False)
 gen.add("first_map_only", bool_t, 0, "When set to true, AMCL will only use the first map it subscribes to, rather than updating each time a new one is received.", False)
@@ -38,7 +38,7 @@ gen.add("first_map_only", bool_t, 0, "When set to true, AMCL will only use the f
 gen.add("laser_min_range", double_t, 0, "Minimum scan range to be considered; -1.0 will cause the laser's reported minimum range to be used.", -1, -1, 1000)
 gen.add("laser_max_range", double_t, 0, "Maximum scan range to be considered; -1.0 will cause the laser's reported maximum range to be used.", -1, -1, 1000)
 
-gen.add("laser_max_beams", int_t, 0, "How many evenly-spaced beams in each scan to be used when updating the filter.", 30, 0, 100)
+gen.add("laser_max_beams", int_t, 0, "How many evenly-spaced beams in each scan to be used when updating the filter.", 30, 0, 250)
 
 gen.add("laser_z_hit", double_t, 0, "Mixture weight for the z_hit part of the model.", .95, 0, 10)
 gen.add("laser_z_short", double_t, 0, "Mixture weight for the z_short part of the model.", .1, 0, 10)


### PR DESCRIPTION
In Addition to #696, which checks the input arguments, this extends the
allowed parameter range in dynamic reconfigure. The description for
"save_pose_rate" says "-1.0 to disable" but allowed only positive values
previously.

Also increase maximum value for laser_max_beams for high performance
systems.

**This should be cherry-picked to lunar and melodic as well.**