### PR TITLE
Allow costmap_2d's voxel_layer to remove obstacles after a timeout.

### DIFF
--- a/costmap_2d/cfg/VoxelPlugin.cfg
+++ b/costmap_2d/cfg/VoxelPlugin.cfg
@@ -16,6 +16,7 @@ gen.add("mark_threshold", int_t, 0, 'The maximum number of marked cells allowed 
 combo_enum = gen.enum([ gen.const("Overwrite", int_t, 0, "b"),
                         gen.const("Maximum",   int_t, 1, "a") ],
                       "Method for combining layers enum")
+gen.add("obstacle_timeout", double_t, 0, "Seconds after which a voxel should be cleared.  0.0 implies living forever", 0.0, 0, 60)
 
 gen.add("combination_method", int_t, 0, "Method for combining two layers", 1, 0, 2, edit_method=combo_enum)
 

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -38,6 +38,9 @@
 #ifndef COSTMAP_2D_VOXEL_LAYER_H_
 #define COSTMAP_2D_VOXEL_LAYER_H_
 
+#include <map>
+#include <boost/tuple/tuple.hpp>
+#include <boost/tuple/tuple_comparison.hpp>
 #include <ros/ros.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
@@ -101,8 +104,12 @@ private:
   voxel_grid::VoxelGrid voxel_grid_;
   double z_resolution_, origin_z_;
   unsigned int unknown_threshold_, mark_threshold_, size_z_;
+  double obstacle_timeout_;
   ros::Publisher clearing_endpoints_pub_;
   sensor_msgs::PointCloud clearing_endpoints_;
+
+  typedef boost::tuple<unsigned int, unsigned int, unsigned int> VoxelIndex;
+  std::map<VoxelIndex, ros::Time> voxel_insertion_times_;
 
   inline bool worldToMap3DFloat(double wx, double wy, double wz, double& mx, double& my, double& mz)
   {

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -89,6 +89,16 @@ void VoxelLayer::reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t l
   unknown_threshold_ = config.unknown_threshold + (VOXEL_BITS - size_z_);
   mark_threshold_ = config.mark_threshold;
   combination_method_ = config.combination_method;
+
+  // If we want to start timing out obstacles, we need to first clear the map,
+  // otherwise those obstacles will never get cleared.
+  if (obstacle_timeout_ == 0 && config.obstacle_timeout > 0.0)
+    reset();
+  // If we no longer need to timeout obstacles, then clear the buffer.
+  if (obstacle_timeout_ > 0 && config.obstacle_timeout == 0)
+    voxel_insertion_times_.clear();
+  obstacle_timeout_ = config.obstacle_timeout;
+
   matchSize();
 }
 
@@ -133,6 +143,51 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
   // update the global current status
   current_ = current;
+
+  // clear obstacles based on timeout
+  if (obstacle_timeout_ > 0.0)
+  {
+    // Get the time of the latest message in an observation buffer.
+    ros::Time latest_obs_stamp;
+    for (size_t i = 0; i < observations.size(); i++)
+    {
+      ros::Time cur_obs_stamp =
+          pcl_conversions::fromPCL(observations[i].cloud_->header).stamp;
+      if (cur_obs_stamp > latest_obs_stamp)
+      {
+        latest_obs_stamp = cur_obs_stamp;
+      }
+    }
+
+    // Make sure we're trying to clear obstacles at a time > 0.
+    if (latest_obs_stamp.toSec() - obstacle_timeout_ > 0.0)
+    {
+      ros::Time expiry_time =
+          latest_obs_stamp - ros::Duration(obstacle_timeout_);
+      std::map<VoxelIndex, ros::Time>::iterator voxel_it;
+      voxel_it = voxel_insertion_times_.begin();
+      while (voxel_it != voxel_insertion_times_.end())
+      {
+        std::map<VoxelIndex, ros::Time>::iterator next_it;
+        next_it = voxel_it;
+        ++next_it;
+        if (voxel_it->second < expiry_time) {
+          unsigned int mx = boost::get<0>(voxel_it->first);
+          unsigned int my = boost::get<1>(voxel_it->first);
+          unsigned int mz = boost::get<2>(voxel_it->first);
+          voxel_grid_.clearVoxelInMap(mx, my, mz,
+                                      unknown_threshold_, mark_threshold_);
+
+          double wx, wy, wz;
+          mapToWorld3D(mx, my, mz, wx, wy, wz);
+          touch(wx, wy, min_x, min_y, max_x, max_y);
+
+          voxel_insertion_times_.erase(voxel_it);
+        }
+        voxel_it = next_it;
+      }
+    }
+  }
 
   // raytrace freespace
   for (unsigned int i = 0; i < clearing_observations.size(); ++i)
@@ -183,6 +238,15 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 
         costmap_[index] = LETHAL_OBSTACLE;
         touch((double)cloud.points[i].x, (double)cloud.points[i].y, min_x, min_y, max_x, max_y);
+      }
+
+      // Add the voxel to the timeout buffer, if needed. Overwrite element
+      // if it already exists.
+      if (obstacle_timeout_ > 0.0)
+      {
+        VoxelIndex voxel_index(mx, my, mz);
+        voxel_insertion_times_[voxel_index] =
+            pcl_conversions::fromPCL(obs.cloud_->header).stamp;
       }
     }
   }

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -498,6 +498,22 @@ void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
   copyMapRegion(local_map, 0, 0, cell_size_x, costmap_, start_x, start_y, size_x_, cell_size_x, cell_size_y);
   copyMapRegion(local_voxel_map, 0, 0, cell_size_x, voxel_map, start_x, start_y, size_x_, cell_size_x, cell_size_y);
 
+  // Shift the indices of obstacles in the voxel_insertion_time data structure.
+  if (obstacle_timeout_ > 0.0)
+  {
+    std::map<VoxelIndex, ros::Time> local_voxel_insertion_times;
+    for (std::map<VoxelIndex, ros::Time>::iterator voxel_it = voxel_insertion_times_.begin();
+         voxel_it != voxel_insertion_times_.end(); ++voxel_it)
+    {
+      unsigned int mx = boost::get<0>(voxel_it->first);
+      unsigned int my = boost::get<1>(voxel_it->first);
+      unsigned int mz = boost::get<2>(voxel_it->first);
+      VoxelIndex new_index(mx - cell_ox, my - cell_oy, mz);
+      local_voxel_insertion_times[new_index] = voxel_it->second;
+    }
+    voxel_insertion_times_ = local_voxel_insertion_times;
+  }
+
   // make sure to clean up
   delete[] local_map;
   delete[] local_voxel_map;

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -92,10 +92,10 @@ void VoxelLayer::reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t l
 
   // If we want to start timing out obstacles, we need to first clear the map,
   // otherwise those obstacles will never get cleared.
-  if (obstacle_timeout_ == 0 && config.obstacle_timeout > 0.0)
+  if (obstacle_timeout_ == 0.0 && config.obstacle_timeout > 0.0)
     reset();
   // If we no longer need to timeout obstacles, then clear the buffer.
-  if (obstacle_timeout_ > 0 && config.obstacle_timeout == 0)
+  if (obstacle_timeout_ > 0.0 && config.obstacle_timeout == 0.0)
     voxel_insertion_times_.clear();
   obstacle_timeout_ = config.obstacle_timeout;
 

--- a/voxel_grid/include/voxel_grid/voxel_grid.h
+++ b/voxel_grid/include/voxel_grid/voxel_grid.h
@@ -135,6 +135,12 @@ public:
 
   inline void clearVoxelInMap(unsigned int x, unsigned int y, unsigned int z)
   {
+    clearVoxelInMap(x, y, z, 1, 1);
+  }
+
+  inline void clearVoxelInMap(unsigned int x, unsigned int y, unsigned int z,
+                              unsigned int unknown_threshold, unsigned int mark_threshold)
+  {
     if(x >= size_x_ || y >= size_y_ || z >= size_z_)
     {
       ROS_DEBUG("Error, voxel out of bounds.\n");
@@ -149,7 +155,8 @@ public:
     unsigned int marked_bits = *col>>16;
 
     //make sure the number of bits in each is below our thesholds
-    if (bitsBelowThreshold(unknown_bits, 1) && bitsBelowThreshold(marked_bits, 1))
+    if (bitsBelowThreshold(unknown_bits, unknown_threshold) &&
+        bitsBelowThreshold(marked_bits, mark_threshold))
     {
       costmap[index] = 0;
     }


### PR DESCRIPTION
This adds a new feature to the costmap_2d's voxel_layer, allowing voxels to be removed after a certain specified timeout.  This is done by maintaining a `std::map` of all current voxels and the time at which they were inserted into the map.  This "obstacle_timeout" can also be changed via dynamics reconfigure.

By default, the `obstacle_timeout` parameter is set to 0.0, which results in no change from the current behavior, and no additional computation.  In this default case, obstacles remain indefinitely in the voxel_layer until they are raytraced away.

This feature also required a small API addition to `clearVoxelInMap` which allows the unknown threshold and clear thresholds to be passed in.  (In my opinion, the incantation without thresholds `clearVoxelInMap(unsigned int x, unsigned int y, unsigned int z)` should be removed from the API entirely, but that's probably for a separate discussion)

Here's a related question on ROS Answers:
https://answers.ros.org/question/215445/why-doesnt-costmap-clear-the-old-obstacles-outside-the-scanner-scope/

_This is my first PR into `ros-planning/navigation` so happy to hear if there's some additional process/workflow I need to be following._
