### PR TITLE
[fix tests] link against pthread

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -141,6 +141,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
   catkin_add_gtest(base_local_planner_utest
     test/gtest_main.cpp
     test/utest.cpp

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -178,6 +178,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/simple_driving_test.xml)
   add_rostest(test/static_tests.launch)
 
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   catkin_add_gtest(array_parser_test test/array_parser_test.cpp)
   target_link_libraries(array_parser_test costmap_2d)
 endif()

--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -75,6 +75,7 @@ if(CATKIN_ENABLE_TESTING)
   copy_test_data( FILES
       test/testmap.bmp
       test/testmap.png )
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp test/test_constants.cpp)
   target_link_libraries(${PROJECT_NAME}_utest
     map_server_image_loader

--- a/navfn/test/CMakeLists.txt
+++ b/navfn/test/CMakeLists.txt
@@ -1,2 +1,3 @@
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 catkin_add_gtest(path_calc_test path_calc_test.cpp ../src/read_pgm_costmap.cpp)
 target_link_libraries(path_calc_test navfn netpbm)

--- a/voxel_grid/CMakeLists.txt
+++ b/voxel_grid/CMakeLists.txt
@@ -31,6 +31,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 if(CATKIN_ENABLE_TESTING)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   catkin_add_gtest(voxel_grid_tests test/voxel_grid_tests.cpp)
   target_link_libraries(voxel_grid_tests
     voxel_grid


### PR DESCRIPTION
Sorry @mikeferguson this should fix why the CI timed out after merging #752.

adds -lpthread in front of all calls to catkin_add_gtest

With this the tests all pass locally, without they can't find symbols.

I've also put this commit onto my branch for #755 