### PR TITLE
Fix: Replaced tf2 setEuler calls with setRPY calls

### DIFF
--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -518,7 +518,7 @@ namespace base_local_planner {
       pose.pose.position.y = p_y;
       pose.pose.position.z = 0.0;
       tf2::Quaternion q;
-      q.setEuler(p_th, 0, 0);
+      q.setRPY(0, 0, p_th);
       tf2::convert(q, pose.pose.orientation);
       local_plan.push_back(pose);
     }

--- a/carrot_planner/src/carrot_planner.cpp
+++ b/carrot_planner/src/carrot_planner.cpp
@@ -150,7 +150,7 @@ namespace carrot_planner {
     plan.push_back(start);
     geometry_msgs::PoseStamped new_goal = goal;
     tf2::Quaternion goal_quat;
-    goal_quat.setEuler(target_yaw, 0, 0);
+    goal_quat.setRPY(0, 0, target_yaw);
 
     new_goal.pose.position.x = target_x;
     new_goal.pose.position.y = target_y;

--- a/global_planner/src/orientation_filter.cpp
+++ b/global_planner/src/orientation_filter.cpp
@@ -44,7 +44,7 @@ namespace global_planner {
 void set_angle(geometry_msgs::PoseStamped* pose, double angle)
 {
   tf2::Quaternion q;
-  q.setEuler( angle, 0, 0 );
+  q.setRPY(0, 0, angle);
   tf2::convert(q, pose->pose.orientation);
 }
 


### PR DESCRIPTION
Introduced by https://github.com/ros-planning/navigation/pull/752. Closes https://github.com/ros-planning/navigation/issues/760