### PR TITLE
[melodic] Fix deps

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(catkin REQUIRED
             nav_msgs
             sensor_msgs
             std_srvs
+            geometry_msgs
+            tf2_msgs
         )
 
 find_package(Boost REQUIRED)
@@ -29,7 +31,14 @@ catkin_package(
         roscpp
         dynamic_reconfigure
         tf2_ros
-  CATKIN_DEPENDS nav_msgs std_srvs
+        geometry_msgs
+        message_filters
+        nav_msgs
+        sensor_msgs
+        std_srvs
+        tf2
+        tf2_geometry_msgs
+        tf2_msgs
   INCLUDE_DIRS include
   LIBRARIES amcl_sensors amcl_map amcl_pf
 )

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED
             roscpp
             sensor_msgs
             std_msgs
+            tf2
             tf2_geometry_msgs
             tf2_ros
             tf2_sensor_msgs
@@ -74,7 +75,10 @@ catkin_package(
         roscpp
         sensor_msgs
         std_msgs
+        tf2
+        tf2_geometry_msgs
         tf2_ros
+        tf2_sensor_msgs
         visualization_msgs
         voxel_grid
     DEPENDS

--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -40,6 +40,7 @@
     <depend>rostest</depend>
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
+    <depend>tf2</depend>
     <depend>tf2_ros</depend>
     <depend>visualization_msgs</depend>
     <depend>voxel_grid</depend>


### PR DESCRIPTION
For AMCL, [previous commit](https://github.com/ros-planning/navigation/commit/960ec291e02b7b80282762f4d8cd77e698a0e728) did not add `sensor_msgs` in all the right places. I went a little further and put all the packages in the `CATKIN_DEPENDS` and added two packages used by `amcl_node`.

I'm not certain what's causing the `costmap_2d` problems, but I added some dependencies just in case.