### PR TITLE
Implement the new move base flex interface for the global planner

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED
     dynamic_reconfigure
     geometry_msgs
     nav_core
+    mbf_costmap_core
     navfn
     nav_msgs
     pluginlib

--- a/global_planner/bgp_mbf_plugin.xml
+++ b/global_planner/bgp_mbf_plugin.xml
@@ -1,0 +1,7 @@
+<library path="lib/libglobal_planner">
+  <class name="global_planner/GlobalPlanner" type="global_planner::GlobalPlanner" base_class_type="mbf_costmap_core::CostmapPlanner">
+    <description>
+      A implementation of a grid based planner using Dijkstras or A*
+    </description>
+  </class>
+</library>

--- a/global_planner/include/global_planner/expander.h
+++ b/global_planner/include/global_planner/expander.h
@@ -45,7 +45,7 @@ namespace global_planner {
 class Expander {
     public:
         Expander(PotentialCalculator* p_calc, int nx, int ny) :
-                unknown_(true), lethal_cost_(253), neutral_cost_(50), factor_(3.0), p_calc_(p_calc) {
+                unknown_(true), canceled_(false), lethal_cost_(253), neutral_cost_(50), factor_(3.0), p_calc_(p_calc) {
             setSize(nx, ny);
         }
         virtual bool calculatePotentials(unsigned char* costs, double start_x, double start_y, double end_x, double end_y,
@@ -88,13 +88,17 @@ class Expander {
             }
         }
 
+        void cancel() {
+            canceled_ = true;
+        }
+
     protected:
         inline int toIndex(int x, int y) {
             return x + nx_ * y;
         }
 
         int nx_, ny_, ns_; /**< size of grid, in pixels */
-        bool unknown_;
+        bool unknown_, canceled_;
         unsigned char lethal_cost_, neutral_cost_;
         int cells_visited_;
         float factor_;

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -53,6 +53,7 @@
 #include <global_planner/traceback.h>
 #include <global_planner/orientation_filter.h>
 #include <global_planner/GlobalPlannerConfig.h>
+#include <mbf_costmap_core/costmap_planner.h>
 
 namespace global_planner {
 
@@ -64,7 +65,7 @@ class GridPath;
  * @brief Provides a ROS wrapper for the global_planner planner which runs a fast, interpolated navigation function on a costmap.
  */
 
-class GlobalPlanner : public nav_core::BaseGlobalPlanner {
+class GlobalPlanner : public nav_core::BaseGlobalPlanner, public mbf_costmap_core::CostmapPlanner {
     public:
         /**
          * @brief  Default constructor for the PlannerCore object
@@ -113,6 +114,42 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
          */
         bool makePlan(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal, double tolerance,
                       std::vector<geometry_msgs::PoseStamped>& plan);
+
+        /**
+         * @brief Given a goal pose in the world, compute a plan
+         * @param start The start pose
+         * @param goal The goal pose
+         * @param tolerance If the goal is obstructed, how many meters the planner can relax the constraint
+         *        in x and y before failing
+         * @param plan The plan... filled by the planner
+         * @param cost The cost for the the plan
+         *  @param message Optional more detailed outcome as a string
+         * @return Result code as described on GetPath action result:
+         *         SUCCESS         = 0
+         *         1..9 are reserved as plugin specific non-error results
+         *         FAILURE         = 50  # Unspecified failure, only used for old, non-mfb_core based plugins
+         *         CANCELED        = 51
+         *         INVALID_START   = 52
+         *         INVALID_GOAL    = 53
+         *         NO_PATH_FOUND   = 54
+         *         PAT_EXCEEDED    = 55
+         *         EMPTY_PATH      = 56
+         *         TF_ERROR        = 57
+         *         NOT_INITIALIZED = 58
+         *         INVALID_PLUGIN  = 59
+         *         INTERNAL_ERROR  = 60
+         *         71..99 are reserved as plugin specific errors
+         */
+        virtual uint32_t makePlan(const geometry_msgs::PoseStamped &start, const geometry_msgs::PoseStamped &goal,
+                                  double tolerance, std::vector<geometry_msgs::PoseStamped> &plan, double &cost,
+                                  std::string &message);
+
+        /**
+         * @brief Requests the planner to cancel, e.g. if it takes too much time.
+         * @remark New on MBF API
+         * @return True if a cancel has been successfully requested, false if not implemented.
+         */
+        virtual bool cancel();
 
         /**
          * @brief  Computes the full navigation function for the map given a point in the world to start from
@@ -172,7 +209,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         costmap_2d::Costmap2D* costmap_;
         std::string frame_id_;
         ros::Publisher plan_pub_;
-        bool initialized_, allow_unknown_, visualize_potential_;
+        bool initialized_, allow_unknown_, visualize_potential_, canceled_;
 
     private:
         void mapToWorld(double mx, double my, double& wx, double& wy);

--- a/global_planner/include/global_planner/traceback.h
+++ b/global_planner/include/global_planner/traceback.h
@@ -44,7 +44,7 @@ namespace global_planner {
 
 class Traceback {
     public:
-        Traceback(PotentialCalculator* p_calc) : p_calc_(p_calc) {}
+        Traceback(PotentialCalculator* p_calc) : p_calc_(p_calc), canceled_(false) {}
 
         virtual bool getPath(float* potential, double start_x, double start_y, double end_x, double end_y, std::vector<std::pair<float, float> >& path) = 0;
         virtual void setSize(int xs, int ys) {
@@ -57,10 +57,16 @@ class Traceback {
         void setLethalCost(unsigned char lethal_cost) {
             lethal_cost_ = lethal_cost;
         }
+
+        void cancel() {
+            canceled_ = true;
+        }
+
     protected:
         int xs_, ys_;
         unsigned char lethal_cost_;
         PotentialCalculator* p_calc_;
+        bool canceled_;
 };
 
 } //end namespace global_planner

--- a/global_planner/package.xml
+++ b/global_planner/package.xml
@@ -24,6 +24,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>mbf_costmap_core</build_depend>
 
   <run_depend>costmap_2d</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
@@ -34,8 +35,10 @@
   <run_depend>pluginlib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>mbf_costmap_core</run_depend>
   <export>
       <nav_core plugin="${prefix}/bgp_plugin.xml" />
+      <mbf_costmap_core plugin="${prefix}/bgp_mbf_plugin.xml" />
   </export>
 
 </package>

--- a/global_planner/src/astar.cpp
+++ b/global_planner/src/astar.cpp
@@ -46,6 +46,7 @@ AStarExpansion::AStarExpansion(PotentialCalculator* p_calc, int xs, int ys) :
 
 bool AStarExpansion::calculatePotentials(unsigned char* costs, double start_x, double start_y, double end_x, double end_y,
                                         int cycles, float* potential) {
+    canceled_ = false;
     queue_.clear();
     int start_i = toIndex(start_x, start_y);
     queue_.push_back(Index(start_i, 0));
@@ -57,6 +58,10 @@ bool AStarExpansion::calculatePotentials(unsigned char* costs, double start_x, d
     int cycle = 0;
 
     while (queue_.size() > 0 && cycle < cycles) {
+        if (canceled_) {
+            return false;
+        }
+
         Index top = queue_[0];
         std::pop_heap(queue_.begin(), queue_.end(), greater1());
         queue_.pop_back();

--- a/global_planner/src/dijkstra.cpp
+++ b/global_planner/src/dijkstra.cpp
@@ -79,6 +79,7 @@ void DijkstraExpansion::setSize(int xs, int ys) {
 
 bool DijkstraExpansion::calculatePotentials(unsigned char* costs, double start_x, double start_y, double end_x, double end_y,
                                            int cycles, float* potential) {
+    canceled_ = false;
     cells_visited_ = 0;
     // priority buffers
     threshold_ = lethal_cost_;
@@ -129,8 +130,11 @@ bool DijkstraExpansion::calculatePotentials(unsigned char* costs, double start_x
     int startCell = toIndex(end_x, end_y);
 
     for (; cycle < cycles; cycle++) // go for this many cycles, unless interrupted
-            {
-        // 
+    {
+        if (canceled_) {
+            return false;
+        }
+
         if (currentEnd_ == 0 && nextEnd_ == 0) // priority blocks empty
             return false;
 

--- a/global_planner/src/gradient_path.cpp
+++ b/global_planner/src/gradient_path.cpp
@@ -66,6 +66,7 @@ void GradientPath::setSize(int xs, int ys) {
 }
 
 bool GradientPath::getPath(float* potential, double start_x, double start_y, double goal_x, double goal_y, std::vector<std::pair<float, float> >& path) {
+    canceled_ = false;
     std::pair<float, float> current;
     int stc = getIndex(goal_x, goal_y);
 
@@ -78,6 +79,10 @@ bool GradientPath::getPath(float* potential, double start_x, double start_y, dou
 
     int c = 0;
     while (c++<ns*4) {
+        if (canceled_) {
+            return false;
+        }
+
         // check if near goal
         double nx = stc % xs_ + dx, ny = stc / xs_ + dy;
 

--- a/global_planner/src/grid_path.cpp
+++ b/global_planner/src/grid_path.cpp
@@ -41,6 +41,7 @@
 namespace global_planner {
 
 bool GridPath::getPath(float* potential, double start_x, double start_y, double end_x, double end_y, std::vector<std::pair<float, float> >& path) {
+    canceled_ = false;
     std::pair<float, float> current;
     current.first = end_x;
     current.second = end_y;
@@ -56,6 +57,9 @@ bool GridPath::getPath(float* potential, double start_x, double start_y, double 
         int min_x = 0, min_y = 0;
         for (int xd = -1; xd <= 1; xd++) {
             for (int yd = -1; yd <= 1; yd++) {
+                if (canceled_) {
+                    return false;
+                }
                 if (xd == 0 && yd == 0)
                     continue;
                 int x = current.first + xd, y = current.second + yd;


### PR DESCRIPTION
Added a second inheritance to GlobalPlanner from the mbf_costmap_core::CostmapPlanner interface to be able to use move_base_flex while backwards compatible to move_base.