### PR TITLE
amcl: Add compile option C++11

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1)
 project(amcl)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 
 find_package(catkin REQUIRED
   COMPONENTS


### PR DESCRIPTION
This is required to build the melodic-devel branch of the navigation stack on kinetic. That is quite useful for porting other packages to the new navigation API without having to install a full-blown melodic system.