### PR TITLE
Remove const from create_nav_plan_astar

### DIFF
--- a/navfn/include/navfn/navfn.h
+++ b/navfn/include/navfn/navfn.h
@@ -93,7 +93,7 @@ positions at about 1/2 cell resolution; else returns 0.
 
 */
 
-  int create_nav_plan_astar(const COSTTYPE *costmap, int nx, int ny,
+  int create_nav_plan_astar(COSTTYPE *costmap, int nx, int ny,
       int* goal, int* start,
       float *plan, int nplan);
 


### PR DESCRIPTION
Fixes https://github.com/ros-planning/navigation/issues/786

Fixes function signature so it matches the implementation