### PR TITLE
fix typo for parameter beam_skip_error_threshold but bandaged for other users in AMCL

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -352,7 +352,11 @@ AmclNode::AmclNode() :
   private_nh_.param("do_beamskip", do_beamskip_, false);
   private_nh_.param("beam_skip_distance", beam_skip_distance_, 0.5);
   private_nh_.param("beam_skip_threshold", beam_skip_threshold_, 0.3);
-  private_nh_.param("beam_skip_error_threshold_", beam_skip_error_threshold_, 0.9);
+  if (private_nh_.hasParam("beam_skip_error_threshold_"))
+  {
+    private_nh_.param("beam_skip_error_threshold_", beam_skip_error_threshold_);
+  }
+  private_nh_.param("beam_skip_error_threshold", beam_skip_error_threshold_, 0.9);
 
   private_nh_.param("laser_z_hit", z_hit_, 0.95);
   private_nh_.param("laser_z_short", z_short_, 0.1);

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -356,7 +356,10 @@ AmclNode::AmclNode() :
   {
     private_nh_.param("beam_skip_error_threshold_", beam_skip_error_threshold_);
   }
-  private_nh_.param("beam_skip_error_threshold", beam_skip_error_threshold_, 0.9);
+  else
+  {
+    private_nh_.param("beam_skip_error_threshold", beam_skip_error_threshold_, 0.9);
+  }
 
   private_nh_.param("laser_z_hit", z_hit_, 0.95);
   private_nh_.param("laser_z_short", z_short_, 0.1);


### PR DESCRIPTION
the underscore in parameter `beam_skip_error_threshold_` is clearly a copy paste error :-) 