### PR TITLE
[kinetic] Fix for adjusting plan resolution

### DIFF
--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -139,15 +139,14 @@ namespace base_local_planner{
     double last_y = global_plan_in[0].pose.position.y;
     global_plan_out.push_back(global_plan_in[0]);
 
-    // we can take "holes" in the plan smaller than 2 grid cells (squared = 4)
-    double min_sq_resolution = resolution * resolution * 4;
+    double min_sq_resolution = resolution * resolution;
 
     for (unsigned int i = 1; i < global_plan_in.size(); ++i) {
       double loop_x = global_plan_in[i].pose.position.x;
       double loop_y = global_plan_in[i].pose.position.y;
       double sqdist = (loop_x - last_x) * (loop_x - last_x) + (loop_y - last_y) * (loop_y - last_y);
       if (sqdist > min_sq_resolution) {
-        int steps = ((sqrt(sqdist) - sqrt(min_sq_resolution)) / resolution) - 1;
+        int steps = ceil((sqrt(sqdist) - sqrt(min_sq_resolution)) / resolution) + 1;
         // add a points in-between
         double deltax = (loop_x - last_x) / steps;
         double deltay = (loop_y - last_y) / steps;

--- a/base_local_planner/src/map_grid.cpp
+++ b/base_local_planner/src/map_grid.cpp
@@ -146,7 +146,7 @@ namespace base_local_planner{
       double loop_y = global_plan_in[i].pose.position.y;
       double sqdist = (loop_x - last_x) * (loop_x - last_x) + (loop_y - last_y) * (loop_y - last_y);
       if (sqdist > min_sq_resolution) {
-        int steps = ceil((sqrt(sqdist) - sqrt(min_sq_resolution)) / resolution) + 1;
+        int steps = ceil((sqrt(sqdist)) / resolution);
         // add a points in-between
         double deltax = (loop_x - last_x) / steps;
         double deltay = (loop_y - last_y) / steps;


### PR DESCRIPTION
Possible fix for #817 

This does change the behavior such that one of the existing tests no longer works. However, I disagree with the results of that test, and it had some suspect parts anyway (i.e. checking the same x coordinate twice each, as opposed to x and y)