### PR TITLE
[kinetic] Add close_polygon flag to polygonOutlineCells method to make it optional

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -255,8 +255,10 @@ public:
    * @brief  Get the map cells that make up the outline of a polygon
    * @param polygon The polygon in map coordinates to rasterize
    * @param polygon_cells Will be set to the cells contained in the outline of the polygon
+   * @param close_polygon Close the polygon by going from the last point to the first (default behavior)
    */
-  void polygonOutlineCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells);
+  void polygonOutlineCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells,
+                           bool close_polygon = true);
 
   /**
    * @brief  Get the map cells that fill a convex polygon

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -337,14 +337,15 @@ bool Costmap2D::setConvexPolygonCost(const std::vector<geometry_msgs::Point>& po
   return true;
 }
 
-void Costmap2D::polygonOutlineCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells)
+void Costmap2D::polygonOutlineCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells,
+                                    bool close_polygon)
 {
   PolygonOutlineCells cell_gatherer(*this, costmap_, polygon_cells);
   for (unsigned int i = 0; i < polygon.size() - 1; ++i)
   {
     raytraceLine(cell_gatherer, polygon[i].x, polygon[i].y, polygon[i + 1].x, polygon[i + 1].y);
   }
-  if (!polygon.empty())
+  if (!polygon.empty() && close_polygon)
   {
     unsigned int last_index = polygon.size() - 1;
     // we also need to close the polygon by going from the last point to the first


### PR DESCRIPTION
The default behavior is the previous one: close polygons, so change will be transparent to existing code