### PR TITLE
[melodic] Add parameters to tailor clear costmaps recovery behavior

### DIFF
--- a/clear_costmap_recovery/include/clear_costmap_recovery/clear_costmap_recovery.h
+++ b/clear_costmap_recovery/include/clear_costmap_recovery/clear_costmap_recovery.h
@@ -50,16 +50,16 @@ namespace clear_costmap_recovery{
     public:
       /**
        * @brief  Constructor, make sure to call initialize in addition to actually initialize the object
-       * @param  
-       * @return 
+       * @param
+       * @return
        */
       ClearCostmapRecovery();
 
       /**
        * @brief  Initialization function for the ClearCostmapRecovery recovery behavior
        * @param tf A pointer to a transform listener
-       * @param global_costmap A pointer to the global_costmap used by the navigation stack 
-       * @param local_costmap A pointer to the local_costmap used by the navigation stack 
+       * @param global_costmap A pointer to the global_costmap used by the navigation stack
+       * @param local_costmap A pointer to the local_costmap used by the navigation stack
        */
       void initialize(std::string name, tf2_ros::Buffer* tf,
           costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap);
@@ -72,14 +72,16 @@ namespace clear_costmap_recovery{
       void runBehavior();
 
     private:
-      void clear(costmap_2d::Costmap2DROS* costmap);      
+      void clear(costmap_2d::Costmap2DROS* costmap);
       void clearMap(boost::shared_ptr<costmap_2d::CostmapLayer> costmap, double pose_x, double pose_y);
       costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
       std::string name_;
       tf2_ros::Buffer* tf_;
       bool initialized_;
+      bool force_updating_; ///< force costmap update after clearing, so we don't need to wait for update thread
       double reset_distance_;
+      std::string affected_maps_; ///< clear only local, global or both costmaps
       std::set<std::string> clearable_layers_; ///< Layer names which will be cleared.
   };
 };
-#endif  
+#endif


### PR DESCRIPTION
- force_updating: force costmap update after clearing, so we don't need to wait for update thread (defaults to false)
- affected_maps: clear only local, global or both costmaps (defaults to both). Clearing local costmap is normally way faster to update, so this allows you to save a lot of time to recover from controller failures.

These changes are particularly useful when we use [move_base_flex](https://github.com/magazino/move_base_flex), as we can minimize the time used by the recovery.
Default behavior is the same as current one, so you won't notice anything until you set the parameters to a non-default value