### PR TITLE
[melodic] Speedup (~25%) inflation layer update

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -192,7 +192,6 @@ private:
   std::vector<std::vector<CellData>> inflation_cells_;
 
   bool* seen_;
-  bool* queued_;
   int seen_size_;
 
   unsigned char** cached_costs_;

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -168,6 +168,7 @@ private:
 
   void computeCaches();
   void deleteKernels();
+  int generateIntegerDistances();
   void inflate_area(int min_i, int min_j, int max_i, int max_j, unsigned char* master_grid);
 
   unsigned int cellDistance(double world_dist)
@@ -175,18 +176,28 @@ private:
     return layered_costmap_->getCostmap()->cellDistance(world_dist);
   }
 
+  /**
+   * @brief  Given an index of a cell in the costmap, place it into a list pending for obstacle inflation
+   * @param  index The index of the cell
+   * @param  mx The x coordinate of the cell (can be computed from the index, but saves time to store it)
+   * @param  my The y coordinate of the cell (can be computed from the index, but saves time to store it)
+   * @param  src_x The x index of the obstacle point inflation started at
+   * @param  src_y The y index of the obstacle point inflation started at
+   */
   inline void enqueue(unsigned int index, unsigned int mx, unsigned int my,
                       unsigned int src_x, unsigned int src_y);
 
   unsigned int cell_inflation_radius_;
   unsigned int cached_cell_inflation_radius_;
-  std::map<double, std::vector<CellData> > inflation_cells_;
+  std::vector<std::vector<CellData>> inflation_cells_;
 
   bool* seen_;
+  bool* queued_;
   int seen_size_;
 
   unsigned char** cached_costs_;
   double** cached_distances_;
+  std::vector<std::vector<int>> distance_matrix_;
   double last_min_x_, last_min_y_, last_max_x_, last_max_y_;
 
   dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig> *dsrv_;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -227,7 +227,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
       unsigned char cost = master_array[index];
       if (cost == LETHAL_OBSTACLE)
       {
-        obs_bin.push_back(CellData(index, i, j, i, j));
+        obs_bin.emplace_back(index, i, j, i, j);
       }
     }
   }
@@ -295,7 +295,7 @@ inline void InflationLayer::enqueue(unsigned int index, unsigned int mx, unsigne
     const int r = cell_inflation_radius_ + 2;
 
     // push the cell data onto the inflation list and mark
-    inflation_cells_[distance_matrix_[mx - src_x+r][my - src_y+r]].push_back(CellData(index, mx, my, src_x, src_y));
+    inflation_cells_[distance_matrix_[mx - src_x+r][my - src_y+r]].emplace_back(index, mx, my, src_x, src_y);
   }
 }
 


### PR DESCRIPTION
This is an follow up of PR #525 implemented by @MirkoFerrati at @Magazino.
As stated in that merged PR, the next biggest CPU eater is the map lookup for distances on enqueue method. This PR speeds up another ~25% by moving from map<double> to vector<>, using pre-cached integer distances.

It has been running on @Magazino robots for several months, so it's definitely well tested.