### PR TITLE
[Windows][melodic] AMCL Windows build bring up.

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -48,6 +48,17 @@ catkin_package(
 
 include_directories(include)
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(src/include)
+
+check_include_file(unistd.h HAVE_UNISTD_H)
+if (HAVE_UNISTD_H)
+  add_definitions(-DHAVE_UNISTD_H)
+endif (HAVE_UNISTD_H)
+
+check_symbol_exists(drand48 stdlib.h HAVE_DRAND48)
+if (HAVE_DRAND48)
+  add_definitions(-DHAVE_DRAND48)
+endif (HAVE_DRAND48)
 
 add_library(amcl_pf
                     src/amcl/pf/pf.c
@@ -82,10 +93,13 @@ target_link_libraries(amcl
 )
 
 install( TARGETS
-    amcl amcl_sensors amcl_map amcl_pf
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    amcl
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install( TARGETS
+    amcl_sensors amcl_map amcl_pf
+    DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
 install(DIRECTORY include/amcl/

--- a/amcl/src/amcl/pf/eig3.c
+++ b/amcl/src/amcl/pf/eig3.c
@@ -8,8 +8,11 @@
 #define MAX(a, b) ((a)>(b)?(a):(b))
 #endif
 
-//#define n 3
+#ifdef _MSC_VER
+#define n 3
+#else
 static int n = 3;
+#endif
 
 static double hypot2(double x, double y) {
   return sqrt(x*x+y*y);

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -33,6 +33,7 @@
 #include "amcl/pf/pf.h"
 #include "amcl/pf/pf_pdf.h"
 #include "amcl/pf/pf_kdtree.h"
+#include "portable_utils.hpp"
 
 
 // Compute the required number of samples, given that there are k bins
@@ -52,7 +53,7 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   pf_sample_t *sample;
   
   srand48(time(NULL));
-
+  
   pf = calloc(1, sizeof(pf_t));
 
   pf->random_pose_fn = random_pose_fn;
@@ -216,7 +217,6 @@ int pf_update_converged(pf_t *pf)
   int i;
   pf_sample_set_t *set;
   pf_sample_t *sample;
-  double total;
 
   set = pf->sets + pf->current_set;
   double mean_x = 0, mean_y = 0;

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -53,7 +53,7 @@ pf_t *pf_alloc(int min_samples, int max_samples,
   pf_sample_t *sample;
   
   srand48(time(NULL));
-  
+
   pf = calloc(1, sizeof(pf_t));
 
   pf->random_pose_fn = random_pose_fn;
@@ -217,6 +217,7 @@ int pf_update_converged(pf_t *pf)
   int i;
   pf_sample_set_t *set;
   pf_sample_t *sample;
+  double total;
 
   set = pf->sets + pf->current_set;
   double mean_x = 0, mean_y = 0;

--- a/amcl/src/amcl/pf/pf_pdf.c
+++ b/amcl/src/amcl/pf/pf_pdf.c
@@ -33,6 +33,7 @@
 //#include <gsl/gsl_randist.h>
 
 #include "amcl/pf/pf_pdf.h"
+#include "portable_utils.hpp"
 
 // Random number generator seed value
 static unsigned int pf_pdf_seed;

--- a/amcl/src/amcl/pf/pf_vector.c
+++ b/amcl/src/amcl/pf/pf_vector.c
@@ -53,7 +53,7 @@ int pf_vector_finite(pf_vector_t a)
   int i;
   
   for (i = 0; i < 3; i++)
-    if (!finite(a.v[i]))
+    if (!isfinite(a.v[i]))
       return 0;
   
   return 1;
@@ -151,7 +151,7 @@ int pf_matrix_finite(pf_matrix_t a)
   
   for (i = 0; i < 3; i++)
     for (j = 0; j < 3; j++)
-      if (!finite(a.m[i][j]))
+      if (!isfinite(a.m[i][j]))
         return 0;
   
   return 1;

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -31,7 +31,9 @@
 #include <math.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 
 #include "amcl/sensors/amcl_laser.h"
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -36,6 +36,7 @@
 #include "amcl/pf/pf.h"
 #include "amcl/sensors/amcl_odom.h"
 #include "amcl/sensors/amcl_laser.h"
+#include "portable_utils.hpp"
 
 #include "ros/assert.h"
 

--- a/amcl/src/include/portable_utils.hpp
+++ b/amcl/src/include/portable_utils.hpp
@@ -9,7 +9,7 @@ extern "C" {
 
 #ifndef HAVE_DRAND48
 // Some system (e.g., Windows) doesn't come with drand48(), srand48().
-// Use rand, and srand to replace it on Windows.
+// Use rand, and srand for such system.
 static double drand48(void)
 {
     return ((double)rand())/RAND_MAX;

--- a/amcl/src/include/portable_utils.hpp
+++ b/amcl/src/include/portable_utils.hpp
@@ -1,0 +1,28 @@
+#ifndef PORTABLE_UTILS_H
+#define PORTABLE_UTILS_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HAVE_DRAND48
+// Some system (e.g., Windows) doesn't come with drand48(), srand48().
+// Use rand, and srand to replace it on Windows.
+static double drand48(void)
+{
+    return ((double)rand())/RAND_MAX;
+}
+
+static void srand48(long int seedval)
+{
+    srand(seedval);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
* Add HAVE_UNISTD and HAVE_DRAND48 and portable_utils.hpp for better cross compiling.
* Variable length array is not supported in MSVC, conditionally disable it.
* Fix install location for shared lib and executables on Windows.
* Use isfinite for better cross compiling.

This change is verified against the https://aka.ms/ros project.