### PR TITLE
[Windows][melodic] map_server Windows build bring up

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -11,12 +11,14 @@ find_package(catkin REQUIRED
 find_package(Bullet REQUIRED)
 find_package(SDL REQUIRED)
 find_package(SDL_image REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(YAMLCPP yaml-cpp REQUIRED)
 if(YAMLCPP_VERSION VERSION_GREATER "0.5.0")
     add_definitions(-DHAVE_YAMLCPP_GT_0_5_0)
 endif()
+link_directories(${YAMLCPP_LIBRARY_DIRS})
 
 catkin_package(
     INCLUDE_DIRS
@@ -36,6 +38,7 @@ include_directories(
     ${SDL_INCLUDE_DIR}
     ${SDL_IMAGE_INCLUDE_DIRS}
     ${YAMLCPP_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
 
 add_library(map_server_image_loader src/image_loader.cpp)
@@ -85,7 +88,7 @@ if(CATKIN_ENABLE_TESTING)
   add_executable(rtest test/rtest.cpp test/test_constants.cpp)
   add_dependencies(rtest ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
   target_link_libraries( rtest
-      gtest
+      ${GTEST_LIBRARIES}
       ${catkin_LIBRARIES}
   )
 
@@ -95,10 +98,11 @@ if(CATKIN_ENABLE_TESTING)
 endif()
 
 ## Install executables and/or libraries
-install(TARGETS map_server-map_saver map_server map_server_image_loader
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(TARGETS map_server-map_saver map_server
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(TARGETS map_server_image_loader
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 ## Install project namespaced headers
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -37,8 +37,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <libgen.h>
 #include <fstream>
+#include <boost/filesystem.hpp>
 
 #include "ros/ros.h"
 #include "ros/console.h"
@@ -145,12 +145,14 @@ class MapServer
             ROS_ERROR("The image tag cannot be an empty string.");
             exit(-1);
           }
-          if(mapfname[0] != '/')
+
+          boost::filesystem::path mapfpath(mapfname);
+          if (!mapfpath.is_absolute())
           {
-            // dirname can modify what you pass it
-            char* fname_copy = strdup(fname.c_str());
-            mapfname = std::string(dirname(fname_copy)) + '/' + mapfname;
-            free(fname_copy);
+            boost::filesystem::path dir(fname);
+            dir = dir.parent_path();
+            mapfpath = dir / mapfpath;
+            mapfname = mapfpath.string();
           }
         } catch (YAML::InvalidScalar &) {
           ROS_ERROR("The map does not contain an image tag or it is invalid.");


### PR DESCRIPTION
* Fix install location for Windows build. (On Windows build, shared library uses RUNTIME location, but not LIBRARY)
* Use boost::filesystem::path to handle path logic and remove the libgen.h dependency for better cross platform.
* Fix gtest hard-coded and add YAML library dir in CMakeList.txt.

This change is verified by https://aka.ms/ros project.