### PR TITLE
ROS_DEBUG prints incorrect gen_id & incorrect namespace for /latch_xy_goal_tolerance

### DIFF
--- a/base_local_planner/include/base_local_planner/latched_stop_rotate_controller.h
+++ b/base_local_planner/include/base_local_planner/latched_stop_rotate_controller.h
@@ -21,9 +21,11 @@ namespace base_local_planner {
 
 class LatchedStopRotateController {
 public:
-  LatchedStopRotateController(const std::string& name = "");
+  LatchedStopRotateController();
   virtual ~LatchedStopRotateController();
 
+  void initialize(const std::string& name = "");
+  
   bool isPositionReached(LocalPlannerUtil* planner_util,
       tf::Stamped<tf::Pose> global_pose);
 

--- a/base_local_planner/src/latched_stop_rotate_controller.cpp
+++ b/base_local_planner/src/latched_stop_rotate_controller.cpp
@@ -19,12 +19,13 @@
 
 namespace base_local_planner {
 
-LatchedStopRotateController::LatchedStopRotateController(const std::string& name) {
-  ros::NodeHandle private_nh("~/" + name);
-  private_nh.param("latch_xy_goal_tolerance", latch_xy_goal_tolerance_, false);
+LatchedStopRotateController::LatchedStopRotateController() {}
 
-  rotating_to_goal_ = false;
-}
+void LatchedStopRotateController::initialize(const std::string& name) {
+    ros::NodeHandle private_nh("~/" + name);
+    private_nh.param("latch_xy_goal_tolerance", latch_xy_goal_tolerance_, false);
+    rotating_to_goal_ = false;
+  }
 
 LatchedStopRotateController::~LatchedStopRotateController() {}
 

--- a/base_local_planner/src/latched_stop_rotate_controller.cpp
+++ b/base_local_planner/src/latched_stop_rotate_controller.cpp
@@ -23,7 +23,9 @@ LatchedStopRotateController::LatchedStopRotateController() {}
 
 void LatchedStopRotateController::initialize(const std::string& name) {
     ros::NodeHandle private_nh("~/" + name);
-    private_nh.param("latch_xy_goal_tolerance", latch_xy_goal_tolerance_, false);
+    std::string param_name;
+    private_nh.searchParam("latch_xy_goal_tolerance", param_name);
+    private_nh.param(param_name, latch_xy_goal_tolerance_, false);
     rotating_to_goal_ = false;
   }
 

--- a/base_local_planner/src/simple_scored_sampling_planner.cpp
+++ b/base_local_planner/src/simple_scored_sampling_planner.cpp
@@ -40,7 +40,7 @@
 #include <ros/console.h>
 
 namespace base_local_planner {
-  
+
   SimpleScoredSamplingPlanner::SimpleScoredSamplingPlanner(std::vector<TrajectorySampleGenerator*> gen_list, std::vector<TrajectoryCostFunction*>& critics, int max_samples) {
     max_samples_ = max_samples;
     gen_list_ = gen_list;
@@ -53,7 +53,7 @@ namespace base_local_planner {
     for(std::vector<TrajectoryCostFunction*>::iterator score_function = critics_.begin(); score_function != critics_.end(); ++score_function) {
       TrajectoryCostFunction* score_function_p = *score_function;
       if (score_function_p->getScale() == 0) {
-	gen_id++;
+        gen_id++;
         continue;
       }
       double cost = score_function_p->scoreTrajectory(traj);
@@ -119,7 +119,7 @@ namespace base_local_planner {
         count++;
         if (max_samples_ > 0 && count >= max_samples_) {
           break;
-        }        
+        }
       }
       if (best_traj_cost >= 0) {
         traj.xv_ = best_traj.xv_;
@@ -142,5 +142,5 @@ namespace base_local_planner {
     return best_traj_cost >= 0;
   }
 
-  
+
 }// namespace

--- a/base_local_planner/src/simple_scored_sampling_planner.cpp
+++ b/base_local_planner/src/simple_scored_sampling_planner.cpp
@@ -53,6 +53,7 @@ namespace base_local_planner {
     for(std::vector<TrajectoryCostFunction*>::iterator score_function = critics_.begin(); score_function != critics_.end(); ++score_function) {
       TrajectoryCostFunction* score_function_p = *score_function;
       if (score_function_p->getScale() == 0) {
+	gen_id++;
         continue;
       }
       double cost = score_function_p->scoreTrajectory(traj);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -117,6 +117,8 @@ namespace dwa_local_planner {
         odom_helper_.setOdomTopic( odom_topic_ );
       }
       
+      latchedStopRotateController_.initialize(name);
+
       initialized_ = true;
 
       dsrv_ = new dynamic_reconfigure::Server<DWAPlannerConfig>(private_nh);
@@ -127,7 +129,7 @@ namespace dwa_local_planner {
       ROS_WARN("This planner has already been initialized, doing nothing.");
     }
   }
-  
+
   bool DWAPlannerROS::setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan) {
     if (! isInitialized()) {
       ROS_ERROR("This planner has not been initialized, please call initialize() before using this planner");
@@ -193,7 +195,7 @@ namespace dwa_local_planner {
     //compute what trajectory to drive along
     tf::Stamped<tf::Pose> drive_cmds;
     drive_cmds.frame_id_ = costmap_ros_->getBaseFrameID();
-    
+
     // call with updated footprint
     base_local_planner::Trajectory path = dp_->findBestPath(global_pose, robot_vel, drive_cmds);
     //ROS_ERROR("Best: %.2f, %.2f, %.2f, %.2f", path.xv_, path.yv_, path.thetav_, path.cost_);
@@ -221,7 +223,7 @@ namespace dwa_local_planner {
       return false;
     }
 
-    ROS_DEBUG_NAMED("dwa_local_planner", "A valid velocity command of (%.2f, %.2f, %.2f) was found for this cycle.", 
+    ROS_DEBUG_NAMED("dwa_local_planner", "A valid velocity command of (%.2f, %.2f, %.2f) was found for this cycle.",
                     cmd_vel.linear.x, cmd_vel.linear.y, cmd_vel.angular.z);
 
     // Fill out the local plan


### PR DESCRIPTION
1)base_local_planner/simple_scored_sampling_planner.cpp:60 ROS_DEBUG prints incorrect gen_id. It skips gen_id++(line 74) whenever `if (score_function_p->getScale() == 0)` is true.
2)The parameter `latch_xy_goal_tolerance` in latched_stop_rotate_controller.cpp was in global namespace. Made corrections to make it `~<name>/latch_xy_goal_tolerance ` according to dwa_local_planner's wiki page.