### PR TITLE
moving clearing area method to costmap_layer so other applications ca…

### DIFF
--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -135,19 +135,7 @@ void ClearCostmapRecovery::clearMap(boost::shared_ptr<costmap_2d::CostmapLayer> 
   costmap->worldToMapNoBounds(start_point_x, start_point_y, start_x, start_y);
   costmap->worldToMapNoBounds(end_point_x, end_point_y, end_x, end_y);
 
-  unsigned char* grid = costmap->getCharMap();
-  for(int x=0; x<(int)costmap->getSizeInCellsX(); x++){
-    bool xrange = x>start_x && x<end_x;
-                   
-    for(int y=0; y<(int)costmap->getSizeInCellsY(); y++){
-      if(xrange && y>start_y && y<end_y)
-        continue;
-      int index = costmap->getIndex(x,y);
-      if(grid[index]!=NO_INFORMATION){
-        grid[index] = NO_INFORMATION;
-      }
-    }
-  }
+  costmap->clearArea(start_x, start_y, end_x, end_y);
 
   double ox = costmap->getOriginX(), oy = costmap->getOriginY();
   double width = costmap->getSizeInMetersX(), height = costmap->getSizeInMetersY();

--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -58,6 +58,8 @@ public:
 
   virtual void matchSize();
 
+  virtual void clearArea(int start_x, int start_y, int end_x, int end_y);
+
   /**
    * If an external source changes values in the costmap,
    * it should call this method with the area that it changed

--- a/costmap_2d/src/costmap_layer.cpp
+++ b/costmap_2d/src/costmap_layer.cpp
@@ -18,6 +18,23 @@ void CostmapLayer::matchSize()
             master->getOriginX(), master->getOriginY());
 }
 
+void CostmapLayer::clearArea(int start_x, int start_y, int end_x, int end_y)
+{
+  unsigned char* grid = getCharMap();
+  for(int x=0; x<(int)getSizeInCellsX(); x++){
+    bool xrange = x>start_x && x<end_x;
+
+    for(int y=0; y<(int)getSizeInCellsY(); y++){
+      if(xrange && y>start_y && y<end_y)
+        continue;
+      int index = getIndex(x,y);
+      if(grid[index]!=NO_INFORMATION){
+        grid[index] = NO_INFORMATION;
+      }
+    }
+  }
+}
+
 void CostmapLayer::addExtraBounds(double mx0, double my0, double mx1, double my1)
 {
     extra_min_x_ = std::min(mx0, extra_min_x_);


### PR DESCRIPTION
…n clear other types.

Essentially: imagine you have a costmap layer that has other data structures storing information than the `costmap_` char pointer. Moving the implementation of clearing an area of the costmap to the costmap itself lets someone override that function and implement the additional requirements to clear the other parts of the state. This is relevant for users of STVL utilizing the default clear costmaps recovery. The bug was reported and trying to get that all squared away before my next release

The API change was made such that it don't effect existing users or costmap_2d or clear costmaps recovery - the default behavior should work the same as before.