### PR TITLE
[melodic] On global_planner, add skip_poses param to optionally skip a number of intermediate poses

### DIFF
--- a/global_planner/cfg/GlobalPlanner.cfg
+++ b/global_planner/cfg/GlobalPlanner.cfg
@@ -8,6 +8,7 @@ gen = ParameterGenerator()
 gen.add("lethal_cost", int_t, 0, "Lethal Cost", 253, 1, 255)
 gen.add("neutral_cost", int_t, 0, "Neutral Cost", 50, 1, 255)
 gen.add("cost_factor", double_t, 0, "Factor to multiply each cost from costmap by", 3.0, 0.01, 5.0)
+gen.add("skip_poses", int_t, 0, "Skip this number of poses when generating the plan", 0, 0, 50)
 gen.add("publish_potential", bool_t, 0, "Publish Potential Costmap", True)
 
 orientation_enum = gen.enum([

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -196,6 +196,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         unsigned char* cost_array_;
         float* potential_array_;
         unsigned int start_x_, start_y_, end_x_, end_y_;
+        unsigned int path_step_;
 
         bool old_navfn_behavior_;
         float convert_offset_;

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -157,6 +157,7 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
 }
 
 void GlobalPlanner::reconfigureCB(global_planner::GlobalPlannerConfig& config, uint32_t level) {
+    path_step_ = config.skip_poses + 1;  // 1 if we want all poses (default behavior)
     planner_->setLethalCost(config.lethal_cost);
     path_maker_->setLethalCost(config.lethal_cost);
     planner_->setNeutralCost(config.neutral_cost);
@@ -361,9 +362,10 @@ bool GlobalPlanner::getPlanFromPotential(double start_x, double start_y, double 
     }
 
     ros::Time plan_time = ros::Time::now();
-    for (int i = path.size() -1; i>=0; i--) {
+    for (int i = path.size() -1; i>=0; i-=path_step_) {
         std::pair<float, float> point = path[i];
-        //convert the plan to world coordinates
+        //convert the plan to world coordinates; we can optionally skip a number of intermediate
+        //poses to make the resulting path less dense (and so lighter and faster to process)
         double world_x, world_y;
         mapToWorld(point.first, point.second, world_x, world_y);
 
@@ -378,9 +380,11 @@ bool GlobalPlanner::getPlanFromPotential(double start_x, double start_y, double 
         pose.pose.orientation.z = 0.0;
         pose.pose.orientation.w = 1.0;
         plan.push_back(pose);
+        if (i > 0 && i < path_step_)
+            i = path_step_;  // ensure we always add the last pose (index 0)
     }
     if(old_navfn_behavior_){
-            plan.push_back(goal);
+        plan.push_back(goal);
     }
     return !plan.empty();
 }


### PR DESCRIPTION
The idea is to make the resulting paths less dense (and so lighter and faster to process)