### PR TITLE
[melodic] On global_planner, do not clear the starting cell in the costmap

### DIFF
--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -176,7 +176,6 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
     private:
         void mapToWorld(double mx, double my, double& wx, double& wy);
         bool worldToMap(double wx, double wy, double& mx, double& my);
-        void clearRobotCell(const geometry_msgs::PoseStamped& global_pose, unsigned int mx, unsigned int my);
         void publishPotential(float* potential);
 
         double planner_window_x_, planner_window_y_, default_tolerance_;

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -166,17 +166,6 @@ void GlobalPlanner::reconfigureCB(global_planner::GlobalPlannerConfig& config, u
     orientation_filter_->setWindowSize(config.orientation_window_size);
 }
 
-void GlobalPlanner::clearRobotCell(const geometry_msgs::PoseStamped& global_pose, unsigned int mx, unsigned int my) {
-    if (!initialized_) {
-        ROS_ERROR(
-                "This planner has not been initialized yet, but it is being used, please call initialize() before use");
-        return;
-    }
-
-    //set the associated costs in the cost map to be free
-    costmap_->setCost(mx, my, costmap_2d::FREE_SPACE);
-}
-
 bool GlobalPlanner::makePlanService(nav_msgs::GetPlan::Request& req, nav_msgs::GetPlan::Response& resp) {
     makePlan(req.start, req.goal, resp.plan.poses);
 
@@ -272,9 +261,6 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     }else{
         worldToMap(wx, wy, goal_x, goal_y);
     }
-
-    //clear the starting cell within the costmap because we know it can't be an obstacle
-    clearRobotCell(start, start_x_i, start_y_i);
 
     int nx = costmap_->getSizeInCellsX(), ny = costmap_->getSizeInCellsY();
 


### PR DESCRIPTION
I wonder what's the reason to do so. Planner seems to work just fine without it.

The reason I need to remove this is because sometimes I call SBPL lattice planner right after global_planner, and it creates paths that go into collision. The reason is that, because of this clearRobotCell method, the robot starts in a zero-cost cell, and SBPL assumes that no action can bring the robot into collision from here (as it assumes the closest obstacle is at at least at inflation_radius m away)