### PR TITLE
[melodic] Add 'do_not_alter_costmap' parameter that forces planner to not change costmap

### DIFF
--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -197,7 +197,10 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         float* potential_array_;
         unsigned int start_x_, start_y_, end_x_, end_y_;
 
+        unsigned char* costmap_char_array_;
+        unsigned int costmap_size_x_, costmap_size_y_;
         bool plan_on_costmap_copy_;
+
         bool old_navfn_behavior_;
         float convert_offset_;
 

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -176,7 +176,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
     private:
         void mapToWorld(double mx, double my, double& wx, double& wy);
         bool worldToMap(double wx, double wy, double& mx, double& my);
-        void clearRobotCell(const geometry_msgs::PoseStamped& global_pose, unsigned int mx, unsigned int my);
+        void clearRobotCell(unsigned char* costarr, unsigned int mx, unsigned int my);
         void publishPotential(float* potential);
 
         double planner_window_x_, planner_window_y_, default_tolerance_;
@@ -197,6 +197,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         float* potential_array_;
         unsigned int start_x_, start_y_, end_x_, end_y_;
 
+        bool do_not_alter_costmap_;
         bool old_navfn_behavior_;
         float convert_offset_;
 

--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -197,7 +197,7 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         float* potential_array_;
         unsigned int start_x_, start_y_, end_x_, end_y_;
 
-        bool do_not_alter_costmap_;
+        bool plan_on_costmap_copy_;
         bool old_navfn_behavior_;
         float convert_offset_;
 

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -99,7 +99,7 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
 
         unsigned int cx = costmap->getSizeInCellsX(), cy = costmap->getSizeInCellsY();
 
-        private_nh.param("do_not_alter_costmap", do_not_alter_costmap_, false);
+        private_nh.param("plan_on_costmap_copy", plan_on_costmap_copy_, false);
         private_nh.param("old_navfn_behavior", old_navfn_behavior_, false);
         if(!old_navfn_behavior_)
             convert_offset_ = 0.5;
@@ -276,7 +276,7 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     int nx = costmap_->getSizeInCellsX(), ny = costmap_->getSizeInCellsY();
 
     unsigned char* costmap_char_array;
-    if(do_not_alter_costmap_){
+    if(plan_on_costmap_copy_){
         //copy costmap's underlying char array so we can freely modify it (we clear robot cell and outline map borders)
         costmap_char_array = new unsigned char[nx * ny];
         memcpy(costmap_char_array, costmap_->getCharMap(), nx * ny);
@@ -324,7 +324,7 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     //publish the plan for visualization purposes
     publishPlan(plan);
     delete potential_array_;
-    if(do_not_alter_costmap_)
+    if(plan_on_costmap_copy_)
         delete costmap_char_array;
     return !plan.empty();
 }

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -99,6 +99,7 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
 
         unsigned int cx = costmap->getSizeInCellsX(), cy = costmap->getSizeInCellsY();
 
+        private_nh.param("do_not_alter_costmap", do_not_alter_costmap_, false);
         private_nh.param("old_navfn_behavior", old_navfn_behavior_, false);
         if(!old_navfn_behavior_)
             convert_offset_ = 0.5;
@@ -166,15 +167,14 @@ void GlobalPlanner::reconfigureCB(global_planner::GlobalPlannerConfig& config, u
     orientation_filter_->setWindowSize(config.orientation_window_size);
 }
 
-void GlobalPlanner::clearRobotCell(const geometry_msgs::PoseStamped& global_pose, unsigned int mx, unsigned int my) {
+void GlobalPlanner::clearRobotCell(unsigned char* costarr, unsigned int mx, unsigned int my) {
     if (!initialized_) {
         ROS_ERROR(
                 "This planner has not been initialized yet, but it is being used, please call initialize() before use");
         return;
     }
-
-    //set the associated costs in the cost map to be free
-    costmap_->setCost(mx, my, costmap_2d::FREE_SPACE);
+    //set the associated costs in the cost array to be free
+    costarr[costmap_->getIndex(mx, my)] = costmap_2d::FREE_SPACE;
 }
 
 bool GlobalPlanner::makePlanService(nav_msgs::GetPlan::Request& req, nav_msgs::GetPlan::Response& resp) {
@@ -273,10 +273,20 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
         worldToMap(wx, wy, goal_x, goal_y);
     }
 
-    //clear the starting cell within the costmap because we know it can't be an obstacle
-    clearRobotCell(start, start_x_i, start_y_i);
-
     int nx = costmap_->getSizeInCellsX(), ny = costmap_->getSizeInCellsY();
+
+    unsigned char* costmap_char_array;
+    if(do_not_alter_costmap_){
+        //copy costmap's underlying char array so we can freely modify it (we clear robot cell and outline map borders)
+        costmap_char_array = new unsigned char[nx * ny];
+        memcpy(costmap_char_array, costmap_->getCharMap(), nx * ny);
+    }else{
+        //default behavior; costmap will be altered after planning is done, until the next update (fine in most cases)
+        costmap_char_array = costmap_->getCharMap();
+    }
+
+    //clear the starting cell within the costmap because we know it can't be an obstacle
+    clearRobotCell(costmap_char_array, start_x_i, start_y_i);
 
     //make sure to resize the underlying array that Navfn uses
     p_calc_->setSize(nx, ny);
@@ -284,13 +294,13 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     path_maker_->setSize(nx, ny);
     potential_array_ = new float[nx * ny];
 
-    outlineMap(costmap_->getCharMap(), nx, ny, costmap_2d::LETHAL_OBSTACLE);
+    outlineMap(costmap_char_array, nx, ny, costmap_2d::LETHAL_OBSTACLE);
 
-    bool found_legal = planner_->calculatePotentials(costmap_->getCharMap(), start_x, start_y, goal_x, goal_y,
+    bool found_legal = planner_->calculatePotentials(costmap_char_array, start_x, start_y, goal_x, goal_y,
                                                     nx * ny * 2, potential_array_);
 
     if(!old_navfn_behavior_)
-        planner_->clearEndpoint(costmap_->getCharMap(), potential_array_, goal_x_i, goal_y_i, 2);
+        planner_->clearEndpoint(costmap_char_array, potential_array_, goal_x_i, goal_y_i, 2);
     if(publish_potential_)
         publishPotential(potential_array_);
 
@@ -314,6 +324,8 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     //publish the plan for visualization purposes
     publishPlan(plan);
     delete potential_array_;
+    if(do_not_alter_costmap_)
+        delete costmap_char_array;
     return !plan.empty();
 }
 


### PR DESCRIPTION
More general version of PR #896, with the requested change of making the change not applicable by default. Instead of just removing the call to _clearRobotCell_, I offer now the option of not altering the costmap at all by copying its underlying char array and working only on it.

Another good thing of this approach is that we can choose (TODO in another PR) to lock the costmap only while copying it, so we allow updates during planning. This is useless on current move_base, but on [move_base_flex](https://github.com/magazino/move_base_flex) it's optional to lock the costmaps, delegating on the plugins to do so. This is a good thing for slow planners like sbpl that only invest a minimal time to copy the costmap at the beginning and then take very long while planning over his copy; on current move_base, all this time the costmap is frozen without any benefit.