### PR TITLE
Restrict max velocity of the robot based on the robot position

### DIFF
--- a/max_velocity_map/CMakeLists.txt
+++ b/max_velocity_map/CMakeLists.txt
@@ -1,0 +1,200 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(max_velocity_map)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  amcl
+  geometry_msgs
+  dynamic_reconfigure
+  roscpp
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES max_velocity_map
+#  CATKIN_DEPENDS dynamic_reconfigure roscpp
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/max_velocity_map.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+add_executable(max_velocity_map_node src/max_velocity_map_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+add_dependencies(max_velocity_map_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(max_velocity_map_node
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_max_velocity_map.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/max_velocity_map/include/max_velocity_map/max_velocity_map.h
+++ b/max_velocity_map/include/max_velocity_map/max_velocity_map.h
@@ -1,0 +1,43 @@
+#include <ros/ros.h>
+#include <amcl/map/map.h>
+#include <std_msgs/Float32.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <nav_msgs/OccupancyGrid.h>
+
+#include <dynamic_reconfigure/DoubleParameter.h>
+#include <dynamic_reconfigure/Reconfigure.h>
+#include <dynamic_reconfigure/Config.h>
+
+class MaxVelocityMap
+{
+  public:
+    MaxVelocityMap();
+    ~MaxVelocityMap();
+
+    private:
+    ros::NodeHandle nh_;
+    ros::Subscriber amcl_sub_;
+    ros::Subscriber map_sub_;
+    ros::Publisher max_vel_x_pub_;
+    ros::Publisher min_vel_x_pub_;
+    ros::Publisher max_vel_y_pub_;
+    ros::Publisher min_vel_y_pub_;
+    map_t* map_;
+    dynamic_reconfigure::ReconfigureRequest srv_req_;
+    dynamic_reconfigure::ReconfigureResponse srv_resp_;
+    dynamic_reconfigure::DoubleParameter double_param_;
+    dynamic_reconfigure::Config conf_;
+    std::string local_planner_;
+    float max_vel_x_initial_;
+    float min_vel_x_initial_;
+    float max_vel_y_initial_;
+    float min_vel_y_initial_;
+    void freeMapDependentMemory();
+    void amclCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg);
+    void mapReceived(const nav_msgs::OccupancyGridConstPtr& msg);
+    void handleMapMessage(const nav_msgs::OccupancyGrid& msg);
+    map_t* convertMap (const nav_msgs::OccupancyGrid& map_msg);
+};
+
+MaxVelocityMap* mvm;
+void reset_params(int sig);

--- a/max_velocity_map/launch/max_velocity_map_sample.launch
+++ b/max_velocity_map/launch/max_velocity_map_sample.launch
@@ -1,0 +1,8 @@
+<launch>
+  <arg name="local_planner" default="/move_base/TrajectoryPlannerROS"/>
+  <!-- limit max velocity based on the current position of the robot-->
+  <node pkg="max_velocity_map" type="max_velocity_map_node" name="max_velocity_map_node" output="screen">
+    <remap from="max_velocity_map" to="map"/>
+    <param name="local_planner" value="$(arg local_planner)"/>
+  </node>
+</launch>

--- a/max_velocity_map/package.xml
+++ b/max_velocity_map/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>max_velocity_map</name>
+  <version>0.0.1</version>
+  <description>The max_velocity_map package</description>
+
+  <maintainer email="708yamaguchi@gmail.com">naoya</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_export_depend>dynamic_reconfigure</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+
+</package>

--- a/max_velocity_map/src/max_velocity_map_node.cpp
+++ b/max_velocity_map/src/max_velocity_map_node.cpp
@@ -1,0 +1,160 @@
+#include <max_velocity_map/max_velocity_map.h>
+#include <algorithm>
+#include <signal.h>
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "max_velocity_map_node");
+  mvm = new MaxVelocityMap();
+  signal(SIGINT, reset_params);  // reset rosparam when Ctrl-C is pressed
+  ros::spin();
+  return(0);
+}
+
+MaxVelocityMap::MaxVelocityMap()
+{
+  // specify local planner
+  ros::param::get("~local_planner", local_planner_);
+  ROS_INFO("%s", local_planner_.c_str());
+  // get rosparam
+  if(nh_.hasParam(local_planner_ + "/max_vel_x")) {
+    nh_.getParam(local_planner_ + "/max_vel_x", max_vel_x_initial_);
+    ROS_INFO("max_vel_x_initial_: %f", max_vel_x_initial_);
+  }
+  if(nh_.hasParam(local_planner_ + "/min_vel_x")) {
+    nh_.getParam(local_planner_ + "/min_vel_x", min_vel_x_initial_);
+    ROS_INFO("min_vel_x_initial_: %f", min_vel_x_initial_);
+  }
+  if(nh_.hasParam(local_planner_ + "/max_vel_y")) {
+    nh_.getParam(local_planner_ + "/max_vel_y", max_vel_y_initial_);
+    ROS_INFO("max_vel_y_initial_: %f", max_vel_y_initial_);
+  }
+  if(nh_.hasParam(local_planner_ + "/min_vel_x")) {
+    nh_.getParam(local_planner_ + "/min_vel_y", min_vel_y_initial_);
+    ROS_INFO("min_vel_y_initial_: %f", min_vel_y_initial_);
+  }
+  // register subscriber and publisher
+  amcl_sub_ = nh_.subscribe("amcl_pose", 100, &MaxVelocityMap::amclCallback, this);
+  map_sub_ = nh_.subscribe("max_velocity_map", 1, &MaxVelocityMap::mapReceived, this);
+  max_vel_x_pub_ = nh_.advertise<std_msgs::Float32>("max_vel_x", 1000);
+  min_vel_x_pub_ = nh_.advertise<std_msgs::Float32>("min_vel_x", 1000);
+  max_vel_y_pub_ = nh_.advertise<std_msgs::Float32>("max_vel_y", 1000);
+  min_vel_y_pub_ = nh_.advertise<std_msgs::Float32>("min_vel_y", 1000);
+}
+
+MaxVelocityMap::~MaxVelocityMap()
+{
+  freeMapDependentMemory();
+  // restore max_vel parameters
+  conf_.doubles.clear();
+  double_param_.name = "max_vel_x";
+  double_param_.value = max_vel_x_initial_;
+  conf_.doubles.push_back(double_param_);
+  double_param_.name = "min_vel_x";
+  double_param_.value = min_vel_x_initial_;
+  conf_.doubles.push_back(double_param_);
+  double_param_.name = "max_vel_y";
+  double_param_.value = max_vel_y_initial_;
+  conf_.doubles.push_back(double_param_);
+  double_param_.name = "min_vel_y";
+  double_param_.value = min_vel_y_initial_;
+  conf_.doubles.push_back(double_param_);
+  srv_req_.config = conf_;
+  ros::service::call(local_planner_ + "/set_parameters", srv_req_, srv_resp_);
+}
+
+void MaxVelocityMap::freeMapDependentMemory()
+{
+  if( map_ != NULL ) {
+    map_free( map_ );
+    map_ = NULL;
+  }
+}
+
+void MaxVelocityMap::amclCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg)
+{
+  float pos_x = msg->pose.pose.position.x;
+  float pos_y = msg->pose.pose.position.y;
+  float pos_z = msg->pose.pose.position.z;
+
+  if( map_ != NULL ) {
+    // get map pixel value of current robot position
+    int index_x = (int)((pos_x - map_->origin_x) / map_->scale);
+    int index_y = (int)((pos_y - map_->origin_y) / map_->scale);
+    // update max_vel parameters
+    float max_vel_ratio = std::max(map_->cells[index_x + index_y * map_->size_x].occ_state / 255.0, 0.2); // avoid too slow movement
+    std_msgs::Float32 msg;
+    // max_vel_x
+    conf_.doubles.clear();
+    double_param_.name = "max_vel_x";
+    double_param_.value = max_vel_x_initial_ * max_vel_ratio;
+    conf_.doubles.push_back(double_param_);
+    msg.data = double_param_.value;
+    max_vel_x_pub_.publish(msg);
+    // min_vel_x
+    double_param_.name = "min_vel_x";
+    double_param_.value = min_vel_x_initial_ * max_vel_ratio;
+    conf_.doubles.push_back(double_param_);
+    msg.data = double_param_.value;
+    min_vel_x_pub_.publish(msg);
+    // max_vel_y
+    double_param_.name = "max_vel_y";
+    double_param_.value = max_vel_y_initial_ * max_vel_ratio;
+    conf_.doubles.push_back(double_param_);
+    msg.data = double_param_.value;
+    max_vel_y_pub_.publish(msg);
+    // min_vel_y
+    double_param_.name = "min_vel_y";
+    double_param_.value = min_vel_y_initial_ * max_vel_ratio;
+    conf_.doubles.push_back(double_param_);
+    msg.data = double_param_.value;
+    min_vel_y_pub_.publish(msg);
+    // call dynamic reconfigure
+    srv_req_.config = conf_;
+    ros::service::call(local_planner_ + "/set_parameters", srv_req_, srv_resp_);
+  }
+}
+
+void MaxVelocityMap::mapReceived(const nav_msgs::OccupancyGridConstPtr& msg)
+{
+  handleMapMessage( *msg );
+}
+
+void MaxVelocityMap::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
+{
+  ROS_INFO("Received a %d X %d map @ %.3f m/pix\n",
+           msg.info.width,
+           msg.info.height,
+           msg.info.resolution);
+
+  freeMapDependentMemory();
+
+  map_ = convertMap(msg);
+}
+
+map_t* MaxVelocityMap::convertMap( const nav_msgs::OccupancyGrid& map_msg )
+{
+  map_t* map = map_alloc();
+  ROS_ASSERT(map);
+
+  map->size_x = map_msg.info.width;
+  map->size_y = map_msg.info.height;
+  map->scale = map_msg.info.resolution;
+  map->origin_x = map_msg.info.origin.position.x;
+  map->origin_y = map_msg.info.origin.position.y;
+  // convert map data
+  map->cells = (map_cell_t*)malloc(sizeof(map_cell_t)*map->size_x*map->size_y);
+  ROS_ASSERT(map->cells);
+  for(int i=0;i<map->size_x * map->size_y;i++)
+  {
+    map->cells[i].occ_state = (unsigned char)map_msg.data[i]; // black: 0, white: 255
+  }
+
+  return map;
+}
+
+void reset_params(int sig)
+{
+  delete mvm; // reset rosparam
+  ros::shutdown();
+}


### PR DESCRIPTION
Overall
=======
This Pull Request enables to restrict robots' max velocity based on the given map.
This function is effective in the places where humans and robots may collide.

Demo
====
Demo is as follows: (The robot slows down in front of the crossroads.)
![max_velocity_map_floor](https://user-images.githubusercontent.com/19769486/61630501-d3e2cd80-acc2-11e9-8402-7112e00efa24.gif)

In the above gif animation, we show max velocity map in the left side. The robot reduces max velocity in the place where map pixel is painted black.
Also, we show current max velocity of the robot (`max_vel_x`) in the pie chart. When the robot goes into the black area, the max velocity reduces.
The line graph means the current speed of the robot (`cmd_vel_x`). You can see the robot's speed is reduced in the black area.

Note
====
In order to use this Pull Request, the max velocity map must be published in the form of `nav_msgs/OccupancyGrid`(This topic can be published by `map_server`), and must be given to `max_velocity_map_node` by remapping the topic name. (Please see the launch file)

You can create your original max velocity map by drawing the black area in the existing map (by some kind of painting tool).
Since `max_velocity_map_node` accepts gray images, gradation is effective to reduce the robot's speed step by step.
