### PR TITLE
Exposing stopped_ variable in costmap2D_ros with the getter function isStopped

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -118,6 +118,14 @@ public:
     }
 
   /**
+   * @brief Is the costmap stopped
+   */
+  bool isStopped()
+    {
+      return stopped_;
+    }
+
+  /**
    * @brief Get the pose of the robot in the global frame of the costmap
    * @param global_pose Will be set to the pose of the robot in the global frame of the costmap
    * @return True if the pose was set successfully, false otherwise

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -120,7 +120,7 @@ public:
   /**
    * @brief Is the costmap stopped
    */
-  bool isStopped()
+  bool isStopped() const
     {
       return stopped_;
     }


### PR DESCRIPTION
Knowing if the costmap is stopped can be of use for different components; for example, costmap converters could synchronously stop their execution, avoiding unnecessary computation.