### PR TITLE
Rotate Recovery Refactor

### DIFF
--- a/rotate_recovery/include/rotate_recovery/rotate_recovery.h
+++ b/rotate_recovery/include/rotate_recovery/rotate_recovery.h
@@ -39,11 +39,7 @@
 #include <nav_core/recovery_behavior.h>
 #include <costmap_2d/costmap_2d_ros.h>
 #include <tf/transform_listener.h>
-#include <ros/ros.h>
 #include <base_local_planner/costmap_model.h>
-#include <geometry_msgs/Twist.h>
-#include <geometry_msgs/Point.h>
-#include <angles/angles.h>
 #include <string>
 
 namespace rotate_recovery
@@ -57,19 +53,18 @@ class RotateRecovery : public nav_core::RecoveryBehavior
 public:
   /**
    * @brief  Constructor, make sure to call initialize in addition to actually initialize the object
-   * @param
-   * @return
    */
   RotateRecovery();
 
   /**
    * @brief  Initialization function for the RotateRecovery recovery behavior
-   * @param tf A pointer to a transform listener
-   * @param global_costmap A pointer to the global_costmap used by the navigation stack
+   * @param name Namespace used in initialization
+   * @param tf (unused)
+   * @param global_costmap (unused)
    * @param local_costmap A pointer to the local_costmap used by the navigation stack
    */
-  void initialize(std::string name, tf::TransformListener* tf,
-                  costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap);
+  void initialize(std::string name, tf::TransformListener*,
+                  costmap_2d::Costmap2DROS*, costmap_2d::Costmap2DROS* local_costmap);
 
   /**
    * @brief  Run the RotateRecovery recovery behavior.
@@ -82,10 +77,7 @@ public:
   ~RotateRecovery();
 
 private:
-  costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
-  costmap_2d::Costmap2D costmap_;
-  std::string name_;
-  tf::TransformListener* tf_;
+  costmap_2d::Costmap2DROS* local_costmap_;
   bool initialized_;
   double sim_granularity_, min_rotational_vel_, max_rotational_vel_, acc_lim_th_, tolerance_, frequency_;
   base_local_planner::CostmapModel* world_model_;

--- a/rotate_recovery/include/rotate_recovery/rotate_recovery.h
+++ b/rotate_recovery/include/rotate_recovery/rotate_recovery.h
@@ -34,8 +34,8 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
-#ifndef ROTATE_RECOVERY_H_
-#define ROTATE_RECOVERY_H_
+#ifndef ROTATE_RECOVERY_ROTATE_RECOVERY_H
+#define ROTATE_RECOVERY_ROTATE_RECOVERY_H
 #include <nav_core/recovery_behavior.h>
 #include <costmap_2d/costmap_2d_ros.h>
 #include <tf/transform_listener.h>
@@ -44,48 +44,51 @@
 #include <geometry_msgs/Twist.h>
 #include <geometry_msgs/Point.h>
 #include <angles/angles.h>
+#include <string>
 
-namespace rotate_recovery{
+namespace rotate_recovery
+{
+/**
+ * @class RotateRecovery
+ * @brief A recovery behavior that rotates the robot in-place to attempt to clear out space
+ */
+class RotateRecovery : public nav_core::RecoveryBehavior
+{
+public:
   /**
-   * @class RotateRecovery
-   * @brief A recovery behavior that rotates the robot in-place to attempt to clear out space
+   * @brief  Constructor, make sure to call initialize in addition to actually initialize the object
+   * @param
+   * @return
    */
-  class RotateRecovery : public nav_core::RecoveryBehavior {
-    public:
-      /**
-       * @brief  Constructor, make sure to call initialize in addition to actually initialize the object
-       * @param
-       * @return
-       */
-      RotateRecovery();
+  RotateRecovery();
 
-      /**
-       * @brief  Initialization function for the RotateRecovery recovery behavior
-       * @param tf A pointer to a transform listener
-       * @param global_costmap A pointer to the global_costmap used by the navigation stack
-       * @param local_costmap A pointer to the local_costmap used by the navigation stack
-       */
-      void initialize(std::string name, tf::TransformListener* tf,
-          costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap);
+  /**
+   * @brief  Initialization function for the RotateRecovery recovery behavior
+   * @param tf A pointer to a transform listener
+   * @param global_costmap A pointer to the global_costmap used by the navigation stack
+   * @param local_costmap A pointer to the local_costmap used by the navigation stack
+   */
+  void initialize(std::string name, tf::TransformListener* tf,
+                  costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap);
 
-      /**
-       * @brief  Run the RotateRecovery recovery behavior.
-       */
-      void runBehavior();
+  /**
+   * @brief  Run the RotateRecovery recovery behavior.
+   */
+  void runBehavior();
 
-      /**
-       * @brief  Destructor for the rotate recovery behavior
-       */
-      ~RotateRecovery();
+  /**
+   * @brief  Destructor for the rotate recovery behavior
+   */
+  ~RotateRecovery();
 
-    private:
-      costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
-      costmap_2d::Costmap2D costmap_;
-      std::string name_;
-      tf::TransformListener* tf_;
-      bool initialized_;
-      double sim_granularity_, min_rotational_vel_, max_rotational_vel_, acc_lim_th_, tolerance_, frequency_;
-      base_local_planner::CostmapModel* world_model_;
-  };
+private:
+  costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
+  costmap_2d::Costmap2D costmap_;
+  std::string name_;
+  tf::TransformListener* tf_;
+  bool initialized_;
+  double sim_granularity_, min_rotational_vel_, max_rotational_vel_, acc_lim_th_, tolerance_, frequency_;
+  base_local_planner::CostmapModel* world_model_;
 };
-#endif
+};  // namespace rotate_recovery
+#endif  // ROTATE_RECOVERY_ROTATE_RECOVERY_H

--- a/rotate_recovery/include/rotate_recovery/rotate_recovery.h
+++ b/rotate_recovery/include/rotate_recovery/rotate_recovery.h
@@ -54,18 +54,18 @@ namespace rotate_recovery{
     public:
       /**
        * @brief  Constructor, make sure to call initialize in addition to actually initialize the object
-       * @param  
-       * @return 
+       * @param
+       * @return
        */
       RotateRecovery();
 
       /**
        * @brief  Initialization function for the RotateRecovery recovery behavior
        * @param tf A pointer to a transform listener
-       * @param global_costmap A pointer to the global_costmap used by the navigation stack 
-       * @param local_costmap A pointer to the local_costmap used by the navigation stack 
+       * @param global_costmap A pointer to the global_costmap used by the navigation stack
+       * @param local_costmap A pointer to the local_costmap used by the navigation stack
        */
-      void initialize(std::string name, tf::TransformListener* tf, 
+      void initialize(std::string name, tf::TransformListener* tf,
           costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap);
 
       /**
@@ -88,4 +88,4 @@ namespace rotate_recovery{
       base_local_planner::CostmapModel* world_model_;
   };
 };
-#endif  
+#endif

--- a/rotate_recovery/src/rotate_recovery.cpp
+++ b/rotate_recovery/src/rotate_recovery.cpp
@@ -41,8 +41,8 @@
 PLUGINLIB_EXPORT_CLASS(rotate_recovery::RotateRecovery, nav_core::RecoveryBehavior)
 
 namespace rotate_recovery {
-RotateRecovery::RotateRecovery(): global_costmap_(NULL), local_costmap_(NULL), 
-  tf_(NULL), initialized_(false), world_model_(NULL) {} 
+RotateRecovery::RotateRecovery(): global_costmap_(NULL), local_costmap_(NULL),
+  tf_(NULL), initialized_(false), world_model_(NULL) {}
 
 void RotateRecovery::initialize(std::string name, tf::TransformListener* tf,
     costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap){

--- a/rotate_recovery/src/rotate_recovery.cpp
+++ b/rotate_recovery/src/rotate_recovery.cpp
@@ -36,6 +36,10 @@
 *********************************************************************/
 #include <rotate_recovery/rotate_recovery.h>
 #include <pluginlib/class_list_macros.h>
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Point.h>
+#include <angles/angles.h>
 #include <algorithm>
 #include <string>
 
@@ -45,21 +49,19 @@ PLUGINLIB_EXPORT_CLASS(rotate_recovery::RotateRecovery, nav_core::RecoveryBehavi
 
 namespace rotate_recovery
 {
-RotateRecovery::RotateRecovery(): global_costmap_(NULL), local_costmap_(NULL),
-  tf_(NULL), initialized_(false), world_model_(NULL) {}
+RotateRecovery::RotateRecovery(): local_costmap_(NULL), initialized_(false), world_model_(NULL)
+{
+}
 
-void RotateRecovery::initialize(std::string name, tf::TransformListener* tf,
-                                costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap)
+void RotateRecovery::initialize(std::string name, tf::TransformListener*,
+                                costmap_2d::Costmap2DROS*, costmap_2d::Costmap2DROS* local_costmap)
 {
   if (!initialized_)
   {
-    name_ = name;
-    tf_ = tf;
-    global_costmap_ = global_costmap;
     local_costmap_ = local_costmap;
 
     // get some parameters from the parameter server
-    ros::NodeHandle private_nh("~/" + name_);
+    ros::NodeHandle private_nh("~/" + name);
     ros::NodeHandle blp_nh("~/TrajectoryPlannerROS");
 
     // we'll simulate every degree by default
@@ -94,9 +96,9 @@ void RotateRecovery::runBehavior()
     return;
   }
 
-  if (global_costmap_ == NULL || local_costmap_ == NULL)
+  if (local_costmap_ == NULL)
   {
-    ROS_ERROR("The costmaps passed to the RotateRecovery object cannot be NULL. Doing nothing.");
+    ROS_ERROR("The costmap passed to the RotateRecovery object cannot be NULL. Doing nothing.");
     return;
   }
   ROS_WARN("Rotate recovery behavior started.");


### PR DESCRIPTION
While looking at #826, I got upset at how convoluted the logic was for the rotate recovery. Too many negative angles and odd calculations. I think this version is much clearer. 

I also took the opportunity to clean things up. 
 * The [first](https://github.com/ros-planning/navigation/commit/af850c4e4711c2457c4522eac2a6b46130f3e095) two [commits](https://github.com/ros-planning/navigation/commit/e405a0cf8264d46cc2eb1659786f189b1d9bdc49) are just white space cleanup and linting. 
 * The [third commit](https://github.com/ros-planning/navigation/commit/b59ce8d1caaa629deafc8174ad836ab57e9402bb) removes unused components.
 * The [fourth commit](https://github.com/ros-planning/navigation/commit/4d28dab896871d2cc6df8c1ce45cee2b3954ad90) is the big one that changes the calculations to be clearer. 

@ebimor Can you check that this fixes your use case?