### PR TITLE
[kinetic] [AMCL] Feature: Selective Resampling

### DIFF
--- a/amcl/include/amcl/pf/pf.h
+++ b/amcl/include/amcl/pf/pf.h
@@ -104,6 +104,7 @@ typedef struct _pf_sample_set_t
   pf_vector_t mean;
   pf_matrix_t cov;
   int converged; 
+  double n_effective;
 } pf_sample_set_t;
 
 
@@ -133,6 +134,9 @@ typedef struct _pf_t
 
   double dist_threshold; //distance threshold in each axis over which the pf is considered to not be converged
   int converged; 
+
+  // boolean parameter to enamble/diable selective resampling
+  int selective_resampling;
 } pf_t;
 
 
@@ -158,6 +162,9 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
 
 // Resample the distribution
 void pf_update_resample(pf_t *pf);
+
+// set selective resampling parameter
+void pf_set_selective_resampling(pf_t *pf, int selective_resampling);
 
 // Compute the CEP statistics (mean and variance).
 void pf_get_cep_stats(pf_t *pf, pf_vector_t *mean, double *var);
@@ -189,6 +196,8 @@ int pf_update_converged(pf_t *pf);
 
 //sets the current set and pf converged values to zero
 void pf_init_converged(pf_t *pf);
+
+void pf_copy_set(pf_sample_set_t* set_a, pf_sample_set_t* set_b);
 
 #ifdef __cplusplus
 }

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -270,6 +270,8 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
 
   // Compute the sample weights
   total = (*sensor_fn) (sensor_data, set);
+
+  set->n_effective = 0;
   
   if (total > 0.0)
   {
@@ -280,6 +282,7 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
       sample = set->samples + i;
       w_avg += sample->weight;
       sample->weight /= total;
+      set->n_effective += sample->weight*sample->weight;
     }
     // Update running averages of likelihood of samples (Prob Rob p258)
     w_avg /= set->sample_count;
@@ -304,9 +307,51 @@ void pf_update_sensor(pf_t *pf, pf_sensor_model_fn_t sensor_fn, void *sensor_dat
     }
   }
 
+  set->n_effective = 1.0/set->n_effective;
   return;
 }
 
+// copy set a to set b
+void copy_set(pf_sample_set_t* set_a, pf_sample_set_t* set_b)
+{
+  int i;
+  double total;
+  pf_sample_t *sample_a, *sample_b;
+
+  // Clean set b's kdtree
+  pf_kdtree_clear(set_b->kdtree);
+
+  // Copy samples from set a to create set b
+  total = 0;
+  set_b->sample_count = 0;
+
+  for(i = 0; i < set_a->sample_count; i++)
+  {
+    sample_b = set_b->samples + set_b->sample_count++;
+
+    sample_a = set_a->samples + i;
+
+    assert(sample_a->weight > 0);
+
+    // Copy sample a to sample b
+    sample_b->pose = sample_a->pose;
+    sample_b->weight = sample_a->weight;
+
+    total += sample_b->weight;
+
+    // Add sample to histogram
+    pf_kdtree_insert(set_b->kdtree, sample_b->pose, sample_b->weight);
+  }
+
+  // Normalize weights
+  for (i = 0; i < set_b->sample_count; i++)
+  {
+    sample_b = set_b->samples + i;
+    sample_b->weight /= total;
+  }
+
+  set_b->converged = set_a->converged;
+}
 
 // Resample the distribution
 void pf_update_resample(pf_t *pf)
@@ -325,6 +370,22 @@ void pf_update_resample(pf_t *pf)
 
   set_a = pf->sets + pf->current_set;
   set_b = pf->sets + (pf->current_set + 1) % 2;
+
+  if (pf->selective_resampling != 0)
+  {
+    if (set_a->n_effective > 0.5*(set_a->sample_count))
+    {
+      // copy set a to b
+      copy_set(set_a,set_b);
+
+      // Re-compute cluster statistics
+      pf_cluster_stats(pf, set_b);
+
+      // Use the newly created sample set
+      pf->current_set = (pf->current_set + 1) % 2;
+      return;
+    }
+  }
 
   // Build up cumulative probability table for resampling.
   // TODO: Replace this with a more efficient procedure
@@ -600,6 +661,10 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
   return;
 }
 
+void pf_set_selective_resampling(pf_t *pf, int selective_resampling)
+{
+  pf->selective_resampling = selective_resampling;
+}
 
 // Compute the CEP statistics (mean and variance).
 void pf_get_cep_stats(pf_t *pf, pf_vector_t *mean, double *var)

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -261,6 +261,7 @@ class AmclNode
     double init_cov_[3];
     laser_model_t laser_model_type_;
     bool tf_broadcast_;
+    bool selective_resampling_;
 
     void reconfigureCB(amcl::AMCLConfig &config, uint32_t level);
 
@@ -406,6 +407,7 @@ AmclNode::AmclNode() :
   private_nh_.param("base_frame_id", base_frame_id_, std::string("base_link"));
   private_nh_.param("global_frame_id", global_frame_id_, std::string("map"));
   private_nh_.param("resample_interval", resample_interval_, 2);
+  private_nh_.param("selective_resampling", selective_resampling_, false);
   double tmp_tol;
   private_nh_.param("transform_tolerance", tmp_tol, 0.1);
   private_nh_.param("recovery_alpha_slow", alpha_slow_, 0.001);
@@ -545,6 +547,7 @@ void AmclNode::reconfigureCB(AMCLConfig &config, uint32_t level)
                  alpha_slow_, alpha_fast_,
                  (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
                  (void *)map_);
+  pf_set_selective_resampling(pf_, selective_resampling_);
   pf_err_ = config.kld_err; 
   pf_z_ = config.kld_z; 
   pf_->pop_err = pf_err_;
@@ -837,6 +840,7 @@ AmclNode::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
                  alpha_slow_, alpha_fast_,
                  (pf_init_model_fn_t)AmclNode::uniformPoseGenerator,
                  (void *)map_);
+  pf_set_selective_resampling(pf_, selective_resampling_);
   pf_->pop_err = pf_err_;
   pf_->pop_z = pf_z_;
 


### PR DESCRIPTION
- Implement selective resampling as described in:

> Grisetti, Giorgio, Cyrill Stachniss, and Wolfram Burgard. "Improved techniques for grid mapping with rao-blackwellized particle filters." IEEE transactions on Robotics 23.1 (2007): 34.

- The main advantage is reducing the resampling rate when not needed and help avoid particle deprivation.

- Compute `n_effective` for current set as `N_eff = 1/(sum(k_i^2))`.
When `n_effective` falls below `N/2` (`N` being the current number of samples), continue to resampling. Otherwise, copy current set to the other set and skip the resampling (switching the set is needed, otherwise the cluster KD tree is not defined properly and it is not possible to compute the clusters' stats)

- When resampling is skipped, recompute cluster stats using `pf_cluster_stats()` in order to still have a result. The result is consistent, as all the samples are propagated using the motion model.

- Additional parameter to enable/disable selective resampling: `selective_resampling` (default: false)