### PR TITLE
[Kinetic] Fix costmap became wrong when map size is changed

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -169,13 +169,12 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
 
   // resize costmap if size, resolution or origin do not match
   Costmap2D* master = layered_costmap_->getCostmap();
-  if (!layered_costmap_->isRolling() &&
-      !layered_costmap_->isSizeLocked() &&
-      (master->getSizeInCellsX() != size_x ||
-       master->getSizeInCellsY() != size_y ||
-       master->getResolution() != new_map->info.resolution ||
-       master->getOriginX() != new_map->info.origin.position.x ||
-       master->getOriginY() != new_map->info.origin.position.y))
+  if (!layered_costmap_->isRolling() && (master->getSizeInCellsX() != size_x ||
+      master->getSizeInCellsY() != size_y ||
+      master->getResolution() != new_map->info.resolution ||
+      master->getOriginX() != new_map->info.origin.position.x ||
+      master->getOriginY() != new_map->info.origin.position.y ||
+      !layered_costmap_->isSizeLocked()))
   {
     // Update the size of the layered costmap (and all layers, including this one)
     ROS_INFO("Resizing costmap to %d X %d at %f m/pix", size_x, size_y, new_map->info.resolution);


### PR DESCRIPTION
Fix costmap became wrong when map size is changed. As described in issue #924