### PR TITLE
parameter for enabling outlineMap added

### DIFF
--- a/global_planner/include/global_planner/planner_core.h
+++ b/global_planner/include/global_planner/planner_core.h
@@ -200,6 +200,8 @@ class GlobalPlanner : public nav_core::BaseGlobalPlanner {
         bool old_navfn_behavior_;
         float convert_offset_;
 
+        bool outline_map_;
+
         dynamic_reconfigure::Server<global_planner::GlobalPlannerConfig> *dsrv_;
         void reconfigureCB(global_planner::GlobalPlannerConfig &config, uint32_t level);
 

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -142,6 +142,7 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
         private_nh.param("planner_window_y", planner_window_y_, 0.0);
         private_nh.param("default_tolerance", default_tolerance_, 0.0);
         private_nh.param("publish_scale", publish_scale_, 100);
+        private_nh.param("outline_map", outline_map_, true);
 
         make_plan_srv_ = private_nh.advertiseService("make_plan", &GlobalPlanner::makePlanService, this);
 
@@ -284,7 +285,8 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
     path_maker_->setSize(nx, ny);
     potential_array_ = new float[nx * ny];
 
-    outlineMap(costmap_->getCharMap(), nx, ny, costmap_2d::LETHAL_OBSTACLE);
+    if(outline_map_)
+        outlineMap(costmap_->getCharMap(), nx, ny, costmap_2d::LETHAL_OBSTACLE);
 
     bool found_legal = planner_->calculatePotentials(costmap_->getCharMap(), start_x, start_y, goal_x, goal_y,
                                                     nx * ny * 2, potential_array_);


### PR DESCRIPTION
Added a parameter for enabling/disabling `outlineMap`. As addressed in issue #907 and a ROS [question](https://answers.ros.org/question/334103/why-are-obstacles-added-at-the-edges-of-the-global-costmap-when-globalplanner-is-used/), `outlineMap` outlines the entire map with lethal obstacles. This was creating obstacles when used with `rolling_window=true`. When disabled, obstacles are not created any more. Tested it with both `jackal_navigation` and `husky_navigation` (ROS melodic, Ubuntu 18.04).