### PR TITLE
[clear_costmap_recovery] add param invert_area_to_clear

### DIFF
--- a/clear_costmap_recovery/include/clear_costmap_recovery/clear_costmap_recovery.h
+++ b/clear_costmap_recovery/include/clear_costmap_recovery/clear_costmap_recovery.h
@@ -80,6 +80,7 @@ namespace clear_costmap_recovery{
       bool initialized_;
       bool force_updating_; ///< force costmap update after clearing, so we don't need to wait for update thread
       double reset_distance_;
+      bool invert_area_to_clear_;
       std::string affected_maps_; ///< clear only local, global or both costmaps
       std::set<std::string> clearable_layers_; ///< Layer names which will be cleared.
   };

--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -59,6 +59,7 @@ void ClearCostmapRecovery::initialize(std::string name, tf2_ros::Buffer* tf,
     ros::NodeHandle private_nh("~/" + name_);
 
     private_nh.param("reset_distance", reset_distance_, 3.0);
+    private_nh.param("invert_area_to_clear", invert_area_to_clear_, false);
     private_nh.param("force_updating", force_updating_, false);
     private_nh.param("affected_maps", affected_maps_, std::string("both"));
     if (affected_maps_ != "local" && affected_maps_ != "global" && affected_maps_ != "both")
@@ -95,8 +96,13 @@ void ClearCostmapRecovery::runBehavior(){
     return;
   }
 
-  ROS_WARN("Clearing %s costmap%s to unstuck robot (%.2fm).", affected_maps_.c_str(),
+  if (!invert_area_to_clear_){
+    ROS_WARN("Clearing %s costmap%s outside a square (%.2fm) large centered on the robot.", affected_maps_.c_str(),
            affected_maps_ == "both" ? "s" : "", reset_distance_);
+  }else {
+    ROS_WARN("Clearing %s costmap%s inside a square (%.2fm) large centered on the robot.", affected_maps_.c_str(),
+           affected_maps_ == "both" ? "s" : "", reset_distance_);
+  }
 
   ros::WallTime t0 = ros::WallTime::now();
   if (affected_maps_ == "global" || affected_maps_ == "both")
@@ -169,7 +175,7 @@ void ClearCostmapRecovery::clearMap(boost::shared_ptr<costmap_2d::CostmapLayer> 
     bool xrange = x>start_x && x<end_x;
 
     for(int y=0; y<(int)costmap->getSizeInCellsY(); y++){
-      if(xrange && y>start_y && y<end_y)
+      if((xrange && y>start_y && y<end_y)!=invert_area_to_clear_)
         continue;
       int index = costmap->getIndex(x,y);
       if(grid[index]!=NO_INFORMATION){


### PR DESCRIPTION
I wanted the possibility to clear obstacles up to a specific distance from the robot, and not from a specific distance until the infinity. In other word to invert the area to clear in the costmap.
I also clarified what is going on through the warning message and the fact that the area cleared is squared based and not circle based as specified in the wiki : "by reverting to the static map outside of a given radius away from the robot"