### PR TITLE
Capped the costs to 255 so that no UInt8 Overflow occurs

### DIFF
--- a/global_planner/include/global_planner/astar.h
+++ b/global_planner/include/global_planner/astar.h
@@ -68,6 +68,7 @@ class AStarExpansion : public Expander {
     private:
         void add(unsigned char* costs, float* potential, float prev_potential, int next_i, int end_x, int end_y);
         std::vector<Index> queue_;
+        uint8_t combined_cost_; 
 };
 
 } //end namespace global_planner

--- a/global_planner/src/astar.cpp
+++ b/global_planner/src/astar.cpp
@@ -86,8 +86,11 @@ void AStarExpansion::add(unsigned char* costs, float* potential, float prev_pote
 
     if(costs[next_i]>=lethal_cost_ && !(unknown_ && costs[next_i]==costmap_2d::NO_INFORMATION))
         return;
-
-    potential[next_i] = p_calc_->calculatePotential(potential, costs[next_i] + neutral_cost_, next_i, prev_potential);
+    if((costs[next_i] + neutral_cost_) > 255)
+        combined_cost_ = 255;
+    else
+        combined_cost_ = costs[next_i] + neutral_cost_;
+    potential[next_i] = p_calc_->calculatePotential(potential, combined_cost_, next_i, prev_potential);
     int x = next_i % nx_, y = next_i / nx_;
     float distance = abs(end_x - x) + abs(end_y - y);
 


### PR DESCRIPTION
This pull request fixes the Issue #784 . Added an additional variable of `uint8_t` which caps the cost to 255 to prevent any numeric overflow, 