### PR TITLE
Fixes gdist- and pdist_scale node paramter names

### DIFF
--- a/base_local_planner/cfg/BaseLocalPlanner.cfg
+++ b/base_local_planner/cfg/BaseLocalPlanner.cfg
@@ -26,8 +26,8 @@ gen.add("sim_time", double_t, 0, "The amount of time to roll trajectories out fo
 gen.add("sim_granularity", double_t, 0, "The granularity with which to check for collisions along each trajectory in meters", 0.025, 0, 5)
 gen.add("angular_sim_granularity", double_t, 0, "The distance between simulation points for angular velocity should be small enough that the robot doesn't hit things", 0.025, 0, pi/2)
 
-gen.add("pdist_scale", double_t, 0, "The weight for the path distance part of the cost function", 0.6, 0, 5)
-gen.add("gdist_scale", double_t, 0, "The weight for the goal distance part of the cost function", 0.8, 0, 5)
+gen.add("path_distance_bias", double_t, 0, "The weight for the path distance part of the cost function", 0.6, 0, 5)
+gen.add("goal_distance_bias", double_t, 0, "The weight for the goal distance part of the cost function", 0.8, 0, 5)
 gen.add("occdist_scale", double_t, 0, "The weight for the obstacle distance part of the cost function", 0.01, 0, 5)
 
 gen.add("oscillation_reset_dist", double_t, 0, "The distance the robot must travel before oscillation flags are reset, in meters", 0.05, 0, 5)

--- a/base_local_planner/include/base_local_planner/trajectory_planner.h
+++ b/base_local_planner/include/base_local_planner/trajectory_planner.h
@@ -80,8 +80,8 @@ namespace base_local_planner {
        * @param sim_granularity The distance between simulation points should be small enough that the robot doesn't hit things
        * @param vx_samples The number of trajectories to sample in the x dimension
        * @param vtheta_samples The number of trajectories to sample in the theta dimension
-       * @param pdist_scale A scaling factor for how close the robot should stay to the path
-       * @param gdist_scale A scaling factor for how aggresively the robot should pursue a local goal
+       * @param path_distance_bias A scaling factor for how close the robot should stay to the path
+       * @param goal_distance_bias A scaling factor for how aggresively the robot should pursue a local goal
        * @param occdist_scale A scaling factor for how much the robot should prefer to stay away from obstacles
        * @param heading_lookahead How far the robot should look ahead of itself when differentiating between different rotational velocities
        * @param oscillation_reset_dist The distance the robot must travel before it can explore rotational velocities that were unsuccessful in the past
@@ -108,7 +108,7 @@ namespace base_local_planner {
           double acc_lim_x = 1.0, double acc_lim_y = 1.0, double acc_lim_theta = 1.0,
           double sim_time = 1.0, double sim_granularity = 0.025, 
           int vx_samples = 20, int vtheta_samples = 20,
-          double pdist_scale = 0.6, double gdist_scale = 0.8, double occdist_scale = 0.2,
+          double path_distance_bias = 0.6, double goal_distance_bias = 0.8, double occdist_scale = 0.2,
           double heading_lookahead = 0.325, double oscillation_reset_dist = 0.05, 
           double escape_reset_dist = 0.10, double escape_reset_theta = M_PI_2,
           bool holonomic_robot = true,
@@ -286,7 +286,7 @@ namespace base_local_planner {
       int vx_samples_; ///< @brief The number of samples we'll take in the x dimenstion of the control space
       int vtheta_samples_; ///< @brief The number of samples we'll take in the theta dimension of the control space
 
-      double pdist_scale_, gdist_scale_, occdist_scale_; ///< @brief Scaling factors for the controller's cost function
+      double path_distance_bias_, goal_distance_bias_, occdist_scale_; ///< @brief Scaling factors for the controller's cost function
       double acc_lim_x_, acc_lim_y_, acc_lim_theta_; ///< @brief The acceleration limits of the robot
 
       double prev_x_, prev_y_; ///< @brief Used to calculate the distance the robot has traveled before reseting oscillation booleans

--- a/base_local_planner/src/trajectory_planner.cpp
+++ b/base_local_planner/src/trajectory_planner.cpp
@@ -79,15 +79,15 @@ namespace base_local_planner{
       sim_granularity_ = config.sim_granularity;
       angular_sim_granularity_ = config.angular_sim_granularity;
 
-      pdist_scale_ = config.pdist_scale;
-      gdist_scale_ = config.gdist_scale;
+      path_distance_bias_ = config.path_distance_bias;
+      goal_distance_bias_ = config.goal_distance_bias;
       occdist_scale_ = config.occdist_scale;
 
       if (meter_scoring_) {
         //if we use meter scoring, then we want to multiply the biases by the resolution of the costmap
         double resolution = costmap_.getResolution();
-        gdist_scale_ *= resolution;
-        pdist_scale_ *= resolution;
+        goal_distance_bias_ *= resolution;
+        path_distance_bias_ *= resolution;
       }
 
       oscillation_reset_dist_ = config.oscillation_reset_dist;
@@ -145,7 +145,7 @@ namespace base_local_planner{
       double acc_lim_x, double acc_lim_y, double acc_lim_theta,
       double sim_time, double sim_granularity,
       int vx_samples, int vtheta_samples,
-      double pdist_scale, double gdist_scale, double occdist_scale,
+      double path_distance_bias, double goal_distance_bias, double occdist_scale,
       double heading_lookahead, double oscillation_reset_dist,
       double escape_reset_dist, double escape_reset_theta,
       bool holonomic_robot,
@@ -160,7 +160,7 @@ namespace base_local_planner{
     world_model_(world_model), footprint_spec_(footprint_spec),
     sim_time_(sim_time), sim_granularity_(sim_granularity), angular_sim_granularity_(angular_sim_granularity),
     vx_samples_(vx_samples), vtheta_samples_(vtheta_samples),
-    pdist_scale_(pdist_scale), gdist_scale_(gdist_scale), occdist_scale_(occdist_scale),
+    path_distance_bias_(path_distance_bias), goal_distance_bias_(goal_distance_bias), occdist_scale_(occdist_scale),
     acc_lim_x_(acc_lim_x), acc_lim_y_(acc_lim_y), acc_lim_theta_(acc_lim_theta),
     prev_x_(0), prev_y_(0), escape_x_(0), escape_y_(0), escape_theta_(0), heading_lookahead_(heading_lookahead),
     oscillation_reset_dist_(oscillation_reset_dist), escape_reset_dist_(escape_reset_dist),
@@ -204,7 +204,7 @@ namespace base_local_planner{
     }
     path_cost = cell.target_dist;
     goal_cost = goal_cell.target_dist;
-    total_cost = pdist_scale_ * path_cost + gdist_scale_ * goal_cost + occdist_scale_ * occ_cost;
+    total_cost = path_distance_bias_ * path_cost + goal_distance_bias_ * goal_cost + occdist_scale_ * occ_cost;
     return true;
   }
 
@@ -362,9 +362,9 @@ namespace base_local_planner{
     //ROS_INFO("OccCost: %f, vx: %.2f, vy: %.2f, vtheta: %.2f", occ_cost, vx_samp, vy_samp, vtheta_samp);
     double cost = -1.0;
     if (!heading_scoring_) {
-      cost = pdist_scale_ * path_dist + goal_dist * gdist_scale_ + occdist_scale_ * occ_cost;
+      cost = path_distance_bias_ * path_dist + goal_dist * goal_distance_bias_ + occdist_scale_ * occ_cost;
     } else {
-      cost = occdist_scale_ * occ_cost + pdist_scale_ * path_dist + 0.3 * heading_diff + goal_dist * gdist_scale_;
+      cost = occdist_scale_ * occ_cost + path_distance_bias_ * path_dist + 0.3 * heading_diff + goal_dist * goal_distance_bias_;
     }
     traj.cost_ = cost;
   }

--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -102,7 +102,7 @@ namespace base_local_planner {
       trans_stopped_velocity_ = 1e-2;
       double sim_time, sim_granularity, angular_sim_granularity;
       int vx_samples, vtheta_samples;
-      double pdist_scale, gdist_scale, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta;
+      double path_distance_bias, goal_distance_bias, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta;
       bool holonomic_robot, dwa, simple_attractor, heading_scoring;
       double heading_scoring_timestep;
       double max_vel_x, min_vel_x;
@@ -166,8 +166,25 @@ namespace base_local_planner {
       private_nh.param("vx_samples", vx_samples, 3);
       private_nh.param("vtheta_samples", vtheta_samples, 20);
 
-      private_nh.param("path_distance_bias", pdist_scale, 0.6);
-      private_nh.param("goal_distance_bias", gdist_scale, 0.8);
+      path_distance_bias = nav_core::loadParameterWithDeprecation(private_nh,
+                                                                  "path_distance_bias",
+                                                                  "pdist_scale",
+                                                                  0.6);
+      goal_distance_bias = nav_core::loadParameterWithDeprecation(private_nh,
+                                                                  "goal_distance_bias",
+                                                                  "gdist_scale",
+                                                                  0.6);
+      // values of the deprecated params need to be applied to the current params, as defaults 
+      // of defined for dynamic reconfigure will override them otherwise.
+      if (private_nh.hasParam("pdist_scale"))
+      {
+        private_nh.setParam("path_distance_bias", path_distance_bias);
+      }
+      if (private_nh.hasParam("gdist_scale"))
+      {
+        private_nh.setParam("goal_distance_bias", goal_distance_bias);
+      }
+
       private_nh.param("occdist_scale", occdist_scale, 0.01);
 
       bool meter_scoring;
@@ -179,8 +196,8 @@ namespace base_local_planner {
         if(meter_scoring) {
           //if we use meter scoring, then we want to multiply the biases by the resolution of the costmap
           double resolution = costmap_->getResolution();
-          gdist_scale *= resolution;
-          pdist_scale *= resolution;
+          goal_distance_bias *= resolution;
+          path_distance_bias *= resolution;
           occdist_scale *= resolution;
         } else {
           ROS_WARN("Trajectory Rollout planner initialized with param meter_scoring set to false. Set it to true to make your settings robust against changes of costmap resolution.");
@@ -235,8 +252,8 @@ namespace base_local_planner {
       footprint_spec_ = costmap_ros_->getRobotFootprint();
 
       tc_ = new TrajectoryPlanner(*world_model_, *costmap_, footprint_spec_,
-          acc_lim_x_, acc_lim_y_, acc_lim_theta_, sim_time, sim_granularity, vx_samples, vtheta_samples, pdist_scale,
-          gdist_scale, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta, holonomic_robot,
+          acc_lim_x_, acc_lim_y_, acc_lim_theta_, sim_time, sim_granularity, vx_samples, vtheta_samples, path_distance_bias,
+          goal_distance_bias, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta, holonomic_robot,
           max_vel_x, min_vel_x, max_vel_th_, min_vel_th_, min_in_place_vel_th_, backup_vel,
           dwa, heading_scoring, heading_scoring_timestep, meter_scoring, simple_attractor, y_vels, stop_time_buffer, sim_period_, angular_sim_granularity);
 

--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -176,11 +176,11 @@ namespace base_local_planner {
                                                                   0.6);
       // values of the deprecated params need to be applied to the current params, as defaults 
       // of defined for dynamic reconfigure will override them otherwise.
-      if (private_nh.hasParam("pdist_scale"))
+      if (private_nh.hasParam("pdist_scale") & !private_nh.hasParam("path_distance_bias"))
       {
         private_nh.setParam("path_distance_bias", path_distance_bias);
       }
-      if (private_nh.hasParam("gdist_scale"))
+      if (private_nh.hasParam("gdist_scale") & !private_nh.hasParam("goal_distance_bias"))
       {
         private_nh.setParam("goal_distance_bias", goal_distance_bias);
       }

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -149,7 +149,7 @@ namespace dwa_local_planner {
       base_local_planner::LocalPlannerUtil *planner_util_;
 
       double stop_time_buffer_; ///< @brief How long before hitting something we're going to enforce that the robot stop
-      double pdist_scale_, gdist_scale_, occdist_scale_;
+      double path_distance_bias_, goal_distance_bias_, occdist_scale_;
       Eigen::Vector3f vsamples_;
 
       double sim_period_;///< @brief The number of seconds to use to compute max/min vels for dwa

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -62,14 +62,14 @@ namespace dwa_local_planner {
         sim_period_);
 
     double resolution = planner_util_->getCostmap()->getResolution();
-    pdist_scale_ = resolution * config.path_distance_bias;
+    path_distance_bias_ = resolution * config.path_distance_bias;
     // pdistscale used for both path and alignment, set  forward_point_distance to zero to discard alignment
-    path_costs_.setScale(pdist_scale_);
-    alignment_costs_.setScale(pdist_scale_);
+    path_costs_.setScale(path_distance_bias_);
+    alignment_costs_.setScale(path_distance_bias_);
 
-    gdist_scale_ = resolution * config.goal_distance_bias;
-    goal_costs_.setScale(gdist_scale_);
-    goal_front_costs_.setScale(gdist_scale_);
+    goal_distance_bias_ = resolution * config.goal_distance_bias;
+    goal_costs_.setScale(goal_distance_bias_);
+    goal_front_costs_.setScale(goal_distance_bias_);
 
     occdist_scale_ = config.occdist_scale;
     obstacle_costs_.setScale(occdist_scale_);
@@ -194,8 +194,8 @@ namespace dwa_local_planner {
     }
 
     total_cost =
-        pdist_scale_ * path_cost +
-        gdist_scale_ * goal_cost +
+        path_distance_bias_ * path_cost +
+        goal_distance_bias_ * goal_cost +
         occdist_scale_ * occ_cost;
     return true;
   }
@@ -277,7 +277,7 @@ namespace dwa_local_planner {
     
     // keeping the nose on the path
     if (sq_dist > forward_point_distance_ * forward_point_distance_ * cheat_factor_) {
-      alignment_costs_.setScale(pdist_scale_);
+      alignment_costs_.setScale(path_distance_bias_);
       // costs for robot being aligned with path (nose on path, not ju
       alignment_costs_.setTargetPoses(global_plan_);
     } else {


### PR DESCRIPTION
Fixes #935. The parameter names are simply changed to fit those defined in the cfg files of BaseLocalPlanner.