### PR TITLE
amcl: include missing CMake functions to fix build

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(amcl)
 
+include(CheckIncludeFile)
+include(CheckSymbolExists)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()


### PR DESCRIPTION
#849 broke `amcl` for me, causing the following error:
```
CMake Error at CMakeLists.txt:53 (check_include_file):
  Unknown CMake command "check_include_file".
```
`check_include_file()` and `check_symbol_exists()` need to be included using `include(CheckIncludeFile)` and `include(CheckSymbolExists)`, respectively.

I'm not sure how this worked correctly for @seanyen and the CI passed.