### PR TITLE
fix published footprint topic name

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -155,7 +155,7 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
   }
 
   private_nh.param(topic_param, topic, std::string("oriented_footprint"));
-  footprint_pub_ = private_nh.advertise<geometry_msgs::PolygonStamped>("footprint", 1);
+  footprint_pub_ = private_nh.advertise<geometry_msgs::PolygonStamped>(topic, 1);
 
   setUnpaddedRobotFootprint(makeFootprintFromParams(private_nh));
 

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -154,7 +154,7 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
     topic_param = "published_footprint";
   }
 
-  private_nh.param(topic_param, topic, std::string("oriented_footprint"));
+  private_nh.param(topic_param, topic, std::string("footprint"));  // TODO: revert to oriented_footprint in N-turtle
   footprint_pub_ = private_nh.advertise<geometry_msgs::PolygonStamped>(topic, 1);
 
   setUnpaddedRobotFootprint(makeFootprintFromParams(private_nh));


### PR DESCRIPTION
It is assumed that the topic name used for publishing current footprint is customizable by getting the name from rosparam, but the value is not used and instead fixed name 'footprint' is used.
This PR fixes to be used the name set using rosparam.

The issue also occurs mixture of topic type between `geometry_msgs/Polygon` and `geometry_msgs/PolygonStamped`.  
The related issue: https://github.com/ros-planning/navigation/issues/885