### PR TITLE
Use const for getter methods

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -112,7 +112,7 @@ public:
   void resetLayers();
 
   /** @brief Same as getLayeredCostmap()->isCurrent(). */
-  bool isCurrent()
+  bool isCurrent() const
     {
       return layered_costmap_->isCurrent();
     }
@@ -139,7 +139,7 @@ public:
   /** @brief Return a pointer to the "master" costmap which receives updates from all the layers.
    *
    * Same as calling getLayeredCostmap()->getCostmap(). */
-  Costmap2D* getCostmap()
+  Costmap2D* getCostmap() const
     {
       return layered_costmap_->getCostmap();
     }
@@ -148,7 +148,7 @@ public:
    * @brief  Returns the global frame of the costmap
    * @return The global frame of the costmap
    */
-  std::string getGlobalFrameID()
+  std::string getGlobalFrameID() const
     {
       return global_frame_;
     }
@@ -157,17 +157,17 @@ public:
    * @brief  Returns the local frame of the costmap
    * @return The local frame of the costmap
    */
-  std::string getBaseFrameID()
+  std::string getBaseFrameID() const
     {
       return robot_base_frame_;
     }
-  LayeredCostmap* getLayeredCostmap()
+  LayeredCostmap* getLayeredCostmap() const
     {
       return layered_costmap_;
     }
 
   /** @brief Returns the current padded footprint as a geometry_msgs::Polygon. */
-  geometry_msgs::Polygon getRobotFootprintPolygon()
+  geometry_msgs::Polygon getRobotFootprintPolygon() const
   {
     return costmap_2d::toPolygon(padded_footprint_);
   }
@@ -180,7 +180,7 @@ public:
    * The footprint initially comes from the rosparam "footprint" but
    * can be overwritten by dynamic reconfigure or by messages received
    * on the "footprint" topic. */
-  std::vector<geometry_msgs::Point> getRobotFootprint()
+  std::vector<geometry_msgs::Point> getRobotFootprint() const
   {
     return padded_footprint_;
   }
@@ -192,7 +192,7 @@ public:
    * The footprint initially comes from the rosparam "footprint" but
    * can be overwritten by dynamic reconfigure or by messages received
    * on the "footprint" topic. */
-  std::vector<geometry_msgs::Point> getUnpaddedRobotFootprint()
+  std::vector<geometry_msgs::Point> getUnpaddedRobotFootprint() const
   {
     return unpadded_footprint_;
   }


### PR DESCRIPTION
To safely manage costmap object in subclasses.