### PR TITLE
Fix move_slow_and_clear sending obsolete params to dwa_local_planner

### DIFF
--- a/move_slow_and_clear/src/move_slow_and_clear.cpp
+++ b/move_slow_and_clear/src/move_slow_and_clear.cpp
@@ -131,14 +131,14 @@ namespace move_slow_and_clear
     //get the old maximum speed for the robot... we'll want to set it back
     if(!limit_set_)
     {
-      if(!planner_nh_.getParam("max_trans_vel", old_trans_speed_))
+      if(!planner_nh_.getParam("max_vel_trans", old_trans_speed_))
       {
-        ROS_ERROR("The planner %s, does not have the parameter max_trans_vel", planner_nh_.getNamespace().c_str());
+        ROS_ERROR("The planner %s, does not have the parameter max_vel_trans", planner_nh_.getNamespace().c_str());
       }
 
-      if(!planner_nh_.getParam("max_rot_vel", old_rot_speed_))
+      if(!planner_nh_.getParam("max_vel_theta", old_rot_speed_))
       {
-        ROS_ERROR("The planner %s, does not have the parameter max_rot_vel", planner_nh_.getNamespace().c_str());
+        ROS_ERROR("The planner %s, does not have the parameter max_vel_theta", planner_nh_.getNamespace().c_str());
       }
     }
 
@@ -194,7 +194,7 @@ namespace move_slow_and_clear
     {
       dynamic_reconfigure::Reconfigure vel_reconfigure;
       dynamic_reconfigure::DoubleParameter new_trans;
-      new_trans.name = "max_trans_vel";
+      new_trans.name = "max_vel_trans";
       new_trans.value = trans_speed;
       vel_reconfigure.request.config.doubles.push_back(new_trans);
       try {
@@ -208,7 +208,7 @@ namespace move_slow_and_clear
     {
       dynamic_reconfigure::Reconfigure rot_reconfigure;
       dynamic_reconfigure::DoubleParameter new_rot;
-      new_rot.name = "max_rot_vel";
+      new_rot.name = "max_vel_theta";
       new_rot.value = rot_speed;
       rot_reconfigure.request.config.doubles.push_back(new_rot);
       try {


### PR DESCRIPTION
The issue happened when use dwa_local_planner with move_slow_and_clear recovery, an error will occur when move_slow_and_clear was triggered:
```
[ WARN] [1577762644.984330470]: Move slow and clear recovery behavior started.
[ERROR] [1577762644.993155077]: DWAPlannerConfig::__fromMessage__ called with an unexpected parameter.
[ERROR] [1577762644.993596271]: Booleans:
[ERROR] [1577762644.993858352]: Integers:
[ERROR] [1577762644.994060902]: Doubles:
[ERROR] [1577762644.994272150]:   max_trans_vel
[ERROR] [1577762644.994460951]: Strings:
[ INFO] [1577762645.088472543]: Recovery setting trans vel: 0.2
[ERROR] [1577762645.089393212]: DWAPlannerConfig::__fromMessage__ called with an unexpected parameter.
[ERROR] [1577762645.089644355]: Booleans:
[ERROR] [1577762645.089762271]: Integers:
[ERROR] [1577762645.089854874]: Doubles:
[ERROR] [1577762645.089926384]:   max_rot_vel
[ERROR] [1577762645.090002685]: Strings:
[ INFO] [1577762645.185269162]: Recovery setting rot vel: 0.4
```