### PR TITLE
Optimize costmap_2d::updateOrigin 

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -264,6 +264,10 @@ void Costmap2D::updateOrigin(double new_origin_x, double new_origin_y)
   cell_ox = int((new_origin_x - origin_x_) / resolution_);
   cell_oy = int((new_origin_y - origin_y_) / resolution_);
 
+  // Nothing to update
+  if (cell_ox == 0 && cell_oy == 0)
+    return;
+
   // compute the associated world coordinates for the origin cell
   // because we want to keep things grid-aligned
   double new_grid_ox, new_grid_oy;


### PR DESCRIPTION
Optimize costmap_2d::updateOrigin in case robot's position changes too little to actually change map origin. Then, the following copying stuff is not needed.
Relevant when rolling_window is True.