### PR TITLE
Add frame ID to empty NavFn paths

### DIFF
--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -349,13 +349,14 @@ namespace navfn {
     //create a message for the plan 
     nav_msgs::Path gui_path;
     gui_path.poses.resize(path.size());
-    gui_path.header.stamp = path[0].header.stamp;
     
     if(path.empty()) {
       //still set a valid frame so visualization won't hit transform issues
     	gui_path.header.frame_id = global_frame_;
+      gui_path.header.stamp = ros::Time::now();
     } else { 
       gui_path.header.frame_id = path[0].header.frame_id;
+      gui_path.header.stamp = path[0].header.stamp;
     }
 
     // Extract the plan in world co-ordinates, we assume the path is all in the same frame

--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -346,15 +346,17 @@ namespace navfn {
       return;
     }
 
+    //given an empty path we won't do anything
+    if(path.empty()) {
+    	return;
+    }
+
     //create a message for the plan 
     nav_msgs::Path gui_path;
     gui_path.poses.resize(path.size());
-
-    if(!path.empty())
-    {
-      gui_path.header.frame_id = path[0].header.frame_id;
-      gui_path.header.stamp = path[0].header.stamp;
-    }
+    gui_path.header.frame_id = path[0].header.frame_id;
+    gui_path.header.stamp = path[0].header.stamp;
+    
 
     // Extract the plan in world co-ordinates, we assume the path is all in the same frame
     for(unsigned int i=0; i < path.size(); i++){

--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -346,17 +346,17 @@ namespace navfn {
       return;
     }
 
-    //given an empty path we won't do anything
-    if(path.empty()) {
-    	return;
-    }
-
     //create a message for the plan 
     nav_msgs::Path gui_path;
     gui_path.poses.resize(path.size());
-    gui_path.header.frame_id = path[0].header.frame_id;
     gui_path.header.stamp = path[0].header.stamp;
     
+    if(path.empty()) {
+      //still set a valid frame so visualization won't hit transform issues
+    	gui_path.header.frame_id = global_frame_;
+    } else { 
+      gui_path.header.frame_id = path[0].header.frame_id;
+    }
 
     // Extract the plan in world co-ordinates, we assume the path is all in the same frame
     for(unsigned int i=0; i < path.size(); i++){


### PR DESCRIPTION
RViz will complain about not being able to transform the path if it doesn't have a frame ID, so we'll just drop these

Closes #963