### PR TITLE
Add missing CMake include(CheckSymbolExists) for CMake >= 3.15

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(amcl)
 
+include(CheckSymbolExists)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()


### PR DESCRIPTION
CMake >= `3.15` expects `include(CheckSymbolExists)` to be called before running the `check_symbol_exists` macro.

When the `include` is missing the following error occurs when building `amcl`:

```
-- Using CATKIN_DEVEL_PREFIX: /home/nlimpert/dev/catkin_ws/devel_isolated/amcl
-- Using CMAKE_PREFIX_PATH: /home/nlimpert/dev/catkin_ws/devel_isolated/map_server;/home/nlimpert/dev/catkin_ws/devel_isolated/map_msgs;/home/nlimpert/dev/catkin_ws/devel_isolated/key_teleop;/home/nlimpert/dev/catkin_ws/devel_isolated/joy_teleop;/home/nlimpert/dev/catkin_ws/devel_isolated/hector_laserscan_to_pointcloud;/home/nlimpert/dev/catkin_ws/devel_isolated/fawkes_msgs;/home/nlimpert/dev/catkin_ws/devel_isolated/fake_localization;/usr/lib64/ros
-- This workspace overlays: /home/nlimpert/dev/catkin_ws/devel_isolated/map_server;/home/nlimpert/dev/catkin_ws/devel_isolated/map_msgs;/home/nlimpert/dev/catkin_ws/devel_isolated/key_teleop;/home/nlimpert/dev/catkin_ws/devel_isolated/joy_teleop;/home/nlimpert/dev/catkin_ws/devel_isolated/hector_laserscan_to_pointcloud;/home/nlimpert/dev/catkin_ws/devel_isolated/fawkes_msgs;/home/nlimpert/dev/catkin_ws/devel_isolated/fake_localization;/usr/lib64/ros
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.17", minimum required is "2")
-- Using PYTHON_EXECUTABLE: /usr/bin/python2
-- Using default Python package layout
-- Using empy: /usr/lib/python2.7/site-packages/em.pyc
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/nlimpert/dev/catkin_ws/build_isolated/amcl/test_results
-- Found gtest: gtests will be built
-- Using Python nosetests: /usr/bin/nosetests
-- catkin 0.7.20
-- BUILD_SHARED_LIBS is on
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- Found PythonInterp: /usr/bin/python2 (found version "2.7.17")
CMake Error at CMakeLists.txt:59 (check_symbol_exists):
  Unknown CMake command "check_symbol_exists".


-- Configuring incomplete, errors occurred!
```
--------------

I have verified this patch to also work with CMake `3.10.2`, `3.14.5` and `3.16.3`.