### PR TITLE
Fix Uknown CMake command check_include_file

### DIFF
--- a/voxel_grid/CMakeLists.txt
+++ b/voxel_grid/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(voxel_grid)
 
+include(CheckIncludeFile)
+
 find_package(catkin REQUIRED
   COMPONENTS
     roscpp


### PR DESCRIPTION
Hello. In Gentoo ROS melodic's voxel_grid stopped building with the error:

```bash
CMake Error at CMakeLists.txt:20 (check_include_file):
  Unknown CMake command "check_include_file".
```

Since this commit: https://github.com/ros-planning/navigation/commit/347bdca491828ab02168963715146b9259151df1#diff-f60f7935c68d159bca0355f1ee829a38
Which is part of the release 1.16.4 on Melodic.

The same happened with amcl in the past as reported in the PR that fixed it: https://github.com/ros-planning/navigation/pull/946

I've tested it and this change fixes it.