### PR TITLE
Fix Unknown CMake command check_include_file (navfn & base_local_planner)

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(base_local_planner)
 
+include(CheckIncludeFile)
+
 find_package(catkin REQUIRED
         COMPONENTS
             angles

--- a/navfn/CMakeLists.txt
+++ b/navfn/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(navfn)
 
+include(CheckIncludeFile)
+
 find_package(catkin REQUIRED
     COMPONENTS
         cmake_modules


### PR DESCRIPTION
Hello,

Both `navfn` and `base_local_planner` are affected by the:

```bash
CMake Error at CMakeLists.txt:58 (check_include_file):
   Unknown CMake command "check_include_file".
```

This PR fixes it as the builds are currently broken in Gentoo.

I'm sorry to make yet another PR for the same issue than last time (https://github.com/ros-planning/navigation/pull/974). I should have grep'ed the repo for more instances of this happening the previous time. I've done it this time and there are no more cases of this in the navigation repo.
I'd request a new release also if possible. Thanks a lot for your time.