### PR TITLE
move_base: Add options for make_plan service

### DIFF
--- a/move_base/cfg/MoveBase.cfg
+++ b/move_base/cfg/MoveBase.cfg
@@ -26,5 +26,8 @@ gen.add("shutdown_costmaps", bool_t, 0, "Determines whether or not to shutdown t
 gen.add("oscillation_timeout", double_t, 0, "How long in seconds to allow for oscillation before executing recovery behaviors.", 0.0, 0, 60)
 gen.add("oscillation_distance", double_t, 0, "How far in meters the robot must move to be considered not to be oscillating.", 0.5, 0, 10)
 
+gen.add("make_plan_clear_costmap", bool_t, 0, "Whether or not to clear the global costmap on make_plan service call.", True)
+gen.add("make_plan_add_unreachable_goal", bool_t, 0, "Whether or not to add the original goal to the path if it is unreachable in the make_plan service call.", True)
+
 gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration", False)
 exit(gen.generate(PACKAGE, "move_base_node", "MoveBase"))

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -198,6 +198,7 @@ namespace move_base {
       ros::Subscriber goal_sub_;
       ros::ServiceServer make_plan_srv_, clear_costmaps_srv_;
       bool shutdown_costmaps_, clearing_rotation_allowed_, recovery_behavior_enabled_;
+      bool make_plan_clear_costmap_, make_plan_add_unreachable_goal_;
       double oscillation_timeout_, oscillation_distance_;
 
       MoveBaseState state_;


### PR DESCRIPTION
Adds the following two parameters for the ~make_plan service of move_base to fix #980:

1. make_plan_clear_costmap
Whether or not to clear the global costmap on make_plan service call.

2. make_plan_add_unreachable_goal
Whether or not to add the original goal to the path if it is unreachable in the make_plan service call.