### PR TITLE
backport noetic memory fixes

### DIFF
--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -52,7 +52,9 @@ namespace costmap_2d
 {
 
 InflationLayer::InflationLayer()
-  : inflation_radius_(0)
+  : resolution_(0)
+  , inflation_radius_(0)
+  , inscribed_radius_(0)
   , weight_(0)
   , inflate_unknown_(false)
   , cell_inflation_radius_(0)

--- a/costmap_2d/test/inflation_tests.cpp
+++ b/costmap_2d/test/inflation_tests.cpp
@@ -97,6 +97,13 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
           continue;
         }
 
+        if (dist == bin->first)
+        {
+          // Adding to our current bin could cause a reallocation
+          // Which appears to cause the iterator to get messed up
+          dist += 0.001;
+        }
+
         if (cell.x_ > 0)
         {
           CellData data(costmap->getIndex(cell.x_-1, cell.y_),


### PR DESCRIPTION
spent some time with valgrind to fix this test,
was failing intermittently in melodic, all the
time in noetic.