### PR TITLE
add explicit call to ros::Timer::stop in the destructor

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -184,6 +184,8 @@ void Costmap2DROS::setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon
 
 Costmap2DROS::~Costmap2DROS()
 {
+  timer_.stop();
+
   map_update_thread_shutdown_ = true;
   if (map_update_thread_ != NULL)
   {


### PR DESCRIPTION
Hi all, 
there is a bug if the costmap_2d_ros class gets destructed while being in the timer-callback. 

Since the class members are destructed in the reverse order of their definition in the header file, we might end up accessing already destructed members inside the movementCB. 

One solution (which technically is better) is to define the timer_ member last - however, it's difficult to maintain (if someone decides to add more members). Therefore I decided to add an explicit `Timer::stop` call to the destructor