### PR TITLE
[noetic] Adding CMake way to find yaml-cpp

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -14,11 +14,18 @@ find_package(SDL_image REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(YAMLCPP yaml-cpp REQUIRED)
-if(YAMLCPP_VERSION VERSION_GREATER "0.5.0")
+pkg_check_modules(YAMLCPP yaml-cpp QUIET)
+if(NOT YAMLCPP_FOUND)
+  find_package(yaml-cpp 0.6 REQUIRED)
+  set(YAMLCPP_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
+  set(YAMLCPP_LIBRARIES ${YAML_CPP_LIBRARIES})
+  add_definitions(-DHAVE_YAMLCPP_GT_0_5_0)
+else()
+  if(YAMLCPP_VERSION VERSION_GREATER "0.5.0")
     add_definitions(-DHAVE_YAMLCPP_GT_0_5_0)
+  endif()
+  link_directories(${YAMLCPP_LIBRARY_DIRS})
 endif()
-link_directories(${YAMLCPP_LIBRARY_DIRS})
 
 catkin_package(
     INCLUDE_DIRS


### PR DESCRIPTION
On some package managers (e.g., `vcpkg` and `conda-fogre`), `pkg-config` file is not generated for `yaml-cpp` Windows build. Instead, the `CMake` config is generated for the package discovery.

This change is to make the `map_server` more portable to be built on those environments.