### PR TITLE
Remove scaling of BLP occdist_scale by costmap resolution

### DIFF
--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -198,7 +198,6 @@ namespace base_local_planner {
           double resolution = costmap_->getResolution();
           goal_distance_bias *= resolution;
           path_distance_bias *= resolution;
-          occdist_scale *= resolution;
         } else {
           ROS_WARN("Trajectory Rollout planner initialized with param meter_scoring set to false. Set it to true to make your settings robust against changes of costmap resolution.");
         }


### PR DESCRIPTION
occdist_scale should not be scaled by the costmap resolution as it doesn't multiply a value that includes a distance.