### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import sys
 import time
 from math import fmod, pi

--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -26,7 +26,7 @@ class TestBasicLocalization(unittest.TestCase):
                 self.tf = t.transform
                 (a_curr, a_diff) = self.compute_angle_diff()
                 print('Curr:\t %16.6f %16.6f %16.6f' % (self.tf.translation.x, self.tf.translation.y, a_curr))
-                print('Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a)
+                print('Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a))
                 print('Diff:\t %16.6f %16.6f %16.6f' % (
                     abs(self.tf.translation.x - self.target_x), abs(self.tf.translation.y - self.target_y), a_diff))
 

--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -68,7 +68,7 @@ class TestBasicLocalization(unittest.TestCase):
         print('Curr:\t %16.6f %16.6f %16.6f' % (self.tf.translation.x, self.tf.translation.y, a_curr))
         print('Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a))
         print('Diff:\t %16.6f %16.6f %16.6f' % (
-            abs(self.tf.translation.x - self.target_x), abs(self.tf.translation.y - self.target_y), a_diff)
+            abs(self.tf.translation.x - self.target_x), abs(self.tf.translation.y - self.target_y), a_diff))
         self.assertNotEquals(self.tf, None)
         self.assertTrue(abs(self.tf.translation.x - self.target_x) <= tolerance_d)
         self.assertTrue(abs(self.tf.translation.y - self.target_y) <= tolerance_d)

--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -25,10 +25,10 @@ class TestBasicLocalization(unittest.TestCase):
             if t.header.frame_id == 'map':
                 self.tf = t.transform
                 (a_curr, a_diff) = self.compute_angle_diff()
-                print 'Curr:\t %16.6f %16.6f %16.6f' % (self.tf.translation.x, self.tf.translation.y, a_curr)
-                print 'Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a)
-                print 'Diff:\t %16.6f %16.6f %16.6f' % (
-                    abs(self.tf.translation.x - self.target_x), abs(self.tf.translation.y - self.target_y), a_diff)
+                print('Curr:\t %16.6f %16.6f %16.6f' % (self.tf.translation.x, self.tf.translation.y, a_curr))
+                print('Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a)
+                print('Diff:\t %16.6f %16.6f %16.6f' % (
+                    abs(self.tf.translation.x - self.target_x), abs(self.tf.translation.y - self.target_y), a_diff))
 
     def compute_angle_diff(self):
         rot = self.tf.rotation
@@ -47,27 +47,27 @@ class TestBasicLocalization(unittest.TestCase):
         target_time = float(sys.argv[7])
 
         if global_localization == 1:
-            #print 'Waiting for service global_localization'
+            #print('Waiting for service global_localization')
             rospy.wait_for_service('global_localization')
             global_localization = rospy.ServiceProxy('global_localization', Empty)
             global_localization()
 
         rospy.init_node('test', anonymous=True)
         while(rospy.rostime.get_time() == 0.0):
-            #print 'Waiting for initial time publication'
+            #print('Waiting for initial time publication')
             time.sleep(0.1)
         start_time = rospy.rostime.get_time()
         # TODO: This should be replace by a pytf listener
         rospy.Subscriber('/tf', TFMessage, self.tf_cb)
 
         while (rospy.rostime.get_time() - start_time) < target_time:
-            #print 'Waiting for end time %.6f (current: %.6f)'%(target_time,(rospy.rostime.get_time() - start_time))
+            #print('Waiting for end time %.6f (current: %.6f)'%(target_time,(rospy.rostime.get_time() - start_time)))
             time.sleep(0.1)
 
         (a_curr, a_diff) = self.compute_angle_diff()
-        print 'Curr:\t %16.6f %16.6f %16.6f' % (self.tf.translation.x, self.tf.translation.y, a_curr)
-        print 'Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a)
-        print 'Diff:\t %16.6f %16.6f %16.6f' % (
+        print('Curr:\t %16.6f %16.6f %16.6f' % (self.tf.translation.x, self.tf.translation.y, a_curr))
+        print('Target:\t %16.6f %16.6f %16.6f' % (self.target_x, self.target_y, self.target_a))
+        print('Diff:\t %16.6f %16.6f %16.6f' % (
             abs(self.tf.translation.x - self.target_x), abs(self.tf.translation.y - self.target_y), a_diff)
         self.assertNotEquals(self.tf, None)
         self.assertTrue(abs(self.tf.translation.x - self.target_x) <= tolerance_d)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Python 2 died on 1/1/2020.