### PR TITLE
Fix #796

### DIFF
--- a/fake_localization/fake_localization.cpp
+++ b/fake_localization/fake_localization.cpp
@@ -247,7 +247,7 @@ class FakeOdomNode
       geometry_msgs::TransformStamped baseInMap;
       try{
 	// just get the latest
-        baseInMap = m_tfBuffer->lookupTransform(base_frame_id_, global_frame_id_, msg->header.stamp);
+        baseInMap = m_tfBuffer->lookupTransform(base_frame_id_, global_frame_id_, ros::Time(0));
       } catch(tf2::TransformException){
         ROS_WARN("Failed to lookup transform!");
         return;


### PR DESCRIPTION
Use ros::Time(0) instead of timestamp in message so as not to fail to lookupTransform.

This change is suggested by @guohefu, @JavierLRH, and @mikeferguson in #796, and seems good to me too.
Thank you!