### PR TITLE
correctly delete previously allocated array

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -315,7 +315,7 @@ bool GlobalPlanner::makePlan(const geometry_msgs::PoseStamped& start, const geom
 
     //publish the plan for visualization purposes
     publishPlan(plan);
-    delete potential_array_;
+    delete[] potential_array_;
     return !plan.empty();
 }
 


### PR DESCRIPTION
found with clang leak sanitizer. Under heavy load calling the replanning service, led to strange freeing related errors and segfaults.