### PR TITLE
costmap_2d: Add missing package dependency to Eigen

### DIFF
--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -30,6 +30,7 @@
     <build_depend>tf2_sensor_msgs</build_depend>
 
     <depend>dynamic_reconfigure</depend>
+    <depend>eigen</depend>
     <depend>geometry_msgs</depend>
     <depend>laser_geometry</depend>
     <depend>map_msgs</depend>


### PR DESCRIPTION
costmap_2d depends on Eigen but it's not explicitly specified in package.xml.
https://github.com/ros-planning/navigation/blob/3bddac0bca09e2a344206e35651324c5e73c972d/costmap_2d/CMakeLists.txt#L26