### PR TITLE
use const-ref-getter for strings and vectors

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -133,7 +133,7 @@ public:
   bool getRobotPose(geometry_msgs::PoseStamped& global_pose) const;
 
   /** @brief Returns costmap name */
-  std::string getName() const
+  inline const std::string& getName() const noexcept
     {
       return name_;
     }
@@ -156,7 +156,7 @@ public:
    * @brief  Returns the global frame of the costmap
    * @return The global frame of the costmap
    */
-  std::string getGlobalFrameID() const
+  inline const std::string& getGlobalFrameID() const noexcept
     {
       return global_frame_;
     }
@@ -165,7 +165,7 @@ public:
    * @brief  Returns the local frame of the costmap
    * @return The local frame of the costmap
    */
-  std::string getBaseFrameID() const
+  inline const std::string& getBaseFrameID() const noexcept
     {
       return robot_base_frame_;
     }
@@ -188,7 +188,7 @@ public:
    * The footprint initially comes from the rosparam "footprint" but
    * can be overwritten by dynamic reconfigure or by messages received
    * on the "footprint" topic. */
-  std::vector<geometry_msgs::Point> getRobotFootprint() const
+  inline const std::vector<geometry_msgs::Point>& getRobotFootprint() const noexcept
   {
     return padded_footprint_;
   }
@@ -200,7 +200,7 @@ public:
    * The footprint initially comes from the rosparam "footprint" but
    * can be overwritten by dynamic reconfigure or by messages received
    * on the "footprint" topic. */
-  std::vector<geometry_msgs::Point> getUnpaddedRobotFootprint() const
+  inline const std::vector<geometry_msgs::Point>& getUnpaddedRobotFootprint() const noexcept
   {
     return unpadded_footprint_;
   }

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -98,7 +98,7 @@ public:
   /** @brief Implement this to make this layer match the size of the parent costmap. */
   virtual void matchSize() {}
 
-  std::string getName() const
+  inline const std::string& getName() const noexcept
   {
     return name_;
   }

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -71,7 +71,7 @@ public:
    */
   void updateMap(double robot_x, double robot_y, double robot_yaw);
 
-  std::string getGlobalFrameID() const
+  inline const std::string& getGlobalFrameID() const noexcept
   {
     return global_frame_;
   }


### PR DESCRIPTION
Convert getters for larger members (strings and vectors) to pass by ref instead of pass by value.
