### PR TITLE
move enabled-logic to the LayeredCostmap

### DIFF
--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -95,6 +95,24 @@ public:
     return current_;
   }
 
+  /**
+   * @brief getter if the current layer is enabled.
+   *
+   * The user may enable/disable a layer though dynamic reconfigure.
+   * Disabled layers won't receive calls to
+   * - Layer::updateCosts
+   * - Layer::updateBounds
+   * - Layer::isCurrent
+   * from the LayeredCostmap.
+   *
+   * Calls to Layer::activate, Layer::deactivate and Layer::reset won't be
+   * blocked.
+   */
+  inline bool isEnabled() const noexcept
+  {
+    return enabled_;
+  }
+
   /** @brief Implement this to make this layer match the size of the parent costmap. */
   virtual void matchSize() {}
 
@@ -120,7 +138,7 @@ protected:
 
   LayeredCostmap* layered_costmap_;
   bool current_;
-  bool enabled_;  ///< Currently this var is managed by subclasses. TODO: make this managed by this class and/or container class.
+  bool enabled_;
   std::string name_;
   tf2_ros::Buffer *tf_;
 

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -176,7 +176,7 @@ void InflationLayer::onFootprintChanged()
 void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
   boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
-  if (!enabled_ || (cell_inflation_radius_ == 0))
+  if (cell_inflation_radius_ == 0)
     return;
 
   // make sure the inflation list is empty at the beginning of the cycle (should always be true)

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -335,8 +335,6 @@ void ObstacleLayer::updateBounds(double robot_x, double robot_y, double robot_ya
 {
   if (rolling_window_)
     updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
-  if (!enabled_)
-    return;
   useExtraBounds(min_x, min_y, max_x, max_y);
 
   bool current = true;
@@ -423,9 +421,6 @@ void ObstacleLayer::updateFootprint(double robot_x, double robot_y, double robot
 
 void ObstacleLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
-  if (!enabled_)
-    return;
-
   if (footprint_clearing_enabled_)
   {
     setConvexPolygonCost(transformed_footprint_, costmap_2d::FREE_SPACE);

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -296,9 +296,6 @@ void StaticLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int
   if (!map_received_)
     return;
 
-  if (!enabled_)
-    return;
-
   if (!layered_costmap_->isRolling())
   {
     // if not rolling, the layered costmap (master_grid) has same coordinates as this layer

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -118,8 +118,6 @@ void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, 
 {
   if (rolling_window_)
     updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
-  if (!enabled_)
-    return;
   useExtraBounds(min_x, min_y, max_x, max_y);
 
   bool current = true;

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -115,6 +115,8 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
        ++plugin)
   {
+    if(!(*plugin)->isEnabled())
+      continue;
     double prev_minx = minx_;
     double prev_miny = miny_;
     double prev_maxx = maxx_;
@@ -148,7 +150,8 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
        ++plugin)
   {
-    (*plugin)->updateCosts(costmap_, x0, y0, xn, yn);
+    if((*plugin)->isEnabled())
+      (*plugin)->updateCosts(costmap_, x0, y0, xn, yn);
   }
 
   bx0_ = x0;
@@ -165,7 +168,8 @@ bool LayeredCostmap::isCurrent()
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
       ++plugin)
   {
-    current_ = current_ && (*plugin)->isCurrent();
+    if((*plugin)->isEnabled())
+      current_ = current_ && (*plugin)->isCurrent();
   }
   return current_;
 }


### PR DESCRIPTION
Hey guys, 
I found it very easy to miss to check if a costmap is enabled in the Layer::updateCosts and Layer::updateBounds methods and think this should be better checked in the LayeredCostmap. 

