### PR TITLE
Fixed to use globally defined values

### DIFF
--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -66,9 +66,9 @@ LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bo
     inscribed_radius_(0.1)
 {
   if (track_unknown)
-    costmap_.setDefaultValue(255);
+    costmap_.setDefaultValue(NO_INFORMATION);
   else
-    costmap_.setDefaultValue(0);
+    costmap_.setDefaultValue(FREE_SPACE);
 }
 
 LayeredCostmap::~LayeredCostmap()


### PR DESCRIPTION
https://github.com/ros-planning/navigation/blob/noetic-devel/costmap_2d/include/costmap_2d/cost_values.h
Despite being defined in this file, used local values.