### PR TITLE
Fix carrot planner

### DIFF
--- a/carrot_planner/CMakeLists.txt
+++ b/carrot_planner/CMakeLists.txt
@@ -3,6 +3,7 @@ project(carrot_planner)
 
 find_package(catkin REQUIRED
   COMPONENTS
+    angles
     base_local_planner
     costmap_2d
     nav_core
@@ -23,6 +24,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES carrot_planner
   CATKIN_DEPENDS
+    angles
     base_local_planner
     costmap_2d
     nav_core

--- a/carrot_planner/include/carrot_planner/carrot_planner.h
+++ b/carrot_planner/include/carrot_planner/carrot_planner.h
@@ -66,6 +66,11 @@ namespace carrot_planner{
       CarrotPlanner(std::string name, costmap_2d::Costmap2DROS* costmap_ros);
 
       /**
+       * @brief Destructor
+       */
+      ~CarrotPlanner();
+
+      /**
        * @brief  Initialization function for the CarrotPlanner
        * @param  name The name of this planner
        * @param  costmap_ros A pointer to the ROS wrapper of the costmap to use for planning

--- a/carrot_planner/include/carrot_planner/carrot_planner.h
+++ b/carrot_planner/include/carrot_planner/carrot_planner.h
@@ -42,7 +42,6 @@
 #include <nav_core/base_global_planner.h>
 
 #include <geometry_msgs/PoseStamped.h>
-#include <angles/angles.h>
 
 #include <base_local_planner/world_model.h>
 #include <base_local_planner/costmap_model.h>

--- a/carrot_planner/package.xml
+++ b/carrot_planner/package.xml
@@ -21,6 +21,7 @@
 
     <build_depend>tf2_geometry_msgs</build_depend>
 
+    <depend>angles</depend>
     <depend>base_local_planner</depend>
     <depend>costmap_2d</depend>
     <depend>eigen</depend>

--- a/carrot_planner/src/carrot_planner.cpp
+++ b/carrot_planner/src/carrot_planner.cpp
@@ -46,10 +46,10 @@ PLUGINLIB_EXPORT_CLASS(carrot_planner::CarrotPlanner, nav_core::BaseGlobalPlanne
 namespace carrot_planner {
 
   CarrotPlanner::CarrotPlanner()
-  : costmap_ros_(NULL), initialized_(false){}
+  : costmap_ros_(NULL), costmap_(NULL), world_model_(NULL), initialized_(false){}
 
   CarrotPlanner::CarrotPlanner(std::string name, costmap_2d::Costmap2DROS* costmap_ros)
-  : costmap_ros_(NULL), initialized_(false){
+  : costmap_ros_(NULL), costmap_(NULL), world_model_(NULL), initialized_(false){
     initialize(name, costmap_ros);
   }
 

--- a/carrot_planner/src/carrot_planner.cpp
+++ b/carrot_planner/src/carrot_planner.cpp
@@ -52,6 +52,11 @@ namespace carrot_planner {
   : costmap_ros_(NULL), initialized_(false){
     initialize(name, costmap_ros);
   }
+
+  CarrotPlanner::~CarrotPlanner() {
+    // deleting a nullptr is a noop
+    delete world_model_;
+  }
   
   void CarrotPlanner::initialize(std::string name, costmap_2d::Costmap2DROS* costmap_ros){
     if(!initialized_){

--- a/carrot_planner/src/carrot_planner.cpp
+++ b/carrot_planner/src/carrot_planner.cpp
@@ -34,6 +34,7 @@
 *
 * Authors: Eitan Marder-Eppstein, Sachin Chitta
 *********************************************************************/
+#include <angles/angles.h>
 #include <carrot_planner/carrot_planner.h>
 #include <pluginlib/class_list_macros.h>
 #include <tf2/convert.h>


### PR DESCRIPTION
Hey guys, 

found out during testing, that the carrot-planner may crash the same way as global-planner did if not called initialize. This PR bundles some miner fixes

## Fixes
- memory leak of world_model
- unitilialized raw pointer
- add missing dependency of angles