### PR TITLE
[noetic](map_server) add rtest dependency to tests

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -95,6 +95,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_executable(rtest test/rtest.cpp test/test_constants.cpp)
   add_dependencies(rtest ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+  add_dependencies(tests rtest)
   target_link_libraries( rtest
       ${GTEST_LIBRARIES}
       ${catkin_LIBRARIES}


### PR DESCRIPTION
To make sure that `rtest` can be executed in the same run as being build. This matches the tests in `costmap_2d`.

Melodic in #1060
Kinetic in #1062