### PR TITLE
Fix memory-leak in costmap-2d-publisher

### DIFF
--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -78,6 +78,7 @@ Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* co
 
 Costmap2DPublisher::~Costmap2DPublisher()
 {
+  delete[] cost_translation_table_;
 }
 
 void Costmap2DPublisher::onNewSubscription(const ros::SingleSubscriberPublisher& pub)


### PR DESCRIPTION
Hi everyone,

There is a memory leak in the costmap-2d-publisher, where we don't release the memory of `cost_translation_table_`. This commit fixes it.