### PR TITLE
navfn: stop installing test headers

### DIFF
--- a/navfn/CMakeLists.txt
+++ b/navfn/CMakeLists.txt
@@ -101,7 +101,7 @@ message (STATUS "NAVFN_HAVE_FLTK: ${NAVFN_HAVE_FLTK}, NETPBM: ${NAVFN_HAVE_NETPB
 # Just linking -lfltk is not sufficient on OS X
 if (NAVFN_HAVE_FLTK AND NAVFN_HAVE_NETPBM AND NOT APPLE)
   message (STATUS "FLTK found: adding navtest to build")
-  add_executable (navtest src/navtest.cpp src/navwin.cpp)
+  add_executable (navtest src/navtest/navtest.cpp src/navtest/navwin.cpp)
   set (FLTK_SKIP_FLUID 1)
   set (FLTK_SKIP_FORMS 1)
   set (FLTK_SKIP_IMAGES 1)

--- a/navfn/src/navtest/navtest.cpp
+++ b/navfn/src/navtest/navtest.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <navfn/navfn.h>
-#include <navfn/navwin.h>
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
@@ -14,6 +13,8 @@
 
 #include <string>
 #include <fstream>
+
+#include "navwin.h"
 
 using namespace navfn;
 

--- a/navfn/src/navtest/navwin.cpp
+++ b/navfn/src/navtest/navwin.cpp
@@ -2,8 +2,8 @@
 // simple timing test of the nav fn planner
 // 
 
-#include <navfn/navwin.h>
 #include <string.h>
+#include "navwin.h"
 
 namespace navfn {
 NavWin::NavWin(int w, int h, const char *name)

--- a/navfn/src/navtest/navwin.h
+++ b/navfn/src/navtest/navwin.h
@@ -12,7 +12,7 @@
 #include <FL/Fl_Window.H>
 #include <FL/fl_draw.H>
 
-#include "navfn.h"
+#include <navfn/navfn.h>
 
 namespace navfn {
   class NavWin 


### PR DESCRIPTION
The navtest executable is only built if FLTK is installed. However, the header it uses is installed regardless, and requires FLTK. Nothing else uses this header, and navfn doesn't depend upon FLTK, so stop installing the header. Also fix navtest to actually build when FLTK is installed.