### PR TITLE
fix boundary point exclusion in convexFillCells

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -414,7 +414,7 @@ void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::ve
 
     MapLocation pt;
     // loop though cells in the column
-    for (unsigned int y = min_pt.y; y < max_pt.y; ++y)
+    for (unsigned int y = min_pt.y; y <= max_pt.y; ++y)
     {
       pt.x = x;
       pt.y = y;


### PR DESCRIPTION
A bug in the function that returns all the cells contained in a (convex) polygon:

- sorts all the points along the polygon outline by x coordinate
- for all points with same x coordinate, find min and max y coordinate
- for that x coordinate, considers all points between min and max y coordinate to be within the polygon

The bug is that the maximum y coordinate also needs to be included.