### PR TITLE
Fixed the risk of divide by zero.

### DIFF
--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -669,6 +669,12 @@ void pf_cluster_stats(pf_t *pf, pf_sample_set_t *set)
     //pf_matrix_fprintf(cluster->cov, stdout, "%e");
   }
 
+  assert(fabs(weight) >= DBL_EPSILON);
+  if (fabs(weight) < DBL_EPSILON)
+  {
+    printf("ERROR : divide-by-zero exception : weight is zero\n");
+    return;
+  }
   // Compute overall filter stats
   set->mean.v[0] = m[0] / weight;
   set->mean.v[1] = m[1] / weight;
@@ -715,6 +721,13 @@ void pf_get_cep_stats(pf_t *pf, pf_vector_t *mean, double *var)
     my += sample->weight * sample->pose.v[1];
     mrr += sample->weight * sample->pose.v[0] * sample->pose.v[0];
     mrr += sample->weight * sample->pose.v[1] * sample->pose.v[1];
+  }
+
+  assert(fabs(mn) >= DBL_EPSILON);
+  if (fabs(mn) < DBL_EPSILON)
+  {
+    printf("ERROR : divide-by-zero exception : mn is zero\n");
+    return;
   }
 
   mean->v[0] = mx / mn;

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -424,8 +424,13 @@ void GlobalPlanner::publishPotential(float* potential)
     for (unsigned int i = 0; i < grid.data.size(); i++) {
         if (potential_array_[i] >= POT_HIGH) {
             grid.data[i] = -1;
-        } else
-            grid.data[i] = potential_array_[i] * publish_scale_ / max;
+        } else {
+            if (fabs(max) < DBL_EPSILON) {
+                grid.data[i] = -1;
+            } else {
+                grid.data[i] = potential_array_[i] * publish_scale_ / max;
+            }
+        }
     }
     potential_pub_.publish(grid);
 }


### PR DESCRIPTION
I found some risk of divide by zero in amcl/src/amcl/pf.c and global_planner/src/planner.core.cpp.
Division by zero in double/float is not an error. But, it raises a floating-point exception in some implementations and has well-defined results: either inf/-in or nan.
However, from the point of view of defensive programming, it is not good that the calculation is continued using an incalculable number such as inf/nan by dividing by a number close to 0. In most cases, these assertions will not be triggered and there will be no side effects.