### PR TITLE
map_server: Initialise NodeHandle outside the MapServer constructor

### DIFF
--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -238,6 +238,7 @@ class MapServer
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "map_server", ros::init_options::AnonymousName);
+  ros::NodeHandle nh("~");
   if(argc != 3 && argc != 2)
   {
     ROS_ERROR("%s", USAGE);


### PR DESCRIPTION
Currently if an exception is raised inside the `MapServer` execution, it's caught by the `try-catch` statement in `main`. However at that point the `ros::NodeHandle` instance is already destroyed since it's constructed inside `MapServer::MapServer` and that's initialised inside the `try` scope.

Because of that the `ROS_ERROR` statement in the `catch` doesn't print anything and the user isn't informed of the exception.

In this PR I'm initialising ~the NodeHandle outside `MapServer` and I'm passing a reference to it during construction.~
a second NodeHandle outside `MapServer` in `main`
