### PR TITLE
Removed unused variables in costmap_2d_ros

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -259,13 +259,11 @@ private:
   void movementCB(const ros::TimerEvent &event);
   void mapUpdateLoop(double frequency);
   bool map_update_thread_shutdown_;
-  bool stop_updates_, initialized_, stopped_, robot_stopped_;
+  bool stop_updates_, initialized_, stopped_;
   boost::thread* map_update_thread_;  ///< @brief A thread for updating the map
-  ros::Timer timer_;
   ros::Time last_publish_;
   ros::Duration publish_cycle;
   pluginlib::ClassLoader<Layer> plugin_loader_;
-  geometry_msgs::PoseStamped old_pose_;
   Costmap2DPublisher* publisher_;
   dynamic_reconfigure::Server<costmap_2d::Costmap2DConfig> *dsrv_;
 


### PR DESCRIPTION
Removed unused variables kike `old_pose_`, `timer_` and `robot_stopped_` from *costmap_2d_ros.cpp* and *costmap_2d_ros.h*. Related issue: #1046.