### PR TITLE
the pose of the robot requires a certain delay tolerance

### DIFF
--- a/base_local_planner/src/goal_functions.cpp
+++ b/base_local_planner/src/goal_functions.cpp
@@ -115,7 +115,8 @@ namespace base_local_planner {
 
       //let's get the pose of the robot in the frame of the plan
       geometry_msgs::PoseStamped robot_pose;
-      tf.transform(global_pose, robot_pose, plan_pose.header.frame_id);
+      //I think that obtaining the pose of the robot requires a certain delay tolerance
+      tf.transform(global_pose, robot_pose, plan_pose.header.frame_id, ros::Duration(0.3));
 
       //we'll discard points on the plan that are outside the local costmap
       double dist_threshold = std::max(costmap.getSizeInCellsX() * costmap.getResolution() / 2.0,


### PR DESCRIPTION
When I was running this project,  to get the robot pose  often had a delay of 0.1 to 0.2 milliseconds, and an exception was thrown. I think the delay tolerance of 0.3ms can be increased here.