### PR TITLE
Dima/update origin

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -218,3 +218,21 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   PATTERN ".svn" EXCLUDE
 )
+
+###############
+## Benchmark ##
+###############
+
+set(${PROJECT_NAME}_BENCHMARK ON)
+if(${PROJECT_NAME}_BENCHMARK)
+  # you may install the benchmark library via sudo apt install libbenchmark-dev
+  find_package(benchmark)
+  if(benchmark_FOUND)
+    message("building benchmark target")
+    add_executable(update_origin_perf perf/update_origin_perf.cpp)
+    target_link_libraries(update_origin_perf benchmark::benchmark ${PROJECT_NAME} ${catkin_LIBRARIES})
+    target_include_directories(update_origin_perf PRIVATE ${catkin_INCLUDE_DIRS})
+  else()
+    message("benchmark library not found")
+  endif()
+endif()

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -185,6 +185,9 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(coordinates_test test/coordinates_test.cpp)
   target_link_libraries(coordinates_test costmap_2d)
+
+  catkin_add_gtest(update_origin_test test/update_origin_test.cpp)
+  target_link_libraries(update_origin_test costmap_2d)
 endif()
 
 install( TARGETS

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -223,7 +223,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Benchmark ##
 ###############
 
-set(${PROJECT_NAME}_BENCHMARK ON)
+set(${PROJECT_NAME}_BENCHMARK OFF)
 if(${PROJECT_NAME}_BENCHMARK)
   # you may install the benchmark library via sudo apt install libbenchmark-dev
   find_package(benchmark)

--- a/costmap_2d/perf/update_origin_perf.cpp
+++ b/costmap_2d/perf/update_origin_perf.cpp
@@ -1,0 +1,86 @@
+#include <benchmark/benchmark.h>
+#include <costmap_2d/costmap_2d.h>
+
+struct Costmap2DLegacy : public costmap_2d::Costmap2D
+{
+
+  Costmap2DLegacy(unsigned int cells_size_x, unsigned int cells_size_y, double resolution,
+                  double origin_x, double origin_y) : costmap_2d::Costmap2D(cells_size_x, cells_size_y, resolution, origin_x, origin_y) {}
+
+  // This code is the legacy version of the updateOrigin method. It's well proven
+  // and requires a temporal buffer for updating the costmap. Our tests will use
+  // this method as ground-truth.
+  void updateOrigin(double new_origin_x, double new_origin_y) override
+  {
+    int cell_ox, cell_oy;
+    cell_ox = int((new_origin_x - origin_x_) / resolution_);
+    cell_oy = int((new_origin_y - origin_y_) / resolution_);
+
+    if (cell_ox == 0 && cell_oy == 0)
+      return;
+
+    double new_grid_ox, new_grid_oy;
+    new_grid_ox = origin_x_ + cell_ox * resolution_;
+    new_grid_oy = origin_y_ + cell_oy * resolution_;
+
+    int size_x = size_x_;
+    int size_y = size_y_;
+
+    int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
+    lower_left_x = std::min(std::max(cell_ox, 0), size_x);
+    lower_left_y = std::min(std::max(cell_oy, 0), size_y);
+    upper_right_x = std::min(std::max(cell_ox + size_x, 0), size_x);
+    upper_right_y = std::min(std::max(cell_oy + size_y, 0), size_y);
+
+    unsigned int cell_size_x = upper_right_x - lower_left_x;
+    unsigned int cell_size_y = upper_right_y - lower_left_y;
+    unsigned char *local_map = new unsigned char[cell_size_x * cell_size_y];
+
+    copyMapRegion(costmap_, lower_left_x, lower_left_y, size_x_, local_map, 0, 0, cell_size_x, cell_size_x, cell_size_y);
+
+    resetMaps();
+
+    origin_x_ = new_grid_ox;
+    origin_y_ = new_grid_oy;
+
+    int start_x = lower_left_x - cell_ox;
+    int start_y = lower_left_y - cell_oy;
+
+    copyMapRegion(local_map, 0, 0, cell_size_x, costmap_, start_x, start_y, size_x_, cell_size_x, cell_size_y);
+    delete[] local_map;
+  }
+};
+
+static void
+perf_legacy(benchmark::State &_state)
+{
+  // Benchmarks for the current updateOrigin implementation
+  Costmap2DLegacy map(1000, 1000, 0.01, 0, 0);
+  for (auto _ : _state)
+  {
+    for (int ii = 0; ii != 10; ++ii)
+    {
+      map.updateOrigin(map.getOriginX() + ii * 0.2, ii * 0.05);
+    }
+  }
+}
+
+static void
+perf_current(benchmark::State &_state)
+{
+  // Benchmarks for the current updateOrigin implementation
+  costmap_2d::Costmap2D map(1000, 1000, 0.01, 0, 0);
+  for (auto _ : _state)
+  {
+    for (int ii = 0; ii != 10; ++ii)
+    {
+      map.updateOrigin(map.getOriginX() + ii * 0.2, ii * 0.1);
+    }
+  }
+}
+
+// benchmarks comparing the tf product of transform with the eigen-based.
+BENCHMARK(perf_legacy);
+BENCHMARK(perf_current);
+
+BENCHMARK_MAIN();

--- a/costmap_2d/perf/update_origin_perf.cpp
+++ b/costmap_2d/perf/update_origin_perf.cpp
@@ -1,15 +1,16 @@
 #include <benchmark/benchmark.h>
 #include <costmap_2d/costmap_2d.h>
 
+#include <cmath>
+
+/// @brief Legacy version of the updateOrigin function used for comparing it with
+/// newer implementations.
 struct Costmap2DLegacy : public costmap_2d::Costmap2D
 {
 
   Costmap2DLegacy(unsigned int cells_size_x, unsigned int cells_size_y, double resolution,
                   double origin_x, double origin_y) : costmap_2d::Costmap2D(cells_size_x, cells_size_y, resolution, origin_x, origin_y) {}
 
-  // This code is the legacy version of the updateOrigin method. It's well proven
-  // and requires a temporal buffer for updating the costmap. Our tests will use
-  // this method as ground-truth.
   void updateOrigin(double new_origin_x, double new_origin_y) override
   {
     int cell_ox, cell_oy;

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -284,7 +284,7 @@ void Costmap2D::updateOrigin(double new_origin_x, double new_origin_y)
   if (std::abs(cell_ox) >= size_x_ || std::abs(cell_oy) >= size_y_)
   {
     // If the new and old maps don't overlap, we can just reset the costmap.
-    ROS_INFO("Maps don't overlap. Dropping entire data");
+    ROS_DEBUG("Maps don't overlap. Dropping entire data");
     resetMaps();
     return;
   }

--- a/costmap_2d/test/update_origin_test.cpp
+++ b/costmap_2d/test/update_origin_test.cpp
@@ -96,10 +96,10 @@ struct ParamCostmap2DFixture : public Costmap2DFixture,
 {
 };
 
-INSTANTIATE_TEST_SUITE_P(/**/,
-                         ParamCostmap2DFixture,
-                         testing::Combine(testing::Range(-0.1, 2.1, 0.55),
-                                          testing::Range(-0.1, 4.1, 0.44)));
+INSTANTIATE_TEST_CASE_P(/**/,
+                        ParamCostmap2DFixture,
+                        testing::Combine(testing::Range(-0.1, 2.1, 0.55),
+                                         testing::Range(-0.1, 4.1, 0.44)));
 
 TEST_P(ParamCostmap2DFixture, regression)
 {

--- a/costmap_2d/test/update_origin_test.cpp
+++ b/costmap_2d/test/update_origin_test.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
+#include <tuple>
 
 /// @brief Helper class which contains the legacy implementation of updateOrigin.
 struct Costmap2DLegacy : public costmap_2d::Costmap2D
@@ -91,13 +91,15 @@ TEST_F(Costmap2DFixture, no_update)
 }
 
 using coordinate = std::tuple<double, double>;
-struct ParamCostmap2DFixture : public Costmap2DFixture, public testing::WithParamInterface<coordinate>
+struct ParamCostmap2DFixture : public Costmap2DFixture,
+                               public testing::WithParamInterface<coordinate>
 {
 };
 
 INSTANTIATE_TEST_SUITE_P(/**/,
                          ParamCostmap2DFixture,
-                         testing::Combine(testing::Range(-0.1, 2.1, 0.55), testing::Range(-0.1, 4.1, 0.44)));
+                         testing::Combine(testing::Range(-0.1, 2.1, 0.55),
+                                          testing::Range(-0.1, 4.1, 0.44)));
 
 TEST_P(ParamCostmap2DFixture, regression)
 {

--- a/costmap_2d/test/update_origin_test.cpp
+++ b/costmap_2d/test/update_origin_test.cpp
@@ -1,0 +1,119 @@
+#include <costmap_2d/costmap_2d.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+/// @brief Helper class which contains the legacy implementation of updateOrigin.
+struct Costmap2DLegacy : public costmap_2d::Costmap2D
+{
+
+  Costmap2DLegacy(unsigned int cells_size_x, unsigned int cells_size_y, double resolution,
+                  double origin_x, double origin_y) : costmap_2d::Costmap2D(cells_size_x, cells_size_y, resolution, origin_x, origin_y) {}
+
+  // This code is the legacy version of the updateOrigin method. It's well proven
+  // and requires a temporal buffer for updating the costmap. Our tests will use
+  // this method as ground-truth.
+  void updateOrigin(double new_origin_x, double new_origin_y) override
+  {
+    int cell_ox, cell_oy;
+    cell_ox = int((new_origin_x - origin_x_) / resolution_);
+    cell_oy = int((new_origin_y - origin_y_) / resolution_);
+
+    if (cell_ox == 0 && cell_oy == 0)
+      return;
+
+    double new_grid_ox, new_grid_oy;
+    new_grid_ox = origin_x_ + cell_ox * resolution_;
+    new_grid_oy = origin_y_ + cell_oy * resolution_;
+
+    int size_x = size_x_;
+    int size_y = size_y_;
+
+    int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
+    lower_left_x = std::min(std::max(cell_ox, 0), size_x);
+    lower_left_y = std::min(std::max(cell_oy, 0), size_y);
+    upper_right_x = std::min(std::max(cell_ox + size_x, 0), size_x);
+    upper_right_y = std::min(std::max(cell_oy + size_y, 0), size_y);
+
+    unsigned int cell_size_x = upper_right_x - lower_left_x;
+    unsigned int cell_size_y = upper_right_y - lower_left_y;
+    unsigned char *local_map = new unsigned char[cell_size_x * cell_size_y];
+
+    copyMapRegion(costmap_, lower_left_x, lower_left_y, size_x_, local_map, 0, 0, cell_size_x, cell_size_x, cell_size_y);
+
+    resetMaps();
+
+    origin_x_ = new_grid_ox;
+    origin_y_ = new_grid_oy;
+
+    int start_x = lower_left_x - cell_ox;
+    int start_y = lower_left_y - cell_oy;
+
+    copyMapRegion(local_map, 0, 0, cell_size_x, costmap_, start_x, start_y, size_x_, cell_size_x, cell_size_y);
+    delete[] local_map;
+  }
+
+  bool operator==(const costmap_2d::Costmap2D &other) const
+  {
+    if (size_x_ != other.getSizeInCellsX() || size_y_ != other.getSizeInCellsY())
+      return false;
+    const auto size = size_x_ * size_y_;
+    return std::equal(costmap_, costmap_ + size, other.getCharMap());
+  }
+};
+
+/// @brief Fixture which will provide a costmap to test.
+struct Costmap2DFixture : public testing::Test
+{
+  Costmap2DLegacy map_;
+  Costmap2DFixture() : map_(10, 20, 0.1, 1, 2)
+  {
+    // Fill the map with some data.
+    const size_t size = map_.getSizeInCellsX() * map_.getSizeInCellsY();
+    auto data = map_.getCharMap();
+    for (size_t ii = 0; ii != size; ++ii, ++data)
+    {
+      // this will overflow - but its fine.
+      *data = ii;
+    }
+  }
+};
+
+TEST_F(Costmap2DFixture, no_update)
+{
+  // Verify that if there is no update, the data does not change.
+  costmap_2d::Costmap2D copy_map(map_);
+
+  map_.updateOrigin(map_.getOriginX(), map_.getOriginY());
+  ASSERT_EQ(map_, copy_map);
+}
+
+using coordinate = std::tuple<double, double>;
+struct ParamCostmap2DFixture : public Costmap2DFixture, public testing::WithParamInterface<coordinate>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(/**/,
+                         ParamCostmap2DFixture,
+                         testing::Combine(testing::Range(-0.1, 2.1, 0.55), testing::Range(-0.1, 4.1, 0.44)));
+
+TEST_P(ParamCostmap2DFixture, regression)
+{
+  // Verfies that the updateOrigin produces the same result as the legacy version.
+  const auto param = GetParam();
+  const auto x = std::get<0>(param);
+  const auto y = std::get<1>(param);
+  costmap_2d::Costmap2D copy_map(map_);
+  map_.updateOrigin(x, y);
+  copy_map.updateOrigin(x, y);
+
+  ASSERT_EQ(map_, copy_map);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Hey, 
I've noticed that the updateOrigin function would always create a local copy of the window... I've rewrote the function such that it can do the update inplace without the extra buffer. This gives some nice performance boost (more prominent for larger costmaps, in the supplied perf-flle ~30%).

Bonus: fixup the assignment operator. 

Best, 
Dima