### PR TITLE
avoid copying of data when dealing with observations

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -183,6 +183,9 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(array_parser_test test/array_parser_test.cpp)
   target_link_libraries(array_parser_test costmap_2d)
 
+  catkin_add_gtest(observation_buffer_test test/observation_buffer_test.cpp)
+  target_link_libraries(observation_buffer_test costmap_2d)
+
   catkin_add_gtest(coordinates_test test/coordinates_test.cpp)
   target_link_libraries(coordinates_test costmap_2d)
 endif()

--- a/costmap_2d/include/costmap_2d/observation.h
+++ b/costmap_2d/include/costmap_2d/observation.h
@@ -49,52 +49,29 @@ public:
   /**
    * @brief  Creates an empty observation
    */
-  Observation() :
-    cloud_(new sensor_msgs::PointCloud2()), obstacle_range_(0.0), raytrace_range_(0.0)
+  Observation() : obstacle_range_(0.0), raytrace_range_(0.0)
   {
   }
 
-  virtual ~Observation()
-  {
-    delete cloud_;
-  }
+  // Keep virtual desctructor in case anyone goes for polymorphism.
+  virtual ~Observation() = default;
 
   /**
    * @brief  Creates an observation from an origin point and a point cloud
    * @param origin The origin point of the observation
    * @param cloud The point cloud of the observation
-   * @param obstacle_range The range out to which an observation should be able to insert obstacles
-   * @param raytrace_range The range out to which an observation should be able to clear via raytracing
+   * @param obstacle_range The range up to which an observation should be able to insert obstacles
+   * @param raytrace_range The range up to which an observation should be able to clear via raytracing
    */
-  Observation(geometry_msgs::Point& origin, const sensor_msgs::PointCloud2 &cloud,
+  Observation(const geometry_msgs::Point& origin, const sensor_msgs::PointCloud2ConstPtr &cloud,
               double obstacle_range, double raytrace_range) :
-      origin_(origin), cloud_(new sensor_msgs::PointCloud2(cloud)),
+      origin_(origin), cloud_(cloud),
       obstacle_range_(obstacle_range), raytrace_range_(raytrace_range)
   {
   }
 
-  /**
-   * @brief  Copy constructor
-   * @param obs The observation to copy
-   */
-  Observation(const Observation& obs) :
-      origin_(obs.origin_), cloud_(new sensor_msgs::PointCloud2(*(obs.cloud_))),
-      obstacle_range_(obs.obstacle_range_), raytrace_range_(obs.raytrace_range_)
-  {
-  }
-
-  /**
-   * @brief  Creates an observation from a point cloud
-   * @param cloud The point cloud of the observation
-   * @param obstacle_range The range out to which an observation should be able to insert obstacles
-   */
-  Observation(const sensor_msgs::PointCloud2 &cloud, double obstacle_range) :
-      cloud_(new sensor_msgs::PointCloud2(cloud)), obstacle_range_(obstacle_range), raytrace_range_(0.0)
-  {
-  }
-
   geometry_msgs::Point origin_;
-  sensor_msgs::PointCloud2* cloud_;
+  sensor_msgs::PointCloud2ConstPtr cloud_;
   double obstacle_range_, raytrace_range_;
 };
 

--- a/costmap_2d/include/costmap_2d/observation_buffer.h
+++ b/costmap_2d/include/costmap_2d/observation_buffer.h
@@ -51,6 +51,18 @@
 
 namespace costmap_2d
 {
+
+/**
+ * @brief Applies a box filter to the given cloud.
+ * 
+ * Filter will remove points which are higher than _max_z or lower than _min_z.
+ * 
+ * @param _cloud The point cloud to filter.
+ * @param _min_z The lower threshold.
+ * @param _max_z The upper threshold.
+ */
+void heightFilterPointCloud(sensor_msgs::PointCloud2& _cloud, double _min_z, double _max_z);
+
 /**
  * @class ObservationBuffer
  * @brief Takes in point clouds from sensors, transforms them to the desired frame, and stores them

--- a/costmap_2d/include/costmap_2d/testing_helper.h
+++ b/costmap_2d/include/costmap_2d/testing_helper.h
@@ -66,13 +66,13 @@ costmap_2d::ObstacleLayer* addObstacleLayer(costmap_2d::LayeredCostmap& layers, 
 
 void addObservation(costmap_2d::ObstacleLayer* olayer, double x, double y, double z = 0.0,
                     double ox = 0.0, double oy = 0.0, double oz = MAX_Z){
-  sensor_msgs::PointCloud2 cloud;
-  sensor_msgs::PointCloud2Modifier modifier(cloud);
+  sensor_msgs::PointCloud2Ptr cloud(new sensor_msgs::PointCloud2{});
+  sensor_msgs::PointCloud2Modifier modifier(*cloud);
   modifier.setPointCloud2FieldsByString(1, "xyz");
   modifier.resize(1);
-  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
+  sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud, "z");
   *iter_x = x;
   *iter_y = y;
   *iter_z = z;

--- a/costmap_2d/test/observation_buffer_test.cpp
+++ b/costmap_2d/test/observation_buffer_test.cpp
@@ -1,0 +1,215 @@
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <costmap_2d/observation_buffer.h>
+
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/PointCloud.h>
+#include <sensor_msgs/point_cloud_conversion.h>
+#include <geometry_msgs/Point32.h>
+
+#include <algorithm>
+#include <set>
+#include <utility>
+
+/**
+ * @brief Compares the points giving x precedence over y and y precedence over z.
+ */
+struct compare_points
+{
+  bool operator()(const geometry_msgs::Point32 &l, const geometry_msgs::Point32 &r) const
+  {
+    if (l.x == r.x)
+    {
+      if (l.y == r.y)
+        return l.z < r.z;
+      return l.y < r.y;
+    }
+    return l.x < r.x;
+  }
+};
+
+/**
+ * @brief Sorts the points using the compare_points functor.
+ */
+std::set<geometry_msgs::Point32, compare_points>
+sort_points(const sensor_msgs::PointCloud &cloud)
+{
+  std::set<geometry_msgs::Point32, compare_points> sorted_points;
+  for (const auto &p : cloud.points)
+    sorted_points.insert(p);
+
+  return sorted_points;
+}
+
+bool equal(const sensor_msgs::PointCloud &l, const sensor_msgs::PointCloud &r)
+{
+  // Sort the points.
+  const auto l_points = sort_points(l);
+  const auto r_points = sort_points(r);
+
+  // Compare the results.
+  return l_points == r_points;
+}
+
+TEST(heightFilterPointCloud, empty)
+{
+  sensor_msgs::PointCloud2 input;
+  ASSERT_NO_THROW(costmap_2d::heightFilterPointCloud(input, 0, 1));
+}
+
+TEST(heightFilterPointCloud, no_z)
+{
+  sensor_msgs::PointCloud2 input;
+  input.point_step = 1;
+  ASSERT_NO_THROW(costmap_2d::heightFilterPointCloud(input, 0, 1));
+}
+
+/**
+ * @brief A copying version of the box-filter.
+ * 
+ * @param _cloud2 The point-cloud to copy.
+ * @param _min_x The lower bound.
+ * @param _max_x The upper bound.
+ */
+void copyingHeightFilterPointCloud(sensor_msgs::PointCloud &_cloud,
+                                   double _min_z, double _max_z)
+{
+  sensor_msgs::PointCloud out = _cloud;
+  auto dd = out.points.begin();
+
+  for (auto ss = _cloud.points.begin(); ss != _cloud.points.end(); ++ss)
+  {
+    if (ss->z <= _max_z && ss->z >= _min_z)
+    {
+      *dd = *ss;
+      ++dd;
+    }
+  }
+
+  out.points.erase(dd, out.points.end());
+  _cloud = out;
+}
+
+TEST(heightFilterPointCloud, no_change)
+{
+  // Create a simple point cloud
+  sensor_msgs::PointCloud points, output;
+  points.points.resize(100);
+
+  double x = 0;
+  for (auto &p : points.points)
+  {
+    p.x = ++x;
+    p.z = 1;
+  }
+
+  sensor_msgs::PointCloud2 input;
+  sensor_msgs::convertPointCloudToPointCloud2(points, input);
+  costmap_2d::heightFilterPointCloud(input, 0, 2);
+
+  ASSERT_TRUE(sensor_msgs::convertPointCloud2ToPointCloud(input, output));
+
+  // We should keep everything.
+  ASSERT_EQ(points, output);
+}
+
+/// The base fixture defining a pair (min_z, max_z) as parameter.
+struct FilterFixture : public testing::TestWithParam<std::pair<double, double>>
+{
+};
+
+using RemoveAllFixture = FilterFixture;
+INSTANTIATE_TEST_CASE_P(/**/, RemoveAllFixture,
+                        testing::Values(
+                            std::make_pair(0., 1.9), // all values above
+                            std::make_pair(2.1, 3.)  // all values below
+                            ));
+
+TEST_P(RemoveAllFixture, regression)
+{
+  // Create a point cloud with uniform points.
+  sensor_msgs::PointCloud points, output;
+  geometry_msgs::Point32 point;
+  point.z = 2;
+  points.points.resize(100, point);
+
+  // Apply the filter.
+  sensor_msgs::PointCloud2 input;
+  sensor_msgs::convertPointCloudToPointCloud2(points, input);
+  const auto param = GetParam();
+  costmap_2d::heightFilterPointCloud(input, param.first, param.second);
+
+  ASSERT_TRUE(sensor_msgs::convertPointCloud2ToPointCloud(input, output));
+
+  // We should remove everything.
+  ASSERT_TRUE(output.points.empty());
+}
+
+using KeepSomeFixture = FilterFixture;
+INSTANTIATE_TEST_CASE_P(/**/, KeepSomeFixture,
+                        testing::Values(
+                            std::make_pair(0., 1.),  // keep lower first half
+                            std::make_pair(1., 3.),  // keep second half
+                            std::make_pair(0.5, 1.5) // keep middle
+                            ));
+
+TEST_P(KeepSomeFixture, regression)
+{
+  // Create a point cloud with different x and z values.
+  sensor_msgs::PointCloud points, output;
+  points.points.resize(100);
+
+  double x = 0;
+  for (auto &p : points.points)
+  {
+    p.x = ++x;
+    p.z = x * 0.02;
+  }
+
+  // Shuffle the points
+  std::random_shuffle(points.points.begin(), points.points.end());
+
+  // Apply the filter.
+  sensor_msgs::PointCloud2 input;
+  sensor_msgs::convertPointCloudToPointCloud2(points, input);
+  const auto param = GetParam();
+  costmap_2d::heightFilterPointCloud(input, param.first, param.second);
+
+  ASSERT_TRUE(sensor_msgs::convertPointCloud2ToPointCloud(input, output));
+
+  // Apply the copying filter
+  copyingHeightFilterPointCloud(points, param.first, param.second);
+
+  ASSERT_TRUE(equal(points, output));
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/costmap_2d/test/observation_buffer_test.cpp
+++ b/costmap_2d/test/observation_buffer_test.cpp
@@ -92,9 +92,9 @@ TEST(heightFilterPointCloud, no_z)
 /**
  * @brief A copying version of the box-filter.
  * 
- * @param _cloud2 The point-cloud to copy.
- * @param _min_x The lower bound.
- * @param _max_x The upper bound.
+ * @param _cloud The point-cloud to filter.
+ * @param _min_z The lower bound.
+ * @param _max_z The upper bound.
  */
 void copyingHeightFilterPointCloud(sensor_msgs::PointCloud &_cloud,
                                    double _min_z, double _max_z)
@@ -117,7 +117,7 @@ void copyingHeightFilterPointCloud(sensor_msgs::PointCloud &_cloud,
 
 TEST(heightFilterPointCloud, no_change)
 {
-  // Create a simple point cloud
+  // Create a simple point cloud.
   sensor_msgs::PointCloud points, output;
   points.points.resize(100);
 
@@ -191,7 +191,7 @@ TEST_P(KeepSomeFixture, regression)
     p.z = x * 0.02;
   }
 
-  // Shuffle the points
+  // Shuffle the points.
   std::random_shuffle(points.points.begin(), points.points.end());
 
   // Apply the filter.


### PR DESCRIPTION
Hey,

I've noticed that we create a deep copy of the point clouds every time we are querying to get the observations. I've exchanged the raw pointer to a const shared pointer (we do not modify the observations).

Additionally I've changed the box-filter algorithm to work without an additional buffer.

The changes reduced the CPU load of a mbf-node (just running the voxel layer) on my system by ~7% (its not much, but...)

Best,
Dima