### PR TITLE
clear already reported observations

### DIFF
--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -191,15 +191,14 @@ void ObservationBuffer::bufferCloud(const sensor_msgs::PointCloud2& cloud)
 // returns a copy of the observations
 void ObservationBuffer::getObservations(vector<Observation>& observations)
 {
-  // first... let's make sure that we don't have any stale observations
-  purgeStaleObservations();
-
   // now we'll just copy the observations for the caller
   list<Observation>::iterator obs_it;
   for (obs_it = observation_list_.begin(); obs_it != observation_list_.end(); ++obs_it)
   {
     observations.push_back(*obs_it);
   }
+
+  observation_list_.clear();
 }
 
 void ObservationBuffer::purgeStaleObservations()


### PR DESCRIPTION
Hey,

The current getObsevation function calls purgeStaleObservation - this function is in the current state a noop, since we don't update the last_updated_ time (as addressed in #1114).

The other change is clearing already reported observations. Currently, for observation_persistence larger than the update_frequency, same points would be painted onto the observation layer. I think it makes sense to drop the observations already incorporated into the costmap.

Best,
Dima