### PR TITLE
Make costmap size use double instead of int

### DIFF
--- a/costmap_2d/cfg/Costmap2D.cfg
+++ b/costmap_2d/cfg/Costmap2D.cfg
@@ -9,8 +9,8 @@ gen.add("update_frequency", double_t, 0, "The frequency in Hz for the map to be 
 gen.add("publish_frequency", double_t, 0, "The frequency in Hz for the map to publish display information.", 0, 0, 100)
 
 #map params
-gen.add("width", int_t, 0, "The width of the map in meters.", 10, 0)
-gen.add("height", int_t, 0, "The height of the map in meters.", 10, 0)
+gen.add("width", double_t, 0, "The width of the map in meters.", 10, 0)
+gen.add("height", double_t, 0, "The height of the map in meters.", 10, 0)
 gen.add("resolution", double_t, 0, "The resolution of the map in meters/cell.", 0.05, 0, 50)
 gen.add("origin_x", double_t, 0, "The x origin of the map in the global frame in meters.", 0)
 gen.add("origin_y", double_t, 0, "The y origin of the map in the global frame in meters.", 0)


### PR DESCRIPTION
Not sure if this is a bug but I don't see any reason not to use a double for the costmap size.
The getSizeInMeters calls also use double as a return type.
I'm working on a small vehicle where a size of less than a meter would come in handy.
