### PR TITLE
fix crashes in AMCL

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1294,7 +1294,7 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
       range_min = laser_scan->range_min;
 
     if(ldata.range_max <= 0.0 || range_min < 0.0) {
-      ROS_ERROR("range_max or range_min from laser is negetive! ignore this message.");
+      ROS_ERROR("range_max or range_min from laser is negative! ignore this message.");
       return; // ignore this.
     }
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1292,6 +1292,12 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
       range_min = std::max(laser_scan->range_min, (float)laser_min_range_);
     else
       range_min = laser_scan->range_min;
+
+    if(ldata.range_max <= 0.0 || range_min < 0.0) {
+      ROS_ERROR("range_max or range_min from laser is negetive! ignore this message.");
+      return; // ignore this.
+    }
+
     // The AMCLLaserData destructor will free this memory
     ldata.ranges = new double[ldata.range_count][2];
     ROS_ASSERT(ldata.ranges);
@@ -1301,6 +1307,8 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
       // readings to max range.
       if(laser_scan->ranges[i] <= range_min)
         ldata.ranges[i][0] = ldata.range_max;
+      else if(laser_scan->ranges[i] > ldata.range_max)
+        ldata.ranges[i][0] = std::numeric_limits<decltype(ldata.range_max)>::max();
       else
         ldata.ranges[i][0] = laser_scan->ranges[i];
       // Compute bearing

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -262,7 +262,7 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& mess
   }
   catch (std::runtime_error &ex)
   {
-    ROS_WARN("transformLaserScanToPointCloud error, it seems the message from laser sensor is malformed. Ignore this message. what(): %s", ex.what());
+    ROS_WARN("transformLaserScanToPointCloud error, it seems the message from laser sensor is malformed. Ignore this laser scan. what(): %s", ex.what());
     return; //ignore this message
   }
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -304,7 +304,7 @@ void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstP
   }
   catch (std::runtime_error &ex)
   {
-    ROS_WARN("transformLaserScanToPointCloud error, it seems the message from laser sensor is malformed. Ignore this message. what(): %s", ex.what());
+    ROS_WARN("transformLaserScanToPointCloud error, it seems the message from laser sensor is malformed. Ignore this laser scan. what(): %s", ex.what());
     return; //ignore this message
   }
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -260,6 +260,11 @@ void ObstacleLayer::laserScanCallback(const sensor_msgs::LaserScanConstPtr& mess
              ex.what());
     projector_.projectLaser(*message, cloud);
   }
+  catch (std::runtime_error &ex)
+  {
+    ROS_WARN("transformLaserScanToPointCloud error, it seems the message from laser sensor is malformed. Ignore this message. what(): %s", ex.what());
+    return; //ignore this message
+  }
 
   // buffer the point cloud
   buffer->lock();

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -302,6 +302,11 @@ void ObstacleLayer::laserScanValidInfCallback(const sensor_msgs::LaserScanConstP
              global_frame_.c_str(), ex.what());
     projector_.projectLaser(message, cloud);
   }
+  catch (std::runtime_error &ex)
+  {
+    ROS_WARN("transformLaserScanToPointCloud error, it seems the message from laser sensor is malformed. Ignore this message. what(): %s", ex.what());
+    return; //ignore this message
+  }
 
   // buffer the point cloud
   buffer->lock();


### PR DESCRIPTION
fix #1151 about move_base crashes.

if the LaserScan.msg is malformed, the move_base will crash.
sensor_msgs/LaserScan.msg:
std_msgs/Header header
float32 angle_min
float32 angle_max
float32 angle_increment
float32 time_increment **#it seems the value is below zero or beyond INT_MAX, roscore will throw a runtime_error.**
float32 scan_time
float32 range_min
float32 range_max
float32[] ranges
float32[] intensities

in roscpp_core/rostime/include/ros/impl/duration.h
`
    if (sec64 < std::numeric_limits<int32_t>::min() || sec64 > std::numeric_limits<int32_t>::max())`
`
      throw std::runtime_error("Duration is out of dual 32-bit range")
`

in roscpp_core/rostime/include/ros/impl/time.h
`
      if (sec64 < 0 || sec64 > std::numeric_limits<uint32_t>::max())`
`
        throw std::runtime_error("Time is out of dual 32-bit range");
`

before fix:
![image](https://user-images.githubusercontent.com/38713965/127674464-e83d3b99-5ea4-471d-a0c2-0c7deb5a2373.png)


after fix:
![image](https://user-images.githubusercontent.com/38713965/127675504-af254d3b-f1d3-47b1-96f1-a3596c30726d.png)
