### PR TITLE
use boost::placeholders::_N instead of deprecated _N

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -4,10 +4,6 @@ project(amcl)
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
-endif()
-
 find_package(catkin REQUIRED
   COMPONENTS
     diagnostic_updater

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -26,7 +26,7 @@
 #include <cmath>
 #include <memory>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 // Signal handling
@@ -486,7 +486,7 @@ AmclNode::AmclNode() :
                                                              100,
                                                              nh_);
   laser_scan_filter_->registerCallback(boost::bind(&AmclNode::laserReceived,
-                                                   this, _1));
+                                                   this, boost::placeholders::_1));
   initial_pose_sub_ = nh_.subscribe("initialpose", 2, &AmclNode::initialPoseReceived, this);
 
   if(use_map_topic_) {
@@ -498,13 +498,13 @@ AmclNode::AmclNode() :
   m_force_update = false;
 
   dsrv_ = new dynamic_reconfigure::Server<amcl::AMCLConfig>(ros::NodeHandle("~"));
-  dynamic_reconfigure::Server<amcl::AMCLConfig>::CallbackType cb = boost::bind(&AmclNode::reconfigureCB, this, _1, _2);
+  dynamic_reconfigure::Server<amcl::AMCLConfig>::CallbackType cb = boost::bind(&AmclNode::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
   dsrv_->setCallback(cb);
 
   // 15s timer to warn on lack of receipt of laser scans, #5209
   laser_check_interval_ = ros::Duration(15.0);
   check_laser_timer_ = nh_.createTimer(laser_check_interval_, 
-                                       boost::bind(&AmclNode::checkLaserReceived, this, _1));
+                                       boost::bind(&AmclNode::checkLaserReceived, this, boost::placeholders::_1));
 
   diagnosic_updater_.setHardwareID("None");
   diagnosic_updater_.add("Standard deviation", this, &AmclNode::standardDeviationDiagnostics);
@@ -661,7 +661,7 @@ void AmclNode::reconfigureCB(AMCLConfig &config, uint32_t level)
                                                              100,
                                                              nh_);
   laser_scan_filter_->registerCallback(boost::bind(&AmclNode::laserReceived,
-                                                   this, _1));
+                                                   this, boost::placeholders::_1));
 
   initial_pose_sub_ = nh_.subscribe("initialpose", 2, &AmclNode::initialPoseReceived, this);
 }

--- a/base_local_planner/src/odometry_helper_ros.cpp
+++ b/base_local_planner/src/odometry_helper_ros.cpp
@@ -94,7 +94,7 @@ void OdometryHelperRos::setOdomTopic(std::string odom_topic)
     if( odom_topic_ != "" )
     {
       ros::NodeHandle gn;
-      odom_sub_ = gn.subscribe<nav_msgs::Odometry>( odom_topic_, 1, boost::bind( &OdometryHelperRos::odomCallback, this, _1 ));
+      odom_sub_ = gn.subscribe<nav_msgs::Odometry>( odom_topic_, 1, boost::bind( &OdometryHelperRos::odomCallback, this, boost::placeholders::_1 ));
     }
     else
     {

--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -48,7 +48,7 @@
 
 #include <ros/console.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <base_local_planner/goal_functions.h>
 #include <nav_msgs/Path.h>

--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -256,11 +256,13 @@ namespace base_local_planner {
           max_vel_x, min_vel_x, max_vel_th_, min_vel_th_, min_in_place_vel_th_, backup_vel,
           dwa, heading_scoring, heading_scoring_timestep, meter_scoring, simple_attractor, y_vels, stop_time_buffer, sim_period_, angular_sim_granularity);
 
-      map_viz_.initialize(name, global_frame_, boost::bind(&TrajectoryPlanner::getCellCosts, tc_, _1, _2, _3, _4, _5, _6));
+      map_viz_.initialize(name, global_frame_, boost::bind(&TrajectoryPlanner::getCellCosts, tc_,
+        boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3,
+        boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6));
       initialized_ = true;
 
       dsrv_ = new dynamic_reconfigure::Server<BaseLocalPlannerConfig>(private_nh);
-      dynamic_reconfigure::Server<BaseLocalPlannerConfig>::CallbackType cb = boost::bind(&TrajectoryPlannerROS::reconfigureCB, this, _1, _2);
+      dynamic_reconfigure::Server<BaseLocalPlannerConfig>::CallbackType cb = boost::bind(&TrajectoryPlannerROS::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
       dsrv_->setCallback(cb);
 
     } else {

--- a/carrot_planner/src/carrot_planner.cpp
+++ b/carrot_planner/src/carrot_planner.cpp
@@ -36,7 +36,7 @@
 *********************************************************************/
 #include <angles/angles.h>
 #include <carrot_planner/carrot_planner.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -35,7 +35,7 @@
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
 #include <clear_costmap_recovery/clear_costmap_recovery.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <boost/pointer_cast.hpp>
 #include <vector>
 

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -84,7 +84,7 @@ void InflationLayer::onInitialize()
     need_reinflation_ = false;
 
     dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig>::CallbackType cb = boost::bind(
-        &InflationLayer::reconfigureCB, this, _1, _2);
+        &InflationLayer::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
 
     if (dsrv_ != NULL){
       dsrv_->clearCallback();

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -40,7 +40,7 @@
 #include <costmap_2d/costmap_math.h>
 #include <costmap_2d/footprint.h>
 #include <boost/thread.hpp>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(costmap_2d::InflationLayer, costmap_2d::Layer)
 

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -39,7 +39,7 @@
 #include <costmap_2d/costmap_math.h>
 #include <tf2_ros/message_filter.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <sensor_msgs/point_cloud2_iterator.h>
 
 PLUGINLIB_EXPORT_CLASS(costmap_2d::ObstacleLayer, costmap_2d::Layer)

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -158,12 +158,12 @@ void ObstacleLayer::onInitialize()
 
       if (inf_is_valid)
       {
-        filter->registerCallback(boost::bind(&ObstacleLayer::laserScanValidInfCallback, this, _1,
+        filter->registerCallback(boost::bind(&ObstacleLayer::laserScanValidInfCallback, this, boost::placeholders::_1,
                                             observation_buffers_.back()));
       }
       else
       {
-        filter->registerCallback(boost::bind(&ObstacleLayer::laserScanCallback, this, _1, observation_buffers_.back()));
+        filter->registerCallback(boost::bind(&ObstacleLayer::laserScanCallback, this, boost::placeholders::_1, observation_buffers_.back()));
       }
 
       observation_subscribers_.push_back(sub);
@@ -184,7 +184,7 @@ void ObstacleLayer::onInitialize()
         boost::shared_ptr < tf2_ros::MessageFilter<sensor_msgs::PointCloud>
         > filter(new tf2_ros::MessageFilter<sensor_msgs::PointCloud>(*sub, *tf_, global_frame_, 50, g_nh));
         filter->registerCallback(
-          boost::bind(&ObstacleLayer::pointCloudCallback, this, _1, observation_buffers_.back()));
+          boost::bind(&ObstacleLayer::pointCloudCallback, this, boost::placeholders::_1, observation_buffers_.back()));
 
       observation_subscribers_.push_back(sub);
       observation_notifiers_.push_back(filter);
@@ -202,7 +202,7 @@ void ObstacleLayer::onInitialize()
       boost::shared_ptr < tf2_ros::MessageFilter<sensor_msgs::PointCloud2>
       > filter(new tf2_ros::MessageFilter<sensor_msgs::PointCloud2>(*sub, *tf_, global_frame_, 50, g_nh));
       filter->registerCallback(
-          boost::bind(&ObstacleLayer::pointCloud2Callback, this, _1, observation_buffers_.back()));
+          boost::bind(&ObstacleLayer::pointCloud2Callback, this, boost::placeholders::_1, observation_buffers_.back()));
 
       observation_subscribers_.push_back(sub);
       observation_notifiers_.push_back(filter);
@@ -225,7 +225,7 @@ void ObstacleLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
 {
   dsrv_ = new dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig>(nh);
   dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig>::CallbackType cb = boost::bind(
-      &ObstacleLayer::reconfigureCB, this, _1, _2);
+      &ObstacleLayer::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
   dsrv_->setCallback(cb);
 }
 

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -119,7 +119,7 @@ void StaticLayer::onInitialize()
 
   dsrv_ = new dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>(nh);
   dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb = boost::bind(
-      &StaticLayer::reconfigureCB, this, _1, _2);
+      &StaticLayer::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
   dsrv_->setCallback(cb);
 }
 

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -38,7 +38,7 @@
  *********************************************************************/
 #include <costmap_2d/static_layer.h>
 #include <costmap_2d/costmap_math.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <tf2/convert.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -36,7 +36,7 @@
  *         David V. Lu!!
  *********************************************************************/
 #include <costmap_2d/voxel_layer.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <sensor_msgs/point_cloud2_iterator.h>
 
 #define VOXEL_BITS 16

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -68,7 +68,7 @@ void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
 {
   voxel_dsrv_ = new dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>(nh);
   dynamic_reconfigure::Server<costmap_2d::VoxelPluginConfig>::CallbackType cb = boost::bind(
-      &VoxelLayer::reconfigureCB, this, _1, _2);
+      &VoxelLayer::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
   voxel_dsrv_->setCallback(cb);
 }
 

--- a/costmap_2d/src/costmap_2d_cloud.cpp
+++ b/costmap_2d/src/costmap_2d_cloud.cpp
@@ -199,7 +199,7 @@ int main(int argc, char** argv)
   ros::Publisher pub_marked = n.advertise < sensor_msgs::PointCloud > ("voxel_marked_cloud", 2);
   ros::Publisher pub_unknown = n.advertise < sensor_msgs::PointCloud > ("voxel_unknown_cloud", 2);
   ros::Subscriber sub = n.subscribe < costmap_2d::VoxelGrid
-      > ("voxel_grid", 1, boost::bind(voxelCallback, pub_marked, pub_unknown, _1));
+      > ("voxel_grid", 1, boost::bind(voxelCallback, pub_marked, pub_unknown, boost::placeholders::_1));
 
   ros::spin();
 

--- a/costmap_2d/src/costmap_2d_markers.cpp
+++ b/costmap_2d/src/costmap_2d_markers.cpp
@@ -146,7 +146,7 @@ int main(int argc, char** argv)
   ROS_DEBUG("Startup");
 
   ros::Publisher pub = n.advertise < visualization_msgs::Marker > ("visualization_marker", 1);
-  ros::Subscriber sub = n.subscribe < costmap_2d::VoxelGrid > ("voxel_grid", 1, boost::bind(voxelCallback, pub, _1));
+  ros::Subscriber sub = n.subscribe < costmap_2d::VoxelGrid > ("voxel_grid", 1, boost::bind(voxelCallback, pub, boost::placeholders::_1));
   g_marker_ns = n.resolveName("voxel_grid");
 
   ros::spin();

--- a/costmap_2d/src/costmap_2d_publisher.cpp
+++ b/costmap_2d/src/costmap_2d_publisher.cpp
@@ -35,7 +35,7 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <costmap_2d/costmap_2d_publisher.h>
 #include <costmap_2d/cost_values.h>
 
@@ -50,7 +50,7 @@ Costmap2DPublisher::Costmap2DPublisher(ros::NodeHandle * ros_node, Costmap2D* co
     always_send_full_costmap_(always_send_full_costmap)
 {
   costmap_pub_ = ros_node->advertise<nav_msgs::OccupancyGrid>(topic_name, 1,
-                                                    boost::bind(&Costmap2DPublisher::onNewSubscription, this, _1));
+                                                    boost::bind(&Costmap2DPublisher::onNewSubscription, this, boost::placeholders::_1));
   costmap_update_pub_ = ros_node->advertise<map_msgs::OccupancyGridUpdate>(topic_name + "_updates", 1);
 
   if (cost_translation_table_ == NULL)

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -172,8 +172,8 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
   timer_ = private_nh.createTimer(ros::Duration(.1), &Costmap2DROS::movementCB, this);
 
   dsrv_ = new dynamic_reconfigure::Server<Costmap2DConfig>(ros::NodeHandle("~/" + name));
-  dynamic_reconfigure::Server<Costmap2DConfig>::CallbackType cb = boost::bind(&Costmap2DROS::reconfigureCB, this, _1,
-                                                                              _2);
+  dynamic_reconfigure::Server<Costmap2DConfig>::CallbackType cb = boost::bind(&Costmap2DROS::reconfigureCB, this, boost::placeholders::_1,
+                                                                              boost::placeholders::_2);
   dsrv_->setCallback(cb);
 }
 

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -154,7 +154,9 @@ namespace dwa_local_planner {
 
 
     private_nh.param("publish_cost_grid_pc", publish_cost_grid_pc_, false);
-    map_viz_.initialize(name, planner_util->getGlobalFrame(), boost::bind(&DWAPlanner::getCellCosts, this, _1, _2, _3, _4, _5, _6));
+    map_viz_.initialize(name, planner_util->getGlobalFrame(), boost::bind(&DWAPlanner::getCellCosts, this,
+        boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3,
+        boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6));
 
     private_nh.param("global_frame_id", frame_id_, std::string("odom"));
 

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -41,7 +41,7 @@
 
 #include <ros/console.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include <base_local_planner/goal_functions.h>
 #include <nav_msgs/Path.h>

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -131,7 +131,7 @@ namespace dwa_local_planner {
       nav_core::warnRenamedParameter(private_nh, "theta_stopped_vel", "rot_stopped_vel");
 
       dsrv_ = new dynamic_reconfigure::Server<DWAPlannerConfig>(private_nh);
-      dynamic_reconfigure::Server<DWAPlannerConfig>::CallbackType cb = boost::bind(&DWAPlannerROS::reconfigureCB, this, _1, _2);
+      dynamic_reconfigure::Server<DWAPlannerConfig>::CallbackType cb = boost::bind(&DWAPlannerROS::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
       dsrv_->setCallback(cb);
     }
     else{
@@ -297,7 +297,7 @@ namespace dwa_local_planner {
           &planner_util_,
           odom_helper_,
           current_pose_,
-          boost::bind(&DWAPlanner::checkTrajectory, dp_, _1, _2, _3));
+          boost::bind(&DWAPlanner::checkTrajectory, dp_, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
     } else {
       bool isOk = dwaComputeVelocityCommands(current_pose_, cmd_vel);
       if (isOk) {

--- a/fake_localization/fake_localization.cpp
+++ b/fake_localization/fake_localization.cpp
@@ -123,12 +123,12 @@ class FakeOdomNode
       stuff_sub_ = nh.subscribe("base_pose_ground_truth", 100, &FakeOdomNode::stuffFilter, this);
       filter_sub_ = new message_filters::Subscriber<nav_msgs::Odometry>(nh, "", 100);
       filter_ = new tf2_ros::MessageFilter<nav_msgs::Odometry>(*filter_sub_, *m_tfBuffer, base_frame_id_, 100, nh);
-      filter_->registerCallback(boost::bind(&FakeOdomNode::update, this, _1));
+      filter_->registerCallback(boost::bind(&FakeOdomNode::update, this, boost::placeholders::_1));
 
       // subscription to "2D Pose Estimate" from RViz:
       m_initPoseSub = new message_filters::Subscriber<geometry_msgs::PoseWithCovarianceStamped>(nh, "initialpose", 1);
       m_initPoseFilter = new tf2_ros::MessageFilter<geometry_msgs::PoseWithCovarianceStamped>(*m_initPoseSub, *m_tfBuffer, global_frame_id_, 1, nh);
-      m_initPoseFilter->registerCallback(boost::bind(&FakeOdomNode::initPoseReceived, this, _1));
+      m_initPoseFilter->registerCallback(boost::bind(&FakeOdomNode::initPoseReceived, this, boost::placeholders::_1));
     }
 
     ~FakeOdomNode(void)

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -36,7 +36,7 @@
  *         David V. Lu!!
  *********************************************************************/
 #include <global_planner/planner_core.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <costmap_2d/cost_values.h>
 #include <costmap_2d/costmap_2d.h>
 

--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -150,7 +150,7 @@ void GlobalPlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
 
         dsrv_ = new dynamic_reconfigure::Server<global_planner::GlobalPlannerConfig>(ros::NodeHandle("~/" + name));
         dynamic_reconfigure::Server<global_planner::GlobalPlannerConfig>::CallbackType cb = boost::bind(
-                &GlobalPlanner::reconfigureCB, this, _1, _2);
+                &GlobalPlanner::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
         dsrv_->setCallback(cb);
 
         initialized_ = true;

--- a/map_server/test/rtest.cpp
+++ b/map_server/test/rtest.cpp
@@ -97,7 +97,7 @@ TEST_F(MapClientTest, call_service)
 /* Try to retrieve the map via topic, and compare to ground truth */
 TEST_F(MapClientTest, subscribe_topic)
 {
-  ros::Subscriber sub = n_->subscribe<nav_msgs::OccupancyGrid>("map", 1, boost::bind(&MapClientTest::mapCallback, this, _1));
+  ros::Subscriber sub = n_->subscribe<nav_msgs::OccupancyGrid>("map", 1, boost::bind(&MapClientTest::mapCallback, this, boost::placeholders::_1));
 
   // Try a few times, because the server may not be up yet.
   int i=20;
@@ -120,7 +120,7 @@ TEST_F(MapClientTest, subscribe_topic)
 /* Try to retrieve the metadata via topic, and compare to ground truth */
 TEST_F(MapClientTest, subscribe_topic_metadata)
 {
-  ros::Subscriber sub = n_->subscribe<nav_msgs::MapMetaData>("map_metadata", 1, boost::bind(&MapClientTest::mapMetaDataCallback, this, _1));
+  ros::Subscriber sub = n_->subscribe<nav_msgs::MapMetaData>("map_metadata", 1, boost::bind(&MapClientTest::mapMetaDataCallback, this, boost::placeholders::_1));
 
   // Try a few times, because the server may not be up yet.
   int i=20;
@@ -140,7 +140,7 @@ TEST_F(MapClientTest, subscribe_topic_metadata)
 /* Change the map, retrieve the map via topic, and compare to ground truth */
 TEST_F(MapClientTest, change_map)
 {
-  ros::Subscriber sub = n_->subscribe<nav_msgs::OccupancyGrid>("map", 1, boost::bind(&MapClientTest::mapCallback, this, _1));
+  ros::Subscriber sub = n_->subscribe<nav_msgs::OccupancyGrid>("map", 1, boost::bind(&MapClientTest::mapCallback, this, boost::placeholders::_1));
 
   // Try a few times, because the server may not be up yet.
   for (int i = 20; i > 0 && !got_map_; i--)

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -58,7 +58,7 @@ namespace move_base {
     planner_plan_(NULL), latest_plan_(NULL), controller_plan_(NULL),
     runPlanner_(false), setup_(false), p_freq_change_(false), c_freq_change_(false), new_global_plan_(false) {
 
-    as_ = new MoveBaseActionServer(ros::NodeHandle(), "move_base", boost::bind(&MoveBase::executeCb, this, _1), false);
+    as_ = new MoveBaseActionServer(ros::NodeHandle(), "move_base", boost::bind(&MoveBase::executeCb, this, boost::placeholders::_1), false);
 
     ros::NodeHandle private_nh("~");
     ros::NodeHandle nh;
@@ -104,7 +104,7 @@ namespace move_base {
     //they won't get any useful information back about its status, but this is useful for tools
     //like nav_view and rviz
     ros::NodeHandle simple_nh("move_base_simple");
-    goal_sub_ = simple_nh.subscribe<geometry_msgs::PoseStamped>("goal", 1, boost::bind(&MoveBase::goalCB, this, _1));
+    goal_sub_ = simple_nh.subscribe<geometry_msgs::PoseStamped>("goal", 1, boost::bind(&MoveBase::goalCB, this, boost::placeholders::_1));
 
     //we'll assume the radius of the robot to be consistent with what's specified for the costmaps
     private_nh.param("local_costmap/inscribed_radius", inscribed_radius_, 0.325);
@@ -175,7 +175,7 @@ namespace move_base {
     as_->start();
 
     dsrv_ = new dynamic_reconfigure::Server<move_base::MoveBaseConfig>(ros::NodeHandle("~"));
-    dynamic_reconfigure::Server<move_base::MoveBaseConfig>::CallbackType cb = boost::bind(&MoveBase::reconfigureCB, this, _1, _2);
+    dynamic_reconfigure::Server<move_base::MoveBaseConfig>::CallbackType cb = boost::bind(&MoveBase::reconfigureCB, this, boost::placeholders::_1, boost::placeholders::_2);
     dsrv_->setCallback(cb);
   }
 

--- a/move_slow_and_clear/src/move_slow_and_clear.cpp
+++ b/move_slow_and_clear/src/move_slow_and_clear.cpp
@@ -35,7 +35,7 @@
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
 #include <move_slow_and_clear/move_slow_and_clear.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <costmap_2d/obstacle_layer.h>
 
 PLUGINLIB_EXPORT_CLASS(move_slow_and_clear::MoveSlowAndClear, nav_core::RecoveryBehavior)

--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -35,7 +35,7 @@
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
 #include <navfn/navfn_ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <costmap_2d/cost_values.h>
 #include <costmap_2d/costmap_2d.h>
 #include <sensor_msgs/point_cloud2_iterator.h>

--- a/rotate_recovery/src/rotate_recovery.cpp
+++ b/rotate_recovery/src/rotate_recovery.cpp
@@ -35,7 +35,7 @@
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
 #include <rotate_recovery/rotate_recovery.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nav_core/parameter_magic.h>
 #include <tf2/utils.h>
 #include <ros/ros.h>


### PR DESCRIPTION
This eliminates a warning message about _1/_2 etc. and boost/bind.hpp being deprecated encountered building this on Ubuntu 22.04 (and from similar changes in other repos probably Arch and Gentoo see them also).

I also had to change to C++17 to avoid std::share_mutex log4cxx build errors- but could separate that out if necessary

    /usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type

