### PR TITLE
Check if stamp of transforomed pose is non-zero

### DIFF
--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -610,7 +610,7 @@ bool Costmap2DROS::getRobotPose(geometry_msgs::PoseStamped& global_pose) const
     return false;
   }
   // check global_pose timeout
-  if (current_time.toSec() - global_pose.header.stamp.toSec() > transform_tolerance_)
+  if (!global_pose.header.stamp.isZero() && current_time.toSec() - global_pose.header.stamp.toSec() > transform_tolerance_)
   {
     ROS_WARN_THROTTLE(1.0,
                       "Costmap2DROS transform timeout. Current time: %.4f, global_pose stamp: %.4f, tolerance: %.4f",

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1194,7 +1194,8 @@ namespace move_base {
     }
 
     // check if global_pose time stamp is within costmap transform tolerance
-    if (current_time.toSec() - global_pose.header.stamp.toSec() > costmap->getTransformTolerance())
+    if (!global_pose.header.stamp.isZero() &&
+        current_time.toSec() - global_pose.header.stamp.toSec() > costmap->getTransformTolerance())
     {
       ROS_WARN_THROTTLE(1.0, "Transform timeout for %s. " \
                         "Current time: %.4f, pose stamp: %.4f, tolerance: %.4f", costmap->getName().c_str(),


### PR DESCRIPTION
If the chain of transformations between `global_frame_` and `robot_base_frame_` are all broadcast-ed as static TF frames (using TF2), the stamp of transformed frame is always zero, which is trapped as timeout error.
With this PR if the stamp is zero, no timeout is checked.