### PR TITLE
make robot_base_frame available in LayeredCostmap

### DIFF
--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -58,7 +58,7 @@ public:
   /**
    * @brief  Constructor for a costmap
    */
-  LayeredCostmap(std::string global_frame, bool rolling_window, bool track_unknown);
+  LayeredCostmap(std::string global_frame, std::string robot_base_frame, bool rolling_window, bool track_unknown);
 
   /**
    * @brief  Destructor
@@ -74,6 +74,11 @@ public:
   inline const std::string& getGlobalFrameID() const noexcept
   {
     return global_frame_;
+  }
+
+  inline const std::string getBaseFrameID() const noexcept
+  {
+    return robot_base_frame_;
   }
 
   void resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x, double origin_y,
@@ -157,6 +162,7 @@ public:
 private:
   Costmap2D costmap_;
   std::string global_frame_;
+  std::string robot_base_frame_;
 
   bool rolling_window_;  /// < @brief Whether or not the costmap should roll with the robot
 

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -109,7 +109,7 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
   private_nh.param("track_unknown_space", track_unknown_space, false);
   private_nh.param("always_send_full_costmap", always_send_full_costmap, false);
 
-  layered_costmap_ = new LayeredCostmap(global_frame_, rolling_window, track_unknown_space);
+  layered_costmap_ = new LayeredCostmap(global_frame_, robot_base_frame_, rolling_window, track_unknown_space);
 
   if (!private_nh.hasParam("plugins"))
   {

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -47,9 +47,10 @@ using std::vector;
 namespace costmap_2d
 {
 
-LayeredCostmap::LayeredCostmap(std::string global_frame, bool rolling_window, bool track_unknown) :
+LayeredCostmap::LayeredCostmap(std::string global_frame, std::string robot_base_frame, bool rolling_window, bool track_unknown) :
     costmap_(),
     global_frame_(global_frame),
+    robot_base_frame_(robot_base_frame),
     rolling_window_(rolling_window),
     current_(false),
     minx_(0.0),

--- a/costmap_2d/test/inflation_tests.cpp
+++ b/costmap_2d/test/inflation_tests.cpp
@@ -136,7 +136,7 @@ void validatePointInflation(unsigned int mx, unsigned int my, Costmap2D* costmap
 
 TEST(costmap, testAdjacentToObstacleCanStillMove){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -162,7 +162,7 @@ TEST(costmap, testAdjacentToObstacleCanStillMove){
 
 TEST(costmap, testInflationShouldNotCreateUnknowns){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -187,7 +187,7 @@ TEST(costmap, testInflationShouldNotCreateUnknowns){
  */
 TEST(costmap, testCostFunctionCorrectness){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   layers.resizeMap(100, 100, 1, 0, 0);
 
   // Footprint with inscribed radius = 5.0
@@ -255,7 +255,7 @@ TEST(costmap, testCostFunctionCorrectness){
  */
 TEST(costmap, testInflationOrderCorrectness){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // Footprint with inscribed radius = 2.1
@@ -284,7 +284,7 @@ TEST(costmap, testInflationOrderCorrectness){
 TEST(costmap, testInflation){
 
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
 
   // Footprint with inscribed radius = 2.1
   //               circumscribed radius = 3.1
@@ -348,7 +348,7 @@ TEST(costmap, testInflation){
 TEST(costmap, testInflation2){
 
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
 
   // Footprint with inscribed radius = 2.1
   //               circumscribed radius = 3.1
@@ -376,7 +376,7 @@ TEST(costmap, testInflation2){
  */
 TEST(costmap, testInflation3){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   // 1 2 3

--- a/costmap_2d/test/obstacle_tests.cpp
+++ b/costmap_2d/test/obstacle_tests.cpp
@@ -73,7 +73,7 @@ using namespace costmap_2d;
 TEST(costmap, testRaytracing){
   tf2_ros::Buffer tf;
 
-  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  LayeredCostmap layers("frame", "base", false, false);  // Not rolling window, not tracking unknown
   addStaticLayer(layers, tf);  // This adds the static map
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);
   
@@ -95,7 +95,7 @@ TEST(costmap, testRaytracing){
  */
 TEST(costmap, testRaytracing2){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   addStaticLayer(layers, tf);
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);
 
@@ -153,7 +153,7 @@ TEST(costmap, testWaveInterference){
   tf2_ros::Buffer tf;
 
   // Start with an empty map, no rolling window, tracking unknown
-  LayeredCostmap layers("frame", false, true);
+  LayeredCostmap layers("frame", "base", false, true);
   layers.resizeMap(10, 10, 1, 0, 0);
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);
 
@@ -181,7 +181,7 @@ TEST(costmap, testWaveInterference){
 TEST(costmap, testZThreshold){
   tf2_ros::Buffer tf;
   // Start with an empty map
-  LayeredCostmap layers("frame", false, true);
+  LayeredCostmap layers("frame", "base", false, true);
   layers.resizeMap(10, 10, 1, 0, 0);
 
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);
@@ -202,7 +202,7 @@ TEST(costmap, testZThreshold){
  */
 TEST(costmap, testDynamicObstacles){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   addStaticLayer(layers, tf);
 
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);
@@ -228,7 +228,7 @@ TEST(costmap, testDynamicObstacles){
  */
 TEST(costmap, testMultipleAdditions){
   tf2_ros::Buffer tf;
-  LayeredCostmap layers("frame", false, false);
+  LayeredCostmap layers("frame", "base", false, false);
   addStaticLayer(layers, tf);
 
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);


### PR DESCRIPTION
I have been working on costmap layers where the robot_base_frame is needed; mainly to allow height filtering to be performed relative to robot z instead of map or sensor z.  I have been working around the issue, but it seems appropriate to make robot_base_frame commonly available to all costmap_2d layers.