### PR TITLE
[map_server] include roslib_INCLUDE_DIRS for unit tests

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -94,6 +94,7 @@ if(CATKIN_ENABLE_TESTING)
   )
 
   find_package(roslib REQUIRED)
+  include_directories(${roslib_INCLUDE_DIRS})
   add_executable(rtest test/rtest.cpp test/test_constants.cpp)
   add_dependencies(rtest ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
   add_dependencies(tests rtest)


### PR DESCRIPTION
I'm observing the same issue mentioned in #1145 and #1227, that is
```
Errors     << map_server:make /home/stwirth/catkin_test/logs/map_server/build.make.001.log
/home/stwirth/catkin_test/src/navigation-release-release-noetic-map_server-1.17.3-1/test/rtest.cpp:35:10: fatal error: ros/package.h: No such file or directory
   35 | #include <ros/package.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/rtest.dir/build.make:63: CMakeFiles/rtest.dir/test/rtest.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1768: CMakeFiles/rtest.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
when building map_server and all its dependencies from scratch.

This fix makes the build pass.
No idea why/how the CI system gets over this.