### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -18,6 +18,8 @@
     <url>http://wiki.ros.org/base_local_planner</url>
 
     <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+    <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+    <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
     <build_depend>cmake_modules</build_depend>
     <build_depend>message_generation</build_depend>

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>base_local_planner</name>
     <version>1.17.3</version>
     <description>

--- a/base_local_planner/setup.py
+++ b/base_local_planner/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.