### PR TITLE
Fix bug where global planner lethal cost is always 1 unit smaller than expected

### DIFF
--- a/global_planner/include/global_planner/dijkstra.h
+++ b/global_planner/include/global_planner/dijkstra.h
@@ -85,7 +85,7 @@ class DijkstraExpansion : public Expander {
 
         float getCost(unsigned char* costs, int n) {
             float c = costs[n];
-            if (c < lethal_cost_ - 1 || (unknown_ && c==255)) {
+            if (c < lethal_cost_ || (unknown_ && c==255)) {
                 c = c * factor_ + neutral_cost_;
                 if (c >= lethal_cost_)
                     c = lethal_cost_ - 1;


### PR DESCRIPTION
## Description

- Fix #1093

Global planner treats `lethal_cost_` as if it was the `costmap_2d::LETHAL_OBSTACLE` cost, and so assumes that `lethal_cost_ - 1` is also in collision (i.e. `costmap_2d::INSCRIBED_INFLATED_OBSTACLE`).

The whole point of this param being dynamically reconfigured is that we don't have to be tied to the value of `costmap_2d::LETHAL_OBSTACLE` and so we also shouldn't assume that `lethal_cost_ - 1` is lethal too.
That's also why the default value for `lethal_cost_` is **253**, not 254.

https://github.com/ros-planning/navigation/blob/9ad644198e132d0e950579a3bc72c29da46e60b0/global_planner/cfg/GlobalPlanner.cfg#L8

Because when planning a path, a cell of cost 253 (i.e. inscribed) is indeed a lethal cell the robot can not traverse.
However, as it stands, the global planner will also treat cells of cost 252 as lethal, which is obviously wrong.