### PR TITLE
Warning: TF_REPEATED_DATA ignoring data with redundant timestamp for frame odom_comb at time 23.567000 according to authority unknown_publisher

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -836,7 +836,7 @@ void
 AmclNode::checkLaserReceived(const ros::TimerEvent& event)
 {
   ros::Duration d = ros::Time::now() - last_laser_received_ts_;
-  if(d > laser_check_interval_)
+  if(d < laser_check_interval_)
   {
     ROS_WARN("No laser scan received (and thus no pose updates have been published) for %f seconds.  Verify that data is being published on the %s topic.",
              d.toSec(),


### PR DESCRIPTION
 
This pull request addresses issue https://github.com/ros-planning/navigation/issues/1125

   I solved this problem by making a small tweak to the amcl_node.cpp file. In order to decrease the frequency of TF_REPEATED_DATA warnings, I lowered the publishing rate of the laser scan because amcl relies on the rate of incoming laser messages. I made this adjustment directly in the .cpp node, and it worked perfectly for me. As a result, the redundant messages no longer appear, which is fantastic.