### PR TITLE
Transforms to global frame before checking quaternion

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -650,12 +650,12 @@ namespace move_base {
 
   void MoveBase::executeCb(const move_base_msgs::MoveBaseGoalConstPtr& move_base_goal)
   {
-    if(!isQuaternionValid(move_base_goal->target_pose.pose.orientation)){
+    geometry_msgs::PoseStamped goal = goalToGlobalFrame(move_base_goal->target_pose);
+
+    if(!isQuaternionValid(goal.pose.orientation)){
       as_->setAborted(move_base_msgs::MoveBaseResult(), "Aborting on goal because it was sent with an invalid quaternion");
       return;
     }
-
-    geometry_msgs::PoseStamped goal = goalToGlobalFrame(move_base_goal->target_pose);
 
     publishZeroVelocity();
     //we have a goal so start the planner
@@ -693,14 +693,14 @@ namespace move_base {
       if(as_->isPreemptRequested()){
         if(as_->isNewGoalAvailable()){
           //if we're active and a new goal is available, we'll accept it, but we won't shut anything down
-          move_base_msgs::MoveBaseGoal new_goal = *as_->acceptNewGoal();
+          move_base_msgs::MoveBaseGoal new_move_base_goal = *as_->acceptNewGoal();
+          geometry_msgs::PoseStamped new_goal = goalToGlobalFrame(new_move_base_goal.target_pose);
 
-          if(!isQuaternionValid(new_goal.target_pose.pose.orientation)){
+          if(!isQuaternionValid(new_goal.pose.orientation)){
             as_->setAborted(move_base_msgs::MoveBaseResult(), "Aborting on goal because it was sent with an invalid quaternion");
             return;
           }
-
-          goal = goalToGlobalFrame(new_goal.target_pose);
+          goal = new_goal;
 
           //we'll make sure that we reset our state for the next execution cycle
           recovery_index_ = 0;


### PR DESCRIPTION
This PR allows goals to be accepted if the quaternion is valid once the goal has been transformed into the `global_frame` instead of requiring the quaternion to be valid in the original frame it was sent in.

For my application, I have defined the transform from `earth -> map`. My map frame is in the ENU local tangent plane. Since there is a rotation between ECEF and ENU, that rotation is expressed in my transform tree.

The `global_frame` that I configure for the planner is still the `map` frame, and I want to be able to send waypoints in both the `earth`, and `map` frame.

When I attempt to send a goal point in the `earth` frame, the quaternion is not "mostly vertical" in the `earth` frame, but it is once it has been transformed to the `global_frame`.