### PR TITLE
The GridPath:: getPath function stopped prematurely while backtracking the path, resulting in the generation of incorrect global paths.

### DIFF
--- a/global_planner/src/grid_path.cpp
+++ b/global_planner/src/grid_path.cpp
@@ -59,7 +59,7 @@ bool GridPath::getPath(float* potential, double start_x, double start_y, double 
                 if (xd == 0 && yd == 0)
                     continue;
                 int x = current.first + xd, y = current.second + yd;
-                if (x >= xs_ || y >= ys_ || x < 0 || y < 0)
+                if (x > xs_ || y > ys_ || x < 0 || y < 0)
                     continue;
                 int index = getIndex(x, y);
                 if (potential[index] < min_val) {

--- a/global_planner/src/grid_path.cpp
+++ b/global_planner/src/grid_path.cpp
@@ -59,6 +59,8 @@ bool GridPath::getPath(float* potential, double start_x, double start_y, double 
                 if (xd == 0 && yd == 0)
                     continue;
                 int x = current.first + xd, y = current.second + yd;
+                if (x >= xs_ || y >= ys_ || x < 0 || y < 0)
+                    continue;
                 int index = getIndex(x, y);
                 if (potential[index] < min_val) {
                     min_val = potential[index];


### PR DESCRIPTION
Through analysis of the algorithm and theoretical thinking, we have found that there is an issue with the code for the backtracking path of GridPath:: getPath. When searching for the backtracking path, it did not restrict the range of the inflated map. As the index mapping to Cartesian coordinates does not have uniqueness, if the search map range is not restricted, there is a good chance of finding an index value outside the map range that is the same as the starting point, and the backtracking function will terminate prematurely, resulting in the generation of an incorrect path that does not include the starting point.

